### PR TITLE
Implement UUID-stable local v2 mv

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ local entry later may expose inheritance. `--mask-warnings=default|on|off`,
 `--warn-mask`, and `--no-warn-mask` control only this warning; they do not
 change the plan, persisted state, success, or exit status.
 
-Persisted v2 `set`, `cp`, `ln`, `rm`, and `load` writes use the same
+Persisted v2 `set`, `cp`, `ln`, `rm`, `mv`, and `load` writes use the same
 recoverable mutation plan. `--mask-action=preserve` is the default: it keeps
 canonical masks when a destination is written, permits active masks to become
 dormant and dormant masks to reactivate, and reports direct hits even when a
@@ -276,6 +276,15 @@ when any such interaction is planned. `--mask-warnings=default|on|off`,
 aggregate warning emitted after a successful commit. The preserve default is
 warning-on; reject defaults to warning-off because it reports the impact as an
 error.
+
+A same-domain/store local v2 `mv` is an identity-preserving rename. It keeps
+both the entry UUID and secret UUID, so existing `ln` aliases remain linked and
+the secret-object refcount does not change. Descendant identity masks continue
+to target the same entry while their authorized last-known address is updated.
+Dry-run and JSON output report the preserved IDs, mask effects, and any
+name-based relation KEYREF rewrites from the exact prepared commit candidate.
+Planning options for inherited or cross-domain/store `mv` remain unavailable
+until those move modes have their own accepted planning contracts.
 
 `--dry-run` and `--json` expose the same `secdat.mutation-plan.v1` used for
 commit. Multi-assignment `set` and `load` preflight and commit the whole batch:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ local entry later may expose inheritance. `--mask-warnings=default|on|off`,
 `--warn-mask`, and `--no-warn-mask` control only this warning; they do not
 change the plan, persisted state, success, or exit status.
 
-Persisted v2 `set`, `cp`, `ln`, `rm`, `mv`, and `load` writes use the same
-recoverable mutation plan. `--mask-action=preserve` is the default: it keeps
+Persisted v2 `set`, `cp`, `ln`, `rm`, and `load` writes, plus same-domain/store
+local v2 `mv`, use the same recoverable mutation plan.
+`--mask-action=preserve` is the default: it keeps
 canonical masks when a destination is written, permits active masks to become
 dormant and dormant masks to reactivate, and reports direct hits even when a
 mask was already dormant. `--mask-action=reject` fails before live mutation

--- a/docs/secdat-spec.md
+++ b/docs/secdat-spec.md
@@ -81,7 +81,7 @@ secdat [--dir DIR] [--store STORE] set [MASK_MUTATION_OPTIONS] KEYREF --generate
 
 secdat [--dir DIR] [--store STORE] rm [-f|--ignore-missing] [MASK_MUTATION_OPTIONS] KEYREF
 secdat [--dir DIR] [--store STORE] rm --ephemeral [-f|--ignore-missing] KEYREF
-secdat [--dir DIR] [--store STORE] mv SRC_KEYREF DST_KEYREF
+secdat [--dir DIR] [--store STORE] mv [MASK_MUTATION_OPTIONS] SRC_KEYREF DST_KEYREF
 secdat [--dir DIR] [--store STORE] cp [MASK_MUTATION_OPTIONS] SRC_KEYREF DST_KEYREF
 secdat [--dir DIR] [--store STORE] ln [--replace] [--skip-same-value-check] [MASK_MUTATION_OPTIONS] SRC_KEYREF|@UUID DST_KEYREF
 
@@ -359,6 +359,10 @@ source removal.
 - for an unqualified source only, if `SRC_KEYREF` is inherited from a parent domain, the source name is hidden with a tombstone in the resolved source current domain after the destination is materialized
 - `mv` preserves the source entry storage mode, including plaintext-at-rest entries created with `set --unsafe`
 - `mv` preserves both the v2 entry UUID and secret UUID; a cross-domain/store move publishes the destination before removing the source and rotates the reference epoch before source removal
+- a same-domain/store local v2 `mv` is a rename of the existing entry, does not change the secret-object refcount, and leaves every existing `ln` alias linked to the same secret UUID
+- descendant canonical masks keep targeting the preserved entry UUID; their authorized last-known domain/store/name fields move in the same recoverable transaction
+- same-domain/store local v2 `mv` accepts `MASK_MUTATION_OPTIONS`; dry-run and JSON report source/destination entry and secret UUIDs, preservation booleans, mask effects, and separate name-based relation KEYREF rewrite consequences from the prepared commit candidate
+- mutation planning for inherited and cross-domain/store `mv` remains unavailable until those contracts are implemented
 - `mv` preserves searchable key metadata on the destination and removes local searchable key metadata from a removed local source
 
 #### FR-6 Key Copy
@@ -977,8 +981,19 @@ secdat [--dir DIR] [--store STORE] rm [--ignore-missing] [MASK_MUTATION_OPTIONS]
 ### 4.6 `mv`
 
 ```text
-secdat [--dir DIR] [--store STORE] mv SRC_KEY DST_KEY
+secdat [--dir DIR] [--store STORE] mv [MASK_MUTATION_OPTIONS] SRC_KEY DST_KEY
 ```
+
+- for a same-domain/store local v2 source, `mv` preserves `entry_id` and
+  `secret_id`, keeps existing links and refcount unchanged, and moves descendant
+  identity-mask last-known metadata atomically
+- `--dry-run` leaves source, destination, masks, metadata, relations, links, and
+  refcount unchanged
+- `--json` reports `source_secret_id`, `destination_secret_id`,
+  `source_entry_id`, `destination_entry_id`, `entry_id_preserved`,
+  `secret_id_preserved`, `mask_impact_rows`, and `relation_consequence_rows`
+- `--mask-action=reject` rejects a planned descendant-mask interaction before
+  live mutation
 
 ### 4.7 `cp`
 

--- a/docs/secdat-spec.md
+++ b/docs/secdat-spec.md
@@ -934,7 +934,7 @@ secdat [--dir DIR] [--store STORE] unmask [--dry-run] [--json] [--mask-chain UUI
 - `reject` fails before live mutation on any direct hit, transition, orphaning, or source-mask creation
 - warning policy is orthogonal to action: preserve defaults to warnings on, reject defaults to warnings off, and explicit `on`/`off` never changes state, success, exit status, or JSON rows
 - warnings are emitted only after a successful commit; dry-run and rejected/failed operations do not claim that a transition occurred
-- `--dry-run` and `--json` expose `secdat.mutation-plan.v1`, including normalized impact counts and authorized rows with domain/store/key, event, states, mask chain, and target entry identity
+- `--dry-run` and `--json` expose `secdat.mutation-plan.v1`, including normalized impact counts and authorized rows with domain/store/source key/effective after key, event, states, mask chain, and target entry identity
 - multi-assignment `set` and `load` execute their entire existing command against a protected state snapshot, preflight the aggregate result, and commit all changed files together
 - a later batch error, locked hidden mask name, ambiguous legacy mask, or `reject` outcome leaves all live entries unchanged
 - warning suppression cannot suppress locked/incomplete analysis, legacy ambiguity, invalid options, or rejection
@@ -992,6 +992,9 @@ secdat [--dir DIR] [--store STORE] mv [MASK_MUTATION_OPTIONS] SRC_KEY DST_KEY
 - `--json` reports `source_secret_id`, `destination_secret_id`,
   `source_entry_id`, `destination_entry_id`, `entry_id_preserved`,
   `secret_id_preserved`, `mask_impact_rows`, and `relation_consequence_rows`
+- a descendant identity mask that retains the moved `entry_id` is reported as
+  `followed`; source or destination name-slot mask interactions remain
+  `direct-hit`
 - `--mask-action=reject` rejects a planned descendant-mask interaction before
   live mutation
 

--- a/docs/secdat.1
+++ b/docs/secdat.1
@@ -444,8 +444,8 @@ With
 .B --ephemeral,
 only the current-domain session-local value is removed, revealing any persisted value it shadowed. Plain rm rejects an ephemeral target.
 .TP
-.B mv SRC_KEYREF DST_KEYREF
-Rename or relocate one key between resolved locations.
+.B mv [\-\-mask-action=preserve|reject] [\-\-mask-warnings=default|on|off] [\-\-warn-mask|\-\-no-warn-mask] [\-\-dry-run] [\-\-json] SRC_KEYREF DST_KEYREF
+Rename or relocate one key between resolved locations. A same-domain/store local v2 rename preserves both entry and secret IDs, existing links, and object refcount. Descendant identity masks follow the preserved entry in the same recoverable transaction. Dry-run and JSON report identity preservation, mask effects, and separate name-based relation KEYREF rewrites from the prepared commit candidate. Mutation planning options do not yet apply to inherited or cross-domain/store moves.
 .TP
 .B cp [\-\-mask-action=preserve|reject] [\-\-mask-warnings=default|on|off] [\-\-warn-mask|\-\-no-warn-mask] [\-\-dry-run] [\-\-json] SRC_KEYREF DST_KEYREF
 Copy one key into another resolved location.

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 15:15+0900\n"
+"POT-Creation-Date: 2026-08-28 17:53+0900\n"
 "PO-Revision-Date: 2026-04-13 00:00+0000\n"
 "Last-Translator: GitHub Copilot <noreply@example.invalid>\n"
 "Language-Team: ja\n"
@@ -59,12 +59,12 @@ msgstr "オプション値が不足しています\n"
 msgid "unknown option: %s\n"
 msgstr "不明なオプションです: %s\n"
 
-#: src/cli.c:1759
+#: src/cli.c:1766
 #, c-format
 msgid "  %s [options] subcommand ...\n"
 msgstr "  %s [オプション] サブコマンド ...\n"
 
-#: src/cli.c:1764
+#: src/cli.c:1771
 #, c-format
 msgid ""
 "\n"
@@ -73,12 +73,12 @@ msgstr ""
 "\n"
 "オプション:\n"
 
-#: src/cli.c:1765
+#: src/cli.c:1772
 msgid ""
 "  -d, --dir DIR      set the base directory used for domain resolution\n"
 msgstr "  -d, --dir DIR      domain 解決に使う基準ディレクトリを指定します\n"
 
-#: src/cli.c:1766
+#: src/cli.c:1773
 msgid ""
 "      --domain DIR   require one exact registered domain root instead of "
 "discovery\n"
@@ -86,14 +86,14 @@ msgstr ""
 "      --domain DIR   ancestor 探索の代わりに登録済みの正確な domain root を必"
 "須にします\n"
 
-#: src/cli.c:1767
+#: src/cli.c:1774
 msgid ""
 "  -s, --store STORE  select the store namespace inside the resolved domain\n"
 msgstr ""
 "  -s, --store STORE  解決された domain 内で使う store namespace を選択しま"
 "す\n"
 
-#: src/cli.c:1768
+#: src/cli.c:1775
 msgid ""
 "  -h, --help         show global help, or combine with COMMAND or TOPIC for "
 "detailed help\n"
@@ -101,11 +101,11 @@ msgstr ""
 "  -h, --help         全体 help を表示します。COMMAND または TOPIC と組み合わ"
 "せると詳細 help を表示します\n"
 
-#: src/cli.c:1769
+#: src/cli.c:1776
 msgid "  -V, --version      print the secdat version\n"
 msgstr "  -V, --version      secdat のバージョンを表示します\n"
 
-#: src/cli.c:1803
+#: src/cli.c:1810
 #, c-format
 msgid ""
 "\n"
@@ -114,62 +114,62 @@ msgstr ""
 "\n"
 "ヘルプ:\n"
 
-#: src/cli.c:1804
+#: src/cli.c:1811
 #, c-format
 msgid "  %s --help\n"
 msgstr "  %s --help\n"
 
-#: src/cli.c:1805
+#: src/cli.c:1812
 #, c-format
 msgid "  %s help [COMMAND...]\n"
 msgstr "  %s help [コマンド名...]\n"
 
-#: src/cli.c:1806
+#: src/cli.c:1813
 #, c-format
 msgid "  %s help usecases\n"
 msgstr "  %s help usecases\n"
 
-#: src/cli.c:1807
+#: src/cli.c:1814
 #, c-format
 msgid "  %s help concepts\n"
 msgstr "  %s help concepts\n"
 
-#: src/cli.c:1808
+#: src/cli.c:1815
 #, c-format
 msgid "  %s help inject\n"
 msgstr "  %s help inject\n"
 
-#: src/cli.c:1810
+#: src/cli.c:1817
 #, c-format
 msgid "  %s --help COMMAND...\n"
 msgstr "  %s --help コマンド名...\n"
 
-#: src/cli.c:1811
+#: src/cli.c:1818
 #, c-format
 msgid "  %s COMMAND --help\n"
 msgstr "  %s コマンド名 --help\n"
 
-#: src/cli.c:1813 src/cli.c:1815
+#: src/cli.c:1820 src/cli.c:1822
 #, c-format
 msgid "  %s --help %s\n"
 msgstr "  %s --help %s\n"
 
-#: src/cli.c:1816
+#: src/cli.c:1823
 #, c-format
 msgid "  %s %s --help\n"
 msgstr "  %s %s --help\n"
 
-#: src/cli.c:1818
+#: src/cli.c:1825
 #, c-format
 msgid "  %s --version\n"
 msgstr "  %s --version\n"
 
-#: src/cli.c:1819
+#: src/cli.c:1826
 #, c-format
 msgid "  %s version\n"
 msgstr "  %s version\n"
 
-#: src/cli.c:1824
+#: src/cli.c:1831
 #, c-format
 msgid ""
 "\n"
@@ -178,25 +178,25 @@ msgstr ""
 "\n"
 "シェル:\n"
 
-#: src/cli.c:1827
+#: src/cli.c:1834
 #, c-format
 msgid "  bash load current shell vars: source <(%s export)\n"
 msgstr "  bash で現在の shell に読み込む: source <(%s export)\n"
 
-#: src/cli.c:1829
+#: src/cli.c:1836
 #, c-format
 msgid "  bash alternative: eval \"$(%s export)\"\n"
 msgstr "  bash の別案: eval \"$(%s export)\"\n"
 
-#: src/cli.c:1832
+#: src/cli.c:1839
 msgid "  bash completion script: completions/secdat.bash\n"
 msgstr "  bash completion script: completions/secdat.bash\n"
 
-#: src/cli.c:1833
+#: src/cli.c:1840
 msgid "  man page source: docs/secdat.1\n"
 msgstr "  man page source: docs/secdat.1\n"
 
-#: src/cli.c:1838
+#: src/cli.c:1845
 #, c-format
 msgid ""
 "\n"
@@ -205,19 +205,19 @@ msgstr ""
 "\n"
 "サポート:\n"
 
-#: src/cli.c:1839
+#: src/cli.c:1846
 msgid "  issues: https://github.com/mako10k/secdat/issues\n"
 msgstr "  issue 報告先: https://github.com/mako10k/secdat/issues\n"
 
-#: src/cli.c:1840
+#: src/cli.c:1847
 msgid "  repository: https://github.com/mako10k/secdat\n"
 msgstr "  repository: https://github.com/mako10k/secdat\n"
 
-#: src/cli.c:1841
+#: src/cli.c:1848
 msgid "  author: Makoto Katsumata <mako10k@mk10.org>\n"
 msgstr "  author: Makoto Katsumata <mako10k@mk10.org>\n"
 
-#: src/cli.c:1846
+#: src/cli.c:1853
 #, c-format
 msgid ""
 "\n"
@@ -226,7 +226,7 @@ msgstr ""
 "\n"
 "グループ:\n"
 
-#: src/cli.c:1847
+#: src/cli.c:1854
 msgid ""
 "  store: manage store namespaces and v1 to v2 migration inside the resolved "
 "current domain\n"
@@ -234,11 +234,11 @@ msgstr ""
 "  store: 解決された current domain 内の store namespace と v1 から v2 への "
 "migration を管理します\n"
 
-#: src/cli.c:1848
+#: src/cli.c:1855
 msgid "  meta: manage non-secret searchable metadata attached to keys\n"
 msgstr "  meta: key に付けた非秘密の検索用 metadata を管理します\n"
 
-#: src/cli.c:1849
+#: src/cli.c:1856
 msgid ""
 "  relation: connect keys into semantic groups with non-secret security "
 "meaning\n"
@@ -246,18 +246,18 @@ msgstr ""
 "  relation: key を意味的なグループとしてつなぎ、非秘密の security meaning を"
 "管理します\n"
 
-#: src/cli.c:1850 src/cli.c:2164
+#: src/cli.c:1857 src/cli.c:2174
 msgid ""
 "  secret: inspect v2 secret-object metadata by UUID without reading secret "
 "values\n"
 msgstr ""
 "  secret: 値を読まずに UUID で v2 secret-object metadata を確認します\n"
 
-#: src/cli.c:1851 src/cli.c:2173
+#: src/cli.c:1858 src/cli.c:2183
 msgid "  domain: manage domain roots and domain discovery scope\n"
 msgstr "  domain: domain root と domain 探索スコープを管理します\n"
 
-#: src/cli.c:1856
+#: src/cli.c:1863
 #, c-format
 msgid ""
 "\n"
@@ -266,11 +266,11 @@ msgstr ""
 "\n"
 "コマンド:\n"
 
-#: src/cli.c:1857 src/cli.c:1906
+#: src/cli.c:1864 src/cli.c:1913
 msgid "  help: show global help or detailed help for one command\n"
 msgstr "  help: 全体ヘルプ、または 1 つのコマンドの詳細ヘルプを表示します\n"
 
-#: src/cli.c:1858 src/cli.c:1910
+#: src/cli.c:1865 src/cli.c:1917
 msgid ""
 "  ls: list effective keys visible from the current domain view, optionally "
 "filtered by safe or unsafe storage\n"
@@ -278,7 +278,7 @@ msgstr ""
 "  ls: 現在の domain view から見える有効な key を、安全または unsafe な保存方"
 "式で絞り込んで一覧します\n"
 
-#: src/cli.c:1859 src/cli.c:1914
+#: src/cli.c:1866 src/cli.c:1921
 msgid ""
 "  list: inspect current-domain entries or identity and legacy masks by "
 "state, with long or JSON detail\n"
@@ -286,7 +286,7 @@ msgstr ""
 "  list: 現在のドメインのエントリー、または ID 連動 mask と従来の名前 mask を"
 "状態別に確認し、long または JSON で詳細を表示します\n"
 
-#: src/cli.c:1860 src/cli.c:1923
+#: src/cli.c:1867 src/cli.c:1930
 msgid ""
 "  attr: show or update one key's visibility, value-access, and bulk_select "
 "attribute\n"
@@ -294,13 +294,13 @@ msgstr ""
 "  attr: 1 つの key の visibility、value-access、bulk_select 属性を表示または"
 "更新します\n"
 
-#: src/cli.c:1861
+#: src/cli.c:1868
 msgid ""
 "  meta: manage non-secret searchable metadata without reading secret values\n"
 msgstr ""
 "  meta: secret value を読まずに、非秘密の検索用 metadata を管理します\n"
 
-#: src/cli.c:1862
+#: src/cli.c:1869
 msgid ""
 "  relation: record semantic links between keys and the security meaning of "
 "those links\n"
@@ -308,7 +308,7 @@ msgstr ""
 "  relation: key 間の意味的な link と、その link の security meaning を記録し"
 "ます\n"
 
-#: src/cli.c:1863
+#: src/cli.c:1870
 msgid ""
 "  meta mark-leaked: mark one key as leaked metadata and suggest high-risk "
 "refresh targets\n"
@@ -316,7 +316,7 @@ msgstr ""
 "  meta mark-leaked: 1 つの key を漏洩 metadata として mark し、高リスクの "
 "refresh target を提案します\n"
 
-#: src/cli.c:1864
+#: src/cli.c:1871
 msgid ""
 "  relation suggest-refresh: suggest high-risk refresh targets related to one "
 "leaked key\n"
@@ -324,7 +324,7 @@ msgstr ""
 "  relation suggest-refresh: 1 つの leaked key に関連する高リスクの refresh "
 "target を提案します\n"
 
-#: src/cli.c:1865
+#: src/cli.c:1872
 msgid ""
 "  relation suggest-link: compare same-name keys across registered domains "
 "and show link candidates\n"
@@ -332,7 +332,7 @@ msgstr ""
 "  relation suggest-link: 登録済み domain 間の同名 key を比較し、link 候補を表"
 "示します\n"
 
-#: src/cli.c:1866 src/cli.c:1987
+#: src/cli.c:1873 src/cli.c:1994
 msgid ""
 "  fsck: check current-domain store metadata for migration and limited "
 "repair\n"
@@ -340,12 +340,12 @@ msgstr ""
 "  fsck: migration と限定的な repair のために現在の domain の store metadata "
 "を検査します\n"
 
-#: src/cli.c:1867
+#: src/cli.c:1874
 msgid "  gc: remove unreachable or dangling v2 graph files after review\n"
 msgstr ""
 "  gc: review 後に到達不能または dangling な v2 graph file を削除します\n"
 
-#: src/cli.c:1868
+#: src/cli.c:1875
 msgid ""
 "  mask: create a rollback-safe identity mask for one inherited key, or "
 "atomically rebind an orphan barrier\n"
@@ -353,7 +353,7 @@ msgstr ""
 "  mask: 継承された 1 つの key に rollback-safe な identity mask を作成する"
 "か、orphan barrier を原子的に rebind します\n"
 
-#: src/cli.c:1869
+#: src/cli.c:1876
 msgid ""
 "  unmask: atomically remove one logical mask chain, with explicit chain "
 "selection when names are ambiguous\n"
@@ -361,14 +361,14 @@ msgstr ""
 "  unmask: name が曖昧な場合は chain を明示的に選択し、1 つの論理 mask chain "
 "を原子的に削除します\n"
 
-#: src/cli.c:1870 src/cli.c:2017
+#: src/cli.c:1877 src/cli.c:2024
 msgid ""
 "  exists: check whether one resolved key is visible from the current domain "
 "view\n"
 msgstr ""
 "  exists: 解決された 1 つの key が現在の domain view から見えるか確認します\n"
 
-#: src/cli.c:1871 src/cli.c:2021
+#: src/cli.c:1878 src/cli.c:2028
 msgid ""
 "  id: print the v2 secret object UUID for one resolved key without reading "
 "its value\n"
@@ -376,7 +376,7 @@ msgstr ""
 "  id: 解決された 1 つの key について、値を読まずに v2 secret object UUID を表"
 "示します\n"
 
-#: src/cli.c:1872 src/cli.c:2026
+#: src/cli.c:1879 src/cli.c:2033
 msgid ""
 "  get: decrypt one resolved key and write it to standard output; --on-demand-"
 "unlock waits for another terminal to unlock\n"
@@ -384,7 +384,7 @@ msgstr ""
 "  get: 解決された 1 つの key を復号して標準出力へ書き出します。--on-demand-"
 "unlock を付けると別端末での unlock を待機します\n"
 
-#: src/cli.c:1873
+#: src/cli.c:1880
 #, fuzzy
 msgid ""
 "  set: store or update one key in the resolved current domain; --generate "
@@ -396,7 +396,7 @@ msgstr ""
 "unsafe は lock 中も見える平文を保存します。--ephemeral は active session "
 "agent に unlocked-only の値を 1 つ保持します\n"
 
-#: src/cli.c:1874
+#: src/cli.c:1881
 msgid ""
 "  rm: remove one key locally or create a tombstone for an inherited key; --"
 "ignore-missing treats absent keys as success; --ephemeral removes only a "
@@ -406,15 +406,15 @@ msgstr ""
 "す。--ignore-missing は未存在の key を成功扱いにします。--ephemeral は "
 "session-local ephemeral value のみを削除します\n"
 
-#: src/cli.c:1875 src/cli.c:2051
+#: src/cli.c:1882 src/cli.c:2058
 msgid "  mv: rename or relocate one key between resolved locations\n"
 msgstr "  mv: 1 つの key を解決先の場所どうしで改名または移動します\n"
 
-#: src/cli.c:1876
+#: src/cli.c:1883
 msgid "  cp: copy one key into another resolved location\n"
 msgstr "  cp: 1 つの key を別の解決先へコピーします\n"
 
-#: src/cli.c:1877 src/cli.c:2060
+#: src/cli.c:1884 src/cli.c:2070
 msgid ""
 "  ln: link another key to the same v2 secret object, including cross-domain "
 "v2 links and authorized @UUID sources\n"
@@ -422,14 +422,14 @@ msgstr ""
 "  ln: 同じ v2 secret object へ別の key を link します。cross-domain v2 link "
 "および認可済み @UUID source も含みます\n"
 
-#: src/cli.c:1878 src/cli.c:2067
+#: src/cli.c:1885 src/cli.c:2077
 msgid ""
 "  exec: build a child environment through supply, route, and final injection "
 "layers\n"
 msgstr ""
 "  exec: supply、route、final の injection layer を通じて子環境を構築します\n"
 
-#: src/cli.c:1879 src/cli.c:2076
+#: src/cli.c:1886 src/cli.c:2086
 msgid ""
 "  export: emit shell-ready export lines that defer secret reads to secdat "
 "get\n"
@@ -437,7 +437,7 @@ msgstr ""
 "  export: secret の読み出しを secdat get に委ねる shell 向け export 行を出力"
 "します\n"
 
-#: src/cli.c:1880 src/cli.c:2080
+#: src/cli.c:1887 src/cli.c:2090
 msgid ""
 "  save: write current-view or selected secrets to a passphrase-protected "
 "bundle\n"
@@ -445,13 +445,13 @@ msgstr ""
 "  save: 現在の view の secret または選択した secret をパスフレーズ保護された "
 "bundle に保存します\n"
 
-#: src/cli.c:1881
+#: src/cli.c:1888
 msgid ""
 "  load: import a passphrase-protected bundle into the current domain view\n"
 msgstr ""
 "  load: パスフレーズ保護された bundle を現在の domain view に取り込みます\n"
 
-#: src/cli.c:1882 src/cli.c:2093
+#: src/cli.c:1889 src/cli.c:2103
 msgid ""
 "  unlock: start or refresh a local unlock for the current domain; --duration "
 "accepts plain minutes, suffix forms like 1h30m, or ISO 8601 durations such "
@@ -464,7 +464,7 @@ msgstr ""
 "ます。--inherit は現在の domain の local override を外して継承状態へ戻しま"
 "す\n"
 
-#: src/cli.c:1883 src/cli.c:2100
+#: src/cli.c:1890 src/cli.c:2110
 msgid ""
 "  inherit: force the current domain back to inherited state by removing a "
 "local lock or clearing a local unlock, without checking whether the result "
@@ -473,11 +473,11 @@ msgstr ""
 "  inherit: 結果がアンロックのままか確認せず、local lock を削除するか、local "
 "unlock を消して、現在の domain を継承状態へ戻します\n"
 
-#: src/cli.c:1884 src/cli.c:2104
+#: src/cli.c:1891 src/cli.c:2114
 msgid "  passwd: change the wrapped-master-key passphrase\n"
 msgstr "  passwd: ラップ済み master key のパスフレーズを変更します\n"
 
-#: src/cli.c:1885 src/cli.c:2108
+#: src/cli.c:1892 src/cli.c:2118
 msgid ""
 "  lock: return the current domain to a locked local state, or do nothing "
 "when it is already locked\n"
@@ -485,7 +485,7 @@ msgstr ""
 "  lock: 現在の domain をローカルなロック状態へ戻し、すでに lock 中なら何もし"
 "ません\n"
 
-#: src/cli.c:1886 src/cli.c:2112
+#: src/cli.c:1893 src/cli.c:2122
 msgid ""
 "  status: report whether secret material is available from the current "
 "domain scope\n"
@@ -493,7 +493,7 @@ msgstr ""
 "  status: 現在の domain scope から secret material が利用可能かどうかを報告し"
 "ます\n"
 
-#: src/cli.c:1887 src/cli.c:2116
+#: src/cli.c:1894 src/cli.c:2126
 msgid ""
 "  wait-unlock: wait until the current domain scope becomes unlocked, or fail "
 "on timeout\n"
@@ -501,7 +501,7 @@ msgstr ""
 "  wait-unlock: 現在の domain scope がアンロックされるまで待機し、タイムアウト"
 "時は失敗します\n"
 
-#: src/cli.c:1888 src/cli.c:2168
+#: src/cli.c:1895 src/cli.c:2178
 msgid ""
 "  secret status: print one v2 secret object's non-secret metadata and "
 "reference counts\n"
@@ -509,7 +509,7 @@ msgstr ""
 "  secret status: 1 つの v2 secret object の非秘密 metadata と参照数を表示しま"
 "す\n"
 
-#: src/cli.c:1889
+#: src/cli.c:1896
 msgid ""
 "  store migrate: validate a v1 store and write the side-by-side v2 domain-"
 "entry/object graph after review\n"
@@ -517,7 +517,7 @@ msgstr ""
 "  store migrate: v1 store を検証し、確認後に side-by-side の v2 domain-entry/"
 "object graph を書き込みます\n"
 
-#: src/cli.c:1890
+#: src/cli.c:1897
 msgid ""
 "  store finalize-migration: inspect or remove legacy v1 fallback files after "
 "a v2 migration\n"
@@ -525,11 +525,11 @@ msgstr ""
 "  store finalize-migration: v2 migration 後の legacy v1 fallback file を確認"
 "または削除します\n"
 
-#: src/cli.c:1891 src/cli.c:2120
+#: src/cli.c:1898 src/cli.c:2130
 msgid "  version: print the secdat version\n"
 msgstr "  version: secdat のバージョンを表示します\n"
 
-#: src/cli.c:1896
+#: src/cli.c:1903
 #, c-format
 msgid ""
 "\n"
@@ -538,14 +538,14 @@ msgstr ""
 "\n"
 "トピック:\n"
 
-#: src/cli.c:1897 src/cli.c:2124
+#: src/cli.c:1904 src/cli.c:2134
 msgid ""
 "  usecases: show example workflows and task-oriented command combinations\n"
 msgstr ""
 "  usecases: 典型的なワークフローと作業指向のコマンド組み合わせ例を表示しま"
 "す\n"
 
-#: src/cli.c:1898
+#: src/cli.c:1905
 msgid ""
 "  concepts: explain domains, stores, inheritance, local unlocks, local "
 "locks, and KEYREF resolution\n"
@@ -553,7 +553,7 @@ msgstr ""
 "  concepts: domain、store、継承、local unlock、local lock、KEYREF 解決の考え"
 "方を説明します\n"
 
-#: src/cli.c:1899 src/cli.c:2132
+#: src/cli.c:1906 src/cli.c:2142
 msgid ""
 "  inject: explain exec --inject layers, rule kinds, selectors, policy files, "
 "and preflight checks\n"
@@ -561,7 +561,7 @@ msgstr ""
 "  inject: exec --inject の層、ルール種別、選択子、ポリシーファイル、事前検証"
 "を説明します\n"
 
-#: src/cli.c:1904
+#: src/cli.c:1911
 #, c-format
 msgid ""
 "\n"
@@ -570,7 +570,7 @@ msgstr ""
 "\n"
 "意味:\n"
 
-#: src/cli.c:1915
+#: src/cli.c:1922
 msgid ""
 "  --masked, --dormant, and --orphaned select mask states; combine them or "
 "use --all-masks for all three\n"
@@ -578,7 +578,7 @@ msgstr ""
 "  --masked、--dormant、--orphaned で mask 状態を選択します。組み合わせるか、"
 "3 状態すべてには --all-masks を使います\n"
 
-#: src/cli.c:1916
+#: src/cli.c:1923
 msgid ""
 "  --long and --json report record kind, resolution, chain, authorized target "
 "identity, and orphan reason\n"
@@ -586,7 +586,7 @@ msgstr ""
 "  --long と --json は record 種別、解決状態、chain、表示を許可された対象 ID、"
 "orphan 理由を表示します\n"
 
-#: src/cli.c:1917
+#: src/cli.c:1924
 msgid ""
 "  locked hidden names are omitted; state=unknown means observation is "
 "incomplete, not a fourth stored state, and lists explicit candidates\n"
@@ -594,7 +594,7 @@ msgstr ""
 "  lock 中の非表示名は省略します。state=unknown は保存済みの第4状態ではなく、"
 "観測が不完全であることを意味し、候補を明示します\n"
 
-#: src/cli.c:1918
+#: src/cli.c:1925
 msgid ""
 "  JSON reports visible and redacted unknown-state counts and whether the "
 "selected-state result is complete\n"
@@ -602,7 +602,7 @@ msgstr ""
 "  JSON は表示可能／非表示の状態不明件数と、選択した状態の結果が完全かを表示し"
 "ます\n"
 
-#: src/cli.c:1919
+#: src/cli.c:1926
 msgid ""
 "  --long and --json cannot be combined with local-entry filters; short state "
 "filters return a union\n"
@@ -610,7 +610,7 @@ msgstr ""
 "  --long と --json はローカルエントリー用 filter と同時指定できません。短い状"
 "態 filter は和集合を返します\n"
 
-#: src/cli.c:1924
+#: src/cli.c:1931
 msgid ""
 "  key_visibility controls whether the key name is visible while locked; "
 "value_access=always stores a public/plaintext-at-rest value; bulk_select "
@@ -622,7 +622,7 @@ msgstr ""
 "bulk_select は --bulk-gate 使用時に export・list・exec の bulk-gated "
 "selection 対象にできるかを制御します\n"
 
-#: src/cli.c:1925
+#: src/cli.c:1932
 msgid ""
 "  v2 effective --bulk-gate selection also requires the secret object's "
 "bulk_select_value policy to allow bulk selection\n"
@@ -630,14 +630,14 @@ msgstr ""
 "  v2 の実効 --bulk-gate selection では、secret object の bulk_select_value "
 "policy が bulk selection を許可している必要があります\n"
 
-#: src/cli.c:1929
+#: src/cli.c:1936
 msgid ""
 "  meta: manage non-secret searchable metadata attached to keys in the "
 "current store\n"
 msgstr ""
 "  meta: current store 内の key に付けた非秘密の検索用 metadata を管理します\n"
 
-#: src/cli.c:1930
+#: src/cli.c:1937
 msgid ""
 "  metadata values are labels or descriptions for lookup; do not store secret "
 "material in metadata\n"
@@ -645,12 +645,12 @@ msgstr ""
 "  metadata value は検索用の label や説明です。metadata には secret material "
 "を保存しないでください\n"
 
-#: src/cli.c:1934
+#: src/cli.c:1941
 msgid "  meta get: print non-secret searchable metadata for one visible key\n"
 msgstr ""
 "  meta get: 1 つの visible key の非秘密な検索用 metadata を表示します\n"
 
-#: src/cli.c:1938
+#: src/cli.c:1945
 msgid ""
 "  meta set: attach or replace one non-secret searchable metadata field on a "
 "local key\n"
@@ -658,11 +658,11 @@ msgstr ""
 "  meta set: local key に非秘密の検索用 metadata field を 1 つ追加または置換し"
 "ます\n"
 
-#: src/cli.c:1942
+#: src/cli.c:1949
 msgid "  meta unset: remove one searchable metadata field from a local key\n"
 msgstr "  meta unset: local key から検索用 metadata field を 1 つ削除します\n"
 
-#: src/cli.c:1946
+#: src/cli.c:1953
 msgid ""
 "  meta search: list visible keys whose non-secret metadata contains all "
 "requested fields or glob-matched values\n"
@@ -670,7 +670,7 @@ msgstr ""
 "  meta search: 指定 field または glob に一致する value をすべて含む非秘密 "
 "metadata を持つ visible key を一覧します\n"
 
-#: src/cli.c:1950
+#: src/cli.c:1957
 msgid ""
 "  meta mark-leaked: mark one key as leaked metadata and print high-risk "
 "relation refresh suggestions\n"
@@ -678,7 +678,7 @@ msgstr ""
 "  meta mark-leaked: 1 つの key を漏洩 metadata として mark し、高リスクの "
 "relation refresh 提案を表示します\n"
 
-#: src/cli.c:1954
+#: src/cli.c:1961
 msgid ""
 "  relation: record semantic links between multiple key references and the "
 "non-secret security meaning of the combination\n"
@@ -686,7 +686,7 @@ msgstr ""
 "  relation: 複数の key reference 間の意味的な link と、その組み合わせの非秘密"
 "な security meaning を記録します\n"
 
-#: src/cli.c:1958
+#: src/cli.c:1965
 msgid ""
 "  relation set: create or replace one semantic relation with two or more "
 "role=KEYREF members\n"
@@ -694,7 +694,7 @@ msgstr ""
 "  relation set: 2 つ以上の role=KEYREF member を持つ semantic relation を作成"
 "または置換します\n"
 
-#: src/cli.c:1962
+#: src/cli.c:1969
 msgid ""
 "  relation ls: list relation identifiers, optionally limited to relations "
 "containing one key\n"
@@ -702,7 +702,7 @@ msgstr ""
 "  relation ls: relation identifier を一覧します。必要なら 1 つの key を含む "
 "relation に絞り込みます\n"
 
-#: src/cli.c:1966
+#: src/cli.c:1973
 msgid ""
 "  relation search: list relation identifiers whose non-secret relation "
 "fields match all filters\n"
@@ -710,7 +710,7 @@ msgstr ""
 "  relation search: すべての filter に一致する非秘密の relation field を持つ "
 "relation identifier を一覧します\n"
 
-#: src/cli.c:1970
+#: src/cli.c:1977
 msgid ""
 "  relation suggest-refresh: suggest high-risk refresh targets related to one "
 "leaked key without reading secret values\n"
@@ -718,7 +718,7 @@ msgstr ""
 "  relation suggest-refresh: secret value を読まずに、1 つの leaked key に関連"
 "する高リスクの refresh target を提案します\n"
 
-#: src/cli.c:1974
+#: src/cli.c:1981
 msgid ""
 "  relation suggest-link: compare same-name keys across registered domains "
 "and print link candidates without printing secret values\n"
@@ -726,7 +726,7 @@ msgstr ""
 "  relation suggest-link: 登録済み domain 間の同名 key を比較し、secret value "
 "を表示せずに link 候補を出力します\n"
 
-#: src/cli.c:1975
+#: src/cli.c:1982
 msgid ""
 "  link clusters are optional non-secret key metadata; by default relation "
 "suggest-link reads the link_cluster field\n"
@@ -734,18 +734,18 @@ msgstr ""
 "  link cluster は任意の非秘密 key metadata です。relation suggest-link は既定"
 "で link_cluster field を読みます\n"
 
-#: src/cli.c:1979
+#: src/cli.c:1986
 msgid ""
 "  relation show: print one semantic relation without reading secret values\n"
 msgstr ""
 "  relation show: secret value を読まずに 1 つの semantic relation を表示しま"
 "す\n"
 
-#: src/cli.c:1983
+#: src/cli.c:1990
 msgid "  relation rm: remove one semantic relation record\n"
 msgstr "  relation rm: semantic relation record を 1 つ削除します\n"
 
-#: src/cli.c:1988
+#: src/cli.c:1995
 msgid ""
 "  with no filters, fsck runs orphaned, dangling, and refcount checks; --"
 "repair only rebuilds cached v2 refcounts\n"
@@ -753,7 +753,7 @@ msgstr ""
 "  filter 指定なしの fsck は orphaned、dangling、refcount check を実行しま"
 "す。--repair は cached v2 refcount だけを再構築します\n"
 
-#: src/cli.c:1989
+#: src/cli.c:1996
 msgid ""
 "  v2 mask checks report orphaned-mask, ambiguous-mask, dangling-mask, and "
 "incomplete-mask-state; dormant masks are valid\n"
@@ -761,7 +761,7 @@ msgstr ""
 "  v2 mask 検査は orphaned-mask、ambiguous-mask、dangling-mask、incomplete-"
 "mask-state を報告します。dormant mask は正常です\n"
 
-#: src/cli.c:1990
+#: src/cli.c:1997
 msgid ""
 "  corrupt mask rows use a non-reversible record-sha256 handle; <redacted> "
 "means the identity is not authorized\n"
@@ -769,7 +769,7 @@ msgstr ""
 "  壊れた mask 行には逆算できない record-sha256 ハンドルを使用します。"
 "<redacted> は identity の表示権限がないことを意味します\n"
 
-#: src/cli.c:1991
+#: src/cli.c:1998
 msgid ""
 "  record-sha256 is the first 16 SHA-256 hex digits of the .mask filename "
 "UUID; match it inside the protected masks directory\n"
@@ -777,7 +777,7 @@ msgstr ""
 "  record-sha256 は .mask ファイル名 UUID の SHA-256 先頭16桁です。保護された "
 "masks ディレクトリ内で照合してください\n"
 
-#: src/cli.c:1992
+#: src/cli.c:1999
 msgid ""
 "  no automatic mask-record repair is available; preserve a corrupt record "
 "until its intended mask can be recovered\n"
@@ -785,7 +785,7 @@ msgstr ""
 "  mask record の自動修復はありません。意図した mask を復元できるまで壊れた "
 "record を保存してください\n"
 
-#: src/cli.c:1993
+#: src/cli.c:2000
 msgid ""
 "  unlock affected domains for <redacted> rows and rerun list --all-masks --"
 "long and fsck\n"
@@ -793,14 +793,14 @@ msgstr ""
 "  <redacted> 行では対象 domain を unlock し、list --all-masks --long と fsck "
 "を再実行してください\n"
 
-#: src/cli.c:1997
+#: src/cli.c:2004
 msgid ""
 "  gc: remove unreachable or dangling v2 graph files after dry-run review\n"
 msgstr ""
 "  gc: dry-run review 後に到達不能または dangling な v2 graph file を削除しま"
 "す\n"
 
-#: src/cli.c:1998
+#: src/cli.c:2005
 msgid ""
 "  --dry-run previews selected v2 graph files; without --dry-run it "
 "permanently removes the selected graph files\n"
@@ -808,7 +808,7 @@ msgstr ""
 "  --dry-run は選択された v2 graph file を事前確認します。--dry-run なしでは選"
 "択された graph file を永続的に削除します\n"
 
-#: src/cli.c:2002
+#: src/cli.c:2009
 msgid ""
 "  mask: create a canonical identity mask and, for public names, its v1 "
 "rollback-compatible tombstone in one recoverable transaction\n"
@@ -816,7 +816,7 @@ msgstr ""
 "  mask: canonical identity mask と、public name の場合は v1 rollback 互換の "
 "tombstone を 1 つの復旧可能な transaction で作成します\n"
 
-#: src/cli.c:2003
+#: src/cli.c:2010
 msgid ""
 "  hidden names remain canonical-only; an unsafe v1 rollback projection is "
 "rejected before mutation\n"
@@ -824,7 +824,7 @@ msgstr ""
 "  hidden name は canonical-only のまま扱い、安全でない v1 rollback 投影は変更"
 "前に拒否します\n"
 
-#: src/cli.c:2004
+#: src/cli.c:2011
 msgid ""
 "  --rebind repairs a legacy or orphan barrier by attaching the current "
 "unique inherited target without an exposure window\n"
@@ -832,7 +832,7 @@ msgstr ""
 "  --rebind は現在の一意な継承 target を露出期間なしで関連付け、legacy または "
 "orphan barrier を修復します\n"
 
-#: src/cli.c:2005
+#: src/cli.c:2012
 msgid ""
 "  when rebind has multiple candidates, use domain ls --ancestors and id KEY "
 "in each ancestor to locate duplicates before retrying\n"
@@ -840,7 +840,7 @@ msgstr ""
 "  rebind に複数候補がある場合は、domain ls --ancestors と各 ancestor の id "
 "KEY で重複を特定してから再実行してください\n"
 
-#: src/cli.c:2006
+#: src/cli.c:2013
 msgid ""
 "  --dry-run reports the immutable plan; --json uses secdat.mask-operation-"
 "plan.v1 for dry-run and committed results\n"
@@ -848,14 +848,14 @@ msgstr ""
 "  --dry-run は不変の plan を報告します。--json は dry-run と commit 済み結果"
 "に secdat.mask-operation-plan.v1 を使います\n"
 
-#: src/cli.c:2010
+#: src/cli.c:2017
 msgid ""
 "  unmask: atomically remove the unique logical mask chain controlling one "
 "key\n"
 msgstr ""
 "  unmask: 1 つの key を制御する一意な論理 mask chain を原子的に削除します\n"
 
-#: src/cli.c:2011
+#: src/cli.c:2018
 msgid ""
 "  name-only removal refuses competing chains and chains protecting multiple "
 "names; inspect list --all-masks --long and retry with --mask-chain UUID\n"
@@ -864,7 +864,7 @@ msgstr ""
 "す。list --all-masks --long で確認し、--mask-chain UUID 付きで再実行してくだ"
 "さい\n"
 
-#: src/cli.c:2012
+#: src/cli.c:2019
 msgid ""
 "  --mask-chain must identify a chain that protects the requested key; --dry-"
 "run/--json list every affected authorized key slot\n"
@@ -872,7 +872,7 @@ msgstr ""
 "  --mask-chain は要求した key を保護する chain を指定する必要があります。--"
 "dry-run/--json は影響する認可済み key slot をすべて表示します\n"
 
-#: src/cli.c:2013
+#: src/cli.c:2020
 msgid ""
 "  deferred-exposure warnings default to on; --mask-warnings=default|on|off, "
 "--warn-mask, and --no-warn-mask change warnings only\n"
@@ -880,7 +880,7 @@ msgstr ""
 "  遅延露出 warning は既定で on です。--mask-warnings=default|on|off、--warn-"
 "mask、--no-warn-mask は warning だけを変更します\n"
 
-#: src/cli.c:2022
+#: src/cli.c:2029
 msgid ""
 "  the UUID is an address, not authority; follow-up metadata commands still "
 "use the current domain/store object view\n"
@@ -888,7 +888,7 @@ msgstr ""
 "  UUID は address であって authority ではありません。後続の metadata command "
 "も現在の domain/store object view を使います\n"
 
-#: src/cli.c:2030
+#: src/cli.c:2037
 #, fuzzy
 msgid ""
 "  set: store or update one key in the resolved current domain; --generate "
@@ -899,19 +899,19 @@ msgstr ""
 "unsafe は lock 中も見える平文を保存します。--ephemeral は active session "
 "agent に unlocked-only の値を 1 つ保持します\n"
 
-#: src/cli.c:2031
+#: src/cli.c:2038
 msgid ""
 "  --generate requires --length N and --charset CLASS[,CLASS...]; classes are "
 "lower, upper, digit, symbol, alnum, hex, base64url, and ascii\n"
 msgstr ""
 
-#: src/cli.c:2032
+#: src/cli.c:2039
 msgid ""
 "  --require-each-class requires at least one character from every named "
 "charset class\n"
 msgstr ""
 
-#: src/cli.c:2033
+#: src/cli.c:2040
 msgid ""
 "  --ephemeral stores only in the active session agent, forces unlocked key/"
 "value access, and defaults bulk_select to exclude\n"
@@ -919,7 +919,7 @@ msgstr ""
 "  --ephemeral は active session agent にのみ保存し、key/value access を "
 "unlocked に固定して、bulk_select の既定を exclude にします\n"
 
-#: src/cli.c:2034
+#: src/cli.c:2041
 msgid ""
 "  ephemeral values shadow persisted same-name values until rm --ephemeral, "
 "lock, or session expiry; use --bulk-select include to allow bulk-gated "
@@ -929,7 +929,7 @@ msgstr ""
 "続値を隠します。bulk-gated selection を許可するには --bulk-select include を"
 "指定します\n"
 
-#: src/cli.c:2035
+#: src/cli.c:2042
 msgid ""
 "  plain set, SDK/FUSE writes, cp, mv, ln, mask, unmask, attr updates, and "
 "save reject an ephemeral target instead of persisting it accidentally\n"
@@ -937,7 +937,7 @@ msgstr ""
 "  plain set、SDK/FUSE write、cp、mv、ln、mask、unmask、attr update、および "
 "save は、ephemeral target を誤って永続化せず拒否します\n"
 
-#: src/cli.c:2036
+#: src/cli.c:2043
 msgid ""
 "  mutation planning options such as --dry-run and --json are not supported "
 "with --ephemeral\n"
@@ -945,7 +945,7 @@ msgstr ""
 "  --dry-run や --json などの mutation planning option は --ephemeral と併用で"
 "きません\n"
 
-#: src/cli.c:2037
+#: src/cli.c:2044
 msgid ""
 "  v2 writes default to --mask-action=preserve; reject fails before any "
 "direct hit or mask state transition\n"
@@ -953,7 +953,7 @@ msgstr ""
 "  v2 write の既定は --mask-action=preserve です。reject は direct hit または "
 "mask state 遷移の前に失敗します\n"
 
-#: src/cli.c:2038
+#: src/cli.c:2045
 msgid ""
 "  mask warnings default to on for preserve and off for reject; warning "
 "controls never change behavior or exit status\n"
@@ -961,7 +961,7 @@ msgstr ""
 "  mask warning は preserve では既定で on、reject では off です。warning 制御"
 "は動作や終了 status を変更しません\n"
 
-#: src/cli.c:2039
+#: src/cli.c:2046
 msgid ""
 "  --dry-run and --json expose the same secdat.mutation-plan.v1 used for one "
 "key or the whole assignment batch\n"
@@ -969,7 +969,7 @@ msgstr ""
 "  --dry-run と --json は、単一 key または assignment batch 全体の commit に使"
 "うものと同じ secdat.mutation-plan.v1 を表示します\n"
 
-#: src/cli.c:2043
+#: src/cli.c:2050
 msgid ""
 "  rm: remove one key locally or create a tombstone for an inherited key; --"
 "ignore-missing treats absent keys as success\n"
@@ -977,7 +977,7 @@ msgstr ""
 "  rm: 1 つの key をローカルに削除するか、継承 key 用の tombstone を作成しま"
 "す。--ignore-missing は未存在の key を成功扱いにします\n"
 
-#: src/cli.c:2044
+#: src/cli.c:2051
 msgid ""
 "  --ephemeral removes only the current domain's session-local ephemeral "
 "value and reveals any persisted value it shadowed\n"
@@ -985,7 +985,7 @@ msgstr ""
 "  --ephemeral は current domain の session-local ephemeral value のみを削除"
 "し、その下に隠れていた永続値を再表示します\n"
 
-#: src/cli.c:2045
+#: src/cli.c:2052
 msgid ""
 "  v2 rm preserves canonical masks and reports reactivation or source-mask "
 "creation through the common mutation plan\n"
@@ -993,7 +993,7 @@ msgstr ""
 "  v2 の rm は canonical mask を保持し、再活性化または source mask 作成を共通 "
 "mutation plan で報告します\n"
 
-#: src/cli.c:2046
+#: src/cli.c:2053
 msgid ""
 "  --mask-action=reject blocks those interactions; warning controls affect "
 "only successful post-commit warnings\n"
@@ -1001,7 +1001,7 @@ msgstr ""
 "  --mask-action=reject はそれらの interaction を拒否します。warning 制御が影"
 "響するのは成功した commit 後の warning だけです\n"
 
-#: src/cli.c:2047
+#: src/cli.c:2054
 msgid ""
 "  --dry-run and --json expose secdat.mutation-plan.v1 without changing "
 "persisted state\n"
@@ -1009,7 +1009,31 @@ msgstr ""
 "  --dry-run と --json は persisted state を変更せずに secdat.mutation-plan."
 "v1 を表示します\n"
 
-#: src/cli.c:2055
+#: src/cli.c:2059
+msgid ""
+"  a same-domain/store local v2 rename preserves both entry and secret IDs, "
+"existing links, and object refcount\n"
+msgstr ""
+"  同じ domain/store 内の local v2 rename は entry ID と secret ID、既存の "
+"link、object refcount を維持します\n"
+
+#: src/cli.c:2060
+msgid ""
+"  descendant identity masks follow the preserved entry; relation KEYREF "
+"rewrites are reported separately in the common mutation plan\n"
+msgstr ""
+"  descendant identity mask は維持された entry に追従します。relation KEYREF "
+"の書き換えは共通 mutation plan で別に報告されます\n"
+
+#: src/cli.c:2061
+msgid ""
+"  --mask-action=preserve is the default; reject, warning controls, dry-run, "
+"and JSON apply to local same-namespace v2 rename\n"
+msgstr ""
+"  --mask-action=preserve が既定です。reject、warning 制御、dry-run、JSON は "
+"local same-namespace v2 rename に適用されます\n"
+
+#: src/cli.c:2065
 msgid ""
 "  cp: copy one key to a new independently identified destination while "
 "preserving destination masks in v2 stores\n"
@@ -1017,7 +1041,7 @@ msgstr ""
 "  cp: v2 store の destination mask を保持しながら、key を独立した新しい識別子"
 "の destination へコピーします\n"
 
-#: src/cli.c:2056
+#: src/cli.c:2066
 msgid ""
 "  --mask-action=preserve is the default; reject, warning controls, dry-run, "
 "and JSON use the common mutation plan\n"
@@ -1025,7 +1049,7 @@ msgstr ""
 "  --mask-action=preserve が既定です。reject、warning 制御、dry-run、JSON は共"
 "通 mutation plan を使います\n"
 
-#: src/cli.c:2061
+#: src/cli.c:2071
 msgid ""
 "  value writes through either linked key affect the shared object; domain-"
 "entry attributes remain per link\n"
@@ -1033,7 +1057,7 @@ msgstr ""
 "  link されたどちらの key から value を書き込んでも共有 object に反映されま"
 "す。domain-entry 属性は link ごとに保持されます\n"
 
-#: src/cli.c:2062
+#: src/cli.c:2072
 msgid ""
 "  --replace allows replacing an existing same-name destination key; by "
 "default it first confirms both values are equal, and --skip-same-value-check "
@@ -1043,7 +1067,7 @@ msgstr ""
 "に両方の値が同じことを確認し、--skip-same-value-check はその確認を省略しま"
 "す\n"
 
-#: src/cli.c:2063
+#: src/cli.c:2073
 msgid ""
 "  destination masks are preserved; reject, warning controls, dry-run, and "
 "JSON use the common mutation plan\n"
@@ -1051,7 +1075,7 @@ msgstr ""
 "  destination mask は保持されます。reject、warning 制御、dry-run、JSON は共"
 "通 mutation plan を使います\n"
 
-#: src/cli.c:2068
+#: src/cli.c:2078
 msgid ""
 "  --inject LAYER:KIND=SELECTOR configures ambient, secret, route, or final "
 "rules; repeated --inject accumulates selectors of the same kind\n"
@@ -1059,7 +1083,7 @@ msgstr ""
 "  --inject LAYER:KIND=SELECTOR で ambient、secret、route、final のルールを設"
 "定します。同じ種別の選択子は --inject を繰り返すと追加されます\n"
 
-#: src/cli.c:2069
+#: src/cli.c:2079
 msgid ""
 "  --inject-file FILE loads a YAML policy; command profiles can refine file "
 "rules before CLI --inject overrides them\n"
@@ -1067,14 +1091,14 @@ msgstr ""
 "  --inject-file FILE で YAML ポリシーを読み込みます。command profile は CLI "
 "--inject が上書きする前に file rule を調整できます\n"
 
-#: src/cli.c:2070
+#: src/cli.c:2080
 msgid ""
 "  --bulk-gate applies the store bulk_select pre-filter before secret supply\n"
 msgstr ""
 "  --bulk-gate は secret 供給の前に store の bulk_select 事前フィルターを適用"
 "します\n"
 
-#: src/cli.c:2071
+#: src/cli.c:2081
 msgid ""
 "  --command-resolution MODE selects CMD lookup: caller-path (default), child-"
 "path, or direct\n"
@@ -1082,7 +1106,7 @@ msgstr ""
 "  --command-resolution MODE は CMD lookup を選択します: caller-path "
 "(default)、child-path、または direct\n"
 
-#: src/cli.c:2072
+#: src/cli.c:2082
 msgid ""
 "  see help inject for the rule vocabulary, selector syntax, YAML shape, and "
 "preflight examples\n"
@@ -1090,7 +1114,7 @@ msgstr ""
 "  ルール語彙、選択子構文、YAML 形式、事前検証例は help inject を参照してくだ"
 "さい\n"
 
-#: src/cli.c:2081
+#: src/cli.c:2091
 msgid ""
 "  --key KEY may be repeated to save only named keys from the selected domain "
 "and store\n"
@@ -1098,7 +1122,7 @@ msgstr ""
 "  --key KEY は繰り返し指定でき、選択した domain と store の指定キーだけを保存"
 "します\n"
 
-#: src/cli.c:2085
+#: src/cli.c:2095
 msgid ""
 "  load: import a passphrase-protected bundle through one v2 mutation plan "
 "and one recoverable transaction\n"
@@ -1106,19 +1130,19 @@ msgstr ""
 "  load: パスフレーズ保護された bundle を 1 つの v2 mutation plan と復旧可能"
 "な transaction で取り込みます\n"
 
-#: src/cli.c:2086
+#: src/cli.c:2096
 msgid ""
 "  --conflict=reject is the default and rejects any destination name visible "
 "in ls; overwrite replaces, skip leaves it unchanged\n"
 msgstr ""
 
-#: src/cli.c:2087
+#: src/cli.c:2097
 msgid ""
 "  linked v2 objects require a v2 destination; --allow-link-split explicitly "
 "materializes independent v1 values\n"
 msgstr ""
 
-#: src/cli.c:2088
+#: src/cli.c:2098
 msgid ""
 "  --mask-action=reject blocks any batch mask interaction; warning controls "
 "never change the batch result\n"
@@ -1126,13 +1150,13 @@ msgstr ""
 "  --mask-action=reject は batch 内の mask interaction を拒否します。warning "
 "制御は batch の結果を変更しません\n"
 
-#: src/cli.c:2089
+#: src/cli.c:2099
 msgid ""
 "  --dry-run and --json report the whole batch without committing any entry\n"
 msgstr ""
 "  --dry-run と --json は、entry を commit せずに batch 全体を報告します\n"
 
-#: src/cli.c:2094
+#: src/cli.c:2104
 msgid ""
 "  --gui forces passphrase prompts through the askpass helper even when a "
 "terminal is available\n"
@@ -1140,7 +1164,7 @@ msgstr ""
 "  --gui は端末が利用可能な場合でも passphrase prompt を askpass helper 経由に"
 "強制します\n"
 
-#: src/cli.c:2095
+#: src/cli.c:2105
 msgid ""
 "  --volatile keeps writes, deletes, tombstones, and read-side resolution "
 "changes in a session overlay; lock --save persists supported overlay changes "
@@ -1150,7 +1174,7 @@ msgstr ""
 "session overlay に保持します。lock --save は lock 前に対応済みの overlay 変更"
 "を永続化します\n"
 
-#: src/cli.c:2096
+#: src/cli.c:2106
 msgid ""
 "  persisted tombstone removal and v2 local-entry deletions still require a "
 "normal writable session\n"
@@ -1158,14 +1182,14 @@ msgstr ""
 "  永続 tombstone の削除と v2 local-entry の削除には、通常の writable session "
 "が引き続き必要です\n"
 
-#: src/cli.c:2128
+#: src/cli.c:2138
 msgid ""
 "  concepts: explain domains, stores, inheritance, sessions, and KEYREF "
 "resolution\n"
 msgstr ""
 "  concepts: domain、store、継承、session、KEYREF 解決の考え方を説明します\n"
 
-#: src/cli.c:2136
+#: src/cli.c:2146
 msgid ""
 "  store: manage store namespaces and migrate v1 stores to the v2 domain-"
 "entry/object layout\n"
@@ -1173,26 +1197,26 @@ msgstr ""
 "  store: store namespace を管理し、v1 store を v2 domain-entry/object layout "
 "へ migrate します\n"
 
-#: src/cli.c:2140
+#: src/cli.c:2150
 msgid ""
 "  store create: create one store namespace in the resolved current domain\n"
 msgstr ""
 "  store create: 解決された current domain 内に store namespace を 1 つ作成し"
 "ます\n"
 
-#: src/cli.c:2144
+#: src/cli.c:2154
 msgid ""
 "  store delete: delete one store namespace from the resolved current domain\n"
 msgstr ""
 "  store delete: 解決された current domain から store namespace を 1 つ削除し"
 "ます\n"
 
-#: src/cli.c:2148
+#: src/cli.c:2158
 msgid "  store ls: list store namespaces in the resolved current domain\n"
 msgstr ""
 "  store ls: 解決された current domain 内の store namespace を一覧表示します\n"
 
-#: src/cli.c:2152
+#: src/cli.c:2162
 msgid ""
 "  store migrate: validate one v1 store; without --dry-run, write the side-by-"
 "side v2 domain-entry/object graph and leave v1 fallback files in place\n"
@@ -1201,7 +1225,7 @@ msgstr ""
 "side の v2 domain-entry/object graph を書き込み、v1 fallback file は残しま"
 "す\n"
 
-#: src/cli.c:2153
+#: src/cli.c:2163
 msgid ""
 "  mask plan counts separate existing canonical masks, conversion candidates, "
 "ambiguous legacy masks, and v1 rollback blockers\n"
@@ -1209,7 +1233,7 @@ msgstr ""
 "  mask plan の件数は既存 canonical mask、変換候補、曖昧な legacy mask、v1 "
 "rollback blocker を区別します\n"
 
-#: src/cli.c:2154
+#: src/cli.c:2164
 msgid ""
 "  dry-run mask-plan rows name each authorized candidate, ambiguity, or "
 "existing canonical mask; ambiguity remains fail closed and does not alone "
@@ -1219,7 +1243,7 @@ msgstr ""
 "mask を名前付きで示します。曖昧な mask は fail closed のまま保持され、それだ"
 "けでは migration を妨げません\n"
 
-#: src/cli.c:2155
+#: src/cli.c:2165
 msgid ""
 "  an unverifiable legacy projection blocks migration; unlock affected "
 "domains, inspect masks, and retry the dry-run\n"
@@ -1227,7 +1251,7 @@ msgstr ""
 "  検証できない legacy 投影は移行を停止します。対象 domain を unlock して "
 "mask を確認し、dry-run を再実行してください\n"
 
-#: src/cli.c:2159
+#: src/cli.c:2169
 msgid ""
 "  store finalize-migration: inspect legacy v1 fallback files; without --dry-"
 "run, remove only removable files and refuse to remove anything while "
@@ -1236,7 +1260,7 @@ msgstr ""
 "  store finalize-migration: legacy v1 fallback file を確認します。--dry-run "
 "なしでは削除可能な file だけを削除し、blocker が残る間は何も削除しません\n"
 
-#: src/cli.c:2160
+#: src/cli.c:2170
 msgid ""
 "  typical order is migrate dry-run, migrate, fsck --format v2, rewrite or "
 "remove fallback-backed values, finalize dry-run, then finalize\n"
@@ -1244,7 +1268,7 @@ msgstr ""
 "  典型的な順序は migrate dry-run、migrate、fsck --format v2、fallback-backed "
 "value の再書き込みまたは削除、finalize dry-run、finalize です\n"
 
-#: src/cli.c:2169
+#: src/cli.c:2179
 msgid ""
 "  UUID lookup is scoped to the current domain/store object view; use the "
 "object's owning context for cross-domain links\n"
@@ -1252,17 +1276,17 @@ msgstr ""
 "  UUID lookup は現在の domain/store object view に閉じます。cross-domain "
 "link では object の所有 context を使ってください\n"
 
-#: src/cli.c:2177
+#: src/cli.c:2187
 msgid "  domain create: register the resolved directory as a domain root\n"
 msgstr ""
 "  domain create: 解決された directory を domain root として登録します\n"
 
-#: src/cli.c:2181
+#: src/cli.c:2191
 msgid "  domain delete: unregister the resolved directory as a domain root\n"
 msgstr ""
 "  domain delete: 解決された directory の domain root 登録を解除します\n"
 
-#: src/cli.c:2185
+#: src/cli.c:2195
 msgid ""
 "  domain move: update a registered domain root path without deleting its "
 "stored secrets\n"
@@ -1270,11 +1294,11 @@ msgstr ""
 "  domain move: 保存済み secret を削除せずに登録済み domain root path を更新し"
 "ます\n"
 
-#: src/cli.c:2189
+#: src/cli.c:2199
 msgid "  domain ls: list domain roots around the scoped directory\n"
 msgstr "  domain ls: scoped directory 周辺の domain root を一覧表示します\n"
 
-#: src/cli.c:2193
+#: src/cli.c:2203
 msgid ""
 "  domain status: report the resolved domain root and effective lock/unlock "
 "source\n"
@@ -1282,7 +1306,7 @@ msgstr ""
 "  domain status: 解決された domain root と有効な lock/unlock source を報告し"
 "ます\n"
 
-#: src/cli.c:2204 src/cli.c:2425
+#: src/cli.c:2214 src/cli.c:2435
 #, c-format
 msgid ""
 "\n"
@@ -1291,12 +1315,12 @@ msgstr ""
 "\n"
 "利用例:\n"
 
-#: src/cli.c:2207
+#: src/cli.c:2217
 #, c-format
 msgid "  read one value to stdout: %s get API_TOKEN --stdout\n"
 msgstr "  1 つの値を標準出力へ読む: %s get API_TOKEN --stdout\n"
 
-#: src/cli.c:2209
+#: src/cli.c:2219
 #, c-format
 msgid ""
 "  wait for another terminal to unlock before reading: %s get --on-demand-"
@@ -1305,20 +1329,20 @@ msgstr ""
 "  読み取り前に別端末の unlock を待つ: %s get --on-demand-unlock --unlock-"
 "timeout 30 API_TOKEN --stdout\n"
 
-#: src/cli.c:2215
+#: src/cli.c:2225
 #, c-format
 msgid ""
 "  write one value from an argument: %s set API_TOKEN --value new-token\n"
 msgstr "  引数から 1 つの値を書き込む: %s set API_TOKEN --value new-token\n"
 
-#: src/cli.c:2217
+#: src/cli.c:2227
 #, c-format
 msgid ""
 "  generate a 40-character token without printing it: %s set API_TOKEN --"
 "generate --length 40 --charset lower,upper,digit --require-each-class\n"
 msgstr ""
 
-#: src/cli.c:2219
+#: src/cli.c:2229
 #, c-format
 msgid ""
 "  read a value from standard input without echoing it in shell history: "
@@ -1327,12 +1351,12 @@ msgstr ""
 "  shell 履歴へ残さず標準入力から値を読む: printf 'token' | %s set API_TOKEN "
 "--stdin\n"
 
-#: src/cli.c:2225
+#: src/cli.c:2235
 #, c-format
 msgid "  inspect one key's current attributes: %s attr API_TOKEN\n"
 msgstr "  1 つの key の現在の属性を確認する: %s attr API_TOKEN\n"
 
-#: src/cli.c:2227
+#: src/cli.c:2237
 #, c-format
 msgid ""
 "  make one value public while keeping the key name visible: %s attr "
@@ -1341,19 +1365,19 @@ msgstr ""
 "  key 名を見えるまま 1 つの value を public にする: %s attr API_TOKEN --"
 "value-access always\n"
 
-#: src/cli.c:2233
+#: src/cli.c:2243
 #, c-format
 msgid "  tag one key for search: %s meta set API_TOKEN service billing\n"
 msgstr ""
 "  検索用に 1 つの key へ tag を付ける: %s meta set API_TOKEN service "
 "billing\n"
 
-#: src/cli.c:2235
+#: src/cli.c:2245
 #, c-format
 msgid "  find keys by metadata: %s meta search service=bill*\n"
 msgstr "  metadata で key を探す: %s meta search service=bill*\n"
 
-#: src/cli.c:2237
+#: src/cli.c:2247
 #, c-format
 msgid ""
 "  mark a leaked key and suggest refresh targets: %s meta mark-leaked "
@@ -1362,7 +1386,7 @@ msgstr ""
 "  leaked key を mark して refresh target を提案する: %s meta mark-leaked "
 "BILLING_PASSWORD\n"
 
-#: src/cli.c:2243
+#: src/cli.c:2253
 #, c-format
 msgid ""
 "  record a credential pair: %s relation set billing-login --kind credential "
@@ -1373,7 +1397,7 @@ msgstr ""
 "credential --member id=BILLING_ID --member password=BILLING_PASSWORD --"
 "security combination-sensitive\n"
 
-#: src/cli.c:2245
+#: src/cli.c:2255
 #, c-format
 msgid ""
 "  find credential relations: %s relation search kind=credential "
@@ -1382,7 +1406,7 @@ msgstr ""
 "  credential relation を探す: %s relation search kind=credential "
 "security=combination-*\n"
 
-#: src/cli.c:2247
+#: src/cli.c:2257
 #, c-format
 msgid ""
 "  suggest refresh targets after a leak: %s relation suggest-refresh "
@@ -1391,7 +1415,7 @@ msgstr ""
 "  leak 後の refresh target を提案する: %s relation suggest-refresh "
 "BILLING_PASSWORD\n"
 
-#: src/cli.c:2249
+#: src/cli.c:2259
 #, c-format
 msgid ""
 "  find same-name cross-domain link candidates: %s relation suggest-link "
@@ -1399,17 +1423,17 @@ msgid ""
 msgstr ""
 "  同名 cross-domain link 候補を探す: %s relation suggest-link APP_TOKEN\n"
 
-#: src/cli.c:2251
+#: src/cli.c:2261
 #, c-format
 msgid "  inspect relation metadata: %s relation show billing-login\n"
 msgstr "  relation metadata を確認する: %s relation show billing-login\n"
 
-#: src/cli.c:2257
+#: src/cli.c:2267
 #, c-format
 msgid "  run all current-domain metadata checks: %s fsck\n"
 msgstr "  current-domain metadata check をすべて実行する: %s fsck\n"
 
-#: src/cli.c:2259
+#: src/cli.c:2269
 #, c-format
 msgid ""
 "  rebuild cached v2 refcounts after review: %s fsck --format v2 --refcount --"
@@ -1418,7 +1442,7 @@ msgstr ""
 "  確認後に cached v2 refcount を再構築する: %s fsck --format v2 --refcount --"
 "repair\n"
 
-#: src/cli.c:2261
+#: src/cli.c:2271
 #, c-format
 msgid ""
 "  validate the global reverse dependency index: %s fsck --format v2 --"
@@ -1427,7 +1451,7 @@ msgstr ""
 "  global reverse dependency index を検証する: %s fsck --format v2 --"
 "dependency-index\n"
 
-#: src/cli.c:2263
+#: src/cli.c:2273
 #, c-format
 msgid ""
 "  rebuild and publish the global reverse dependency index: %s fsck --format "
@@ -1436,7 +1460,7 @@ msgstr ""
 "  global reverse dependency index を再構築して公開する: %s fsck --format v2 "
 "--dependency-index --repair\n"
 
-#: src/cli.c:2269
+#: src/cli.c:2279
 #, c-format
 msgid ""
 "  preview unreachable v2 graph files before deletion: %s gc --format v2 --"
@@ -1444,12 +1468,12 @@ msgid ""
 msgstr ""
 "  削除前に到達不能な v2 graph file を確認する: %s gc --format v2 --dry-run\n"
 
-#: src/cli.c:2271
+#: src/cli.c:2281
 #, c-format
 msgid "  delete the reviewed unreachable v2 graph files: %s gc --format v2\n"
 msgstr "  確認済みの到達不能な v2 graph file を削除する: %s gc --format v2\n"
 
-#: src/cli.c:2277
+#: src/cli.c:2287
 #, c-format
 msgid ""
 "  preview the canonical identity and any safe rollback projection: %s mask --"
@@ -1458,7 +1482,7 @@ msgstr ""
 "  canonical identity と安全な rollback 投影を確認する: %s mask --dry-run --"
 "json API_TOKEN\n"
 
-#: src/cli.c:2279
+#: src/cli.c:2289
 #, c-format
 msgid ""
 "  repair an orphan barrier without exposing the replacement target: %s mask "
@@ -1467,7 +1491,7 @@ msgstr ""
 "  置換 target を露出せずに orphan barrier を修復する: %s mask --rebind "
 "API_TOKEN\n"
 
-#: src/cli.c:2285
+#: src/cli.c:2295
 #, c-format
 msgid ""
 "  preview every record removed from the unique chain: %s unmask --dry-run --"
@@ -1476,7 +1500,7 @@ msgstr ""
 "  一意な chain から削除する全 record を確認する: %s unmask --dry-run --json "
 "API_TOKEN\n"
 
-#: src/cli.c:2287
+#: src/cli.c:2297
 #, c-format
 msgid ""
 "  inspect and explicitly remove one multi-name chain: %s unmask --dry-run --"
@@ -1485,14 +1509,14 @@ msgstr ""
 "  複数 name の chain を確認して明示的に削除する: %s unmask --dry-run --mask-"
 "chain UUID API_TOKEN\n"
 
-#: src/cli.c:2289
+#: src/cli.c:2299
 #, c-format
 msgid ""
 "  suppress only the post-commit warning: %s unmask --no-warn-mask API_TOKEN\n"
 msgstr ""
 "  commit 後の warning だけを抑制する: %s unmask --no-warn-mask API_TOKEN\n"
 
-#: src/cli.c:2295
+#: src/cli.c:2305
 #, c-format
 msgid ""
 "  load current shell variables without printing raw secrets: source <(%s "
@@ -1500,7 +1524,7 @@ msgid ""
 msgstr ""
 "  生の secret を表示せず現在の shell 変数へ読み込む: source <(%s export)\n"
 
-#: src/cli.c:2297
+#: src/cli.c:2307
 #, c-format
 msgid ""
 "  export one namespace before running another tool: eval \"$(%s --store app "
@@ -1509,7 +1533,7 @@ msgstr ""
 "  別ツール実行前に 1 つの namespace を export する: eval \"$(%s --store app "
 "export --pattern 'APP_*')\"\n"
 
-#: src/cli.c:2303
+#: src/cli.c:2313
 #, c-format
 msgid ""
 "  run one command with matching secrets injected: %s exec --inject secret:"
@@ -1518,7 +1542,7 @@ msgstr ""
 "  一致した secret を注入して 1 つのコマンドを実行する: %s exec --inject "
 "secret:only=APP_* env\n"
 
-#: src/cli.c:2305
+#: src/cli.c:2315
 #, c-format
 msgid ""
 "  exclude one inherited key while running a child process: %s exec --inject "
@@ -1527,7 +1551,7 @@ msgstr ""
 "  子プロセス実行時に 1 つの継承 key を除外する: %s exec --inject secret:"
 "only=APP_* --inject secret:omit=APP_DEBUG_* CMD\n"
 
-#: src/cli.c:2311
+#: src/cli.c:2321
 #, c-format
 msgid ""
 "  share one v2 secret object under another key: %s ln APP_TOKEN "
@@ -1536,7 +1560,7 @@ msgstr ""
 "  1 つの v2 secret object を別 key 名で共有する: %s ln APP_TOKEN "
 "SERVICE_TOKEN\n"
 
-#: src/cli.c:2313
+#: src/cli.c:2323
 #, c-format
 msgid ""
 "  link across explicit domains/stores: %s ln /src/domain/APP_TOKEN:app /dst/"
@@ -1545,7 +1569,7 @@ msgstr ""
 "  明示した domain/store をまたいで link する: %s ln /src/domain/APP_TOKEN:"
 "app /dst/domain/APP_TOKEN:ops\n"
 
-#: src/cli.c:2315
+#: src/cli.c:2325
 #, c-format
 msgid ""
 "  replace an existing same-name destination after value confirmation: %s ln "
@@ -1554,7 +1578,7 @@ msgstr ""
 "  値確認後に既存の同名 destination を置換する: %s ln --replace /src/domain/"
 "APP_TOKEN /dst/domain/APP_TOKEN\n"
 
-#: src/cli.c:2321
+#: src/cli.c:2331
 #, c-format
 msgid ""
 "  resolve one key to its v2 secret object UUID without reading it: %s id "
@@ -1563,7 +1587,7 @@ msgstr ""
 "  value を読まずに 1 つの key を v2 secret object UUID へ解決する: %s id "
 "API_TOKEN\n"
 
-#: src/cli.c:2323
+#: src/cli.c:2333
 #, c-format
 msgid ""
 "  inspect that object from its owning domain/store context: %s secret status "
@@ -1572,12 +1596,12 @@ msgstr ""
 "  その object の owning domain/store context から確認する: %s secret status "
 "01234567-89ab-4def-8123-456789abcdef\n"
 
-#: src/cli.c:2329
+#: src/cli.c:2339
 #, c-format
 msgid "  start a session for the current project directory: %s unlock\n"
 msgstr "  現在の project directory 用 session を開始する: %s unlock\n"
 
-#: src/cli.c:2331
+#: src/cli.c:2341
 #, c-format
 msgid ""
 "  refresh an active session for 15 minutes without re-entering the "
@@ -1586,7 +1610,7 @@ msgstr ""
 "  パスフレーズ再入力なしで有効な session を 15 分延長する: %s unlock --"
 "duration 15\n"
 
-#: src/cli.c:2333
+#: src/cli.c:2343
 #, c-format
 msgid ""
 "  unlock one specific domain from elsewhere: %s --dir ~/example/project "
@@ -1594,7 +1618,7 @@ msgid ""
 msgstr ""
 "  別の場所から特定 domain を unlock する: %s --dir ~/example/project unlock\n"
 
-#: src/cli.c:2339
+#: src/cli.c:2349
 #, c-format
 msgid ""
 "  block a script until another terminal unlocks the same domain: %s --dir ~/"
@@ -1603,7 +1627,7 @@ msgstr ""
 "  別端末が同じ domain を unlock するまで script を待機させる: %s --dir ~/"
 "example/project wait-unlock --timeout 900\n"
 
-#: src/cli.c:2341
+#: src/cli.c:2351
 #, c-format
 msgid ""
 "  poll quietly before a later secret read: %s wait-unlock --timeout 30 --"
@@ -1612,48 +1636,48 @@ msgstr ""
 "  後続の secret 読み取り前に静かに待機する: %s wait-unlock --timeout 30 --"
 "quiet\n"
 
-#: src/cli.c:2347
+#: src/cli.c:2357
 #, c-format
 msgid "  check whether the current domain can read secrets now: %s status\n"
 msgstr "  現在の domain が今 secret を読めるか確認する: %s status\n"
 
-#: src/cli.c:2349
+#: src/cli.c:2359
 #, c-format
 msgid "  use exit status only in scripts: %s status --quiet\n"
 msgstr "  script では終了コードだけを使う: %s status --quiet\n"
 
-#: src/cli.c:2351
+#: src/cli.c:2361
 #, c-format
 msgid "  read machine-readable state in scripts: %s status --json\n"
 msgstr "  script で機械可読な状態を読む: %s status --json\n"
 
-#: src/cli.c:2357
+#: src/cli.c:2367
 #, c-format
 msgid ""
 "  inspect local tombstones and overrides before cleanup: %s list --masked\n"
 msgstr ""
 "  cleanup 前に local tombstone と override を確認する: %s list --masked\n"
 
-#: src/cli.c:2359
+#: src/cli.c:2369
 #, c-format
 msgid ""
 "  inspect only plaintext-at-rest entries in the current domain: %s list --"
 "unsafe\n"
 msgstr "  現在の domain の平文保存エントリだけ確認する: %s list --unsafe\n"
 
-#: src/cli.c:2365
+#: src/cli.c:2375
 #, c-format
 msgid "  create one namespace for app-specific keys: %s store create app\n"
 msgstr "  app 専用 key 用 namespace を 1 つ作る: %s store create app\n"
 
-#: src/cli.c:2367
+#: src/cli.c:2377
 #, c-format
 msgid ""
 "  inspect available namespaces before selecting one with --store: %s store "
 "ls\n"
 msgstr "  --store で選ぶ前に利用可能 namespace を確認する: %s store ls\n"
 
-#: src/cli.c:2369 src/cli.c:2381
+#: src/cli.c:2379 src/cli.c:2391
 #, c-format
 msgid ""
 "  inspect a v1 to v2 migration before writing: %s store migrate app --to-"
@@ -1662,7 +1686,7 @@ msgstr ""
 "  書き込み前に v1 から v2 への migration を確認する: %s store migrate app --"
 "to-format v2 --dry-run\n"
 
-#: src/cli.c:2371
+#: src/cli.c:2381
 #, c-format
 msgid ""
 "  write the v2 domain-entry/object graph after review: %s store migrate app "
@@ -1671,7 +1695,7 @@ msgstr ""
 "  確認後に v2 domain-entry/object graph を書き込む: %s store migrate app --"
 "to-format v2\n"
 
-#: src/cli.c:2373
+#: src/cli.c:2383
 #, c-format
 msgid ""
 "  inspect legacy fallback files after blockers are rewritten or removed: %s "
@@ -1680,7 +1704,7 @@ msgstr ""
 "  blocker の再書き込みまたは削除後に legacy fallback file を確認する: %s "
 "store finalize-migration app --from-format v1 --dry-run\n"
 
-#: src/cli.c:2375
+#: src/cli.c:2385
 #, c-format
 msgid ""
 "  remove removable legacy fallback files after review: %s store finalize-"
@@ -1689,7 +1713,7 @@ msgstr ""
 "  確認後に削除可能な legacy fallback file を削除する: %s store finalize-"
 "migration app --from-format v1\n"
 
-#: src/cli.c:2383
+#: src/cli.c:2393
 #, c-format
 msgid ""
 "  write the v2 graph after reviewing the dry-run output: %s store migrate "
@@ -1698,7 +1722,7 @@ msgstr ""
 "  dry-run 出力を確認してから v2 graph を書き込む: %s store migrate app --to-"
 "format v2\n"
 
-#: src/cli.c:2389
+#: src/cli.c:2399
 #, c-format
 msgid ""
 "  identify legacy fallback blockers before deleting anything: %s store "
@@ -1707,7 +1731,7 @@ msgstr ""
 "  何かを削除する前に legacy fallback blocker を特定する: %s store finalize-"
 "migration app --from-format v1 --dry-run\n"
 
-#: src/cli.c:2391
+#: src/cli.c:2401
 #, c-format
 msgid ""
 "  remove removable legacy fallback files only after blockers are gone: %s "
@@ -1716,7 +1740,7 @@ msgstr ""
 "  blocker がなくなってから削除可能な legacy fallback file だけを削除する: %s "
 "store finalize-migration app --from-format v1\n"
 
-#: src/cli.c:2397
+#: src/cli.c:2407
 #, c-format
 msgid ""
 "  inspect one v2 secret object by UUID without reading its value: %s secret "
@@ -1725,14 +1749,14 @@ msgstr ""
 "  value を読まずに UUID で 1 つの v2 secret object を確認する: %s secret "
 "status 01234567-89ab-4def-8123-456789abcdef\n"
 
-#: src/cli.c:2399
+#: src/cli.c:2409
 #, c-format
 msgid ""
 "  resolve a visible or unlocked key to its UUID first: %s id API_TOKEN\n"
 msgstr ""
 "  先に visible または unlocked な key を UUID へ解決する: %s id API_TOKEN\n"
 
-#: src/cli.c:2401
+#: src/cli.c:2411
 #, c-format
 msgid ""
 "  for cross-domain links, run status from the object's owning domain/store "
@@ -1741,12 +1765,12 @@ msgstr ""
 "  cross-domain link では object の owning domain/store context から status を"
 "実行してください\n"
 
-#: src/cli.c:2407
+#: src/cli.c:2417
 #, c-format
 msgid "  register the current directory as a domain root: %s domain create\n"
 msgstr "  現在 directory を domain root として登録する: %s domain create\n"
 
-#: src/cli.c:2409
+#: src/cli.c:2419
 #, c-format
 msgid ""
 "  recover a moved domain root: %s --dir /new/path domain move --from /old/"
@@ -1755,7 +1779,7 @@ msgstr ""
 "  移動した domain root を復旧する: %s --dir /new/path domain move --from /"
 "old/path\n"
 
-#: src/cli.c:2411
+#: src/cli.c:2421
 #, c-format
 msgid ""
 "  inspect inherited and blocked descendants: %s domain ls -l --descendants\n"
@@ -1763,7 +1787,7 @@ msgstr ""
 "  継承中および block 中の descendant を確認する: %s domain ls -l --"
 "descendants\n"
 
-#: src/cli.c:2418
+#: src/cli.c:2428
 #, c-format
 msgid ""
 "  see %s help usecases for workflow-oriented examples across multiple "
@@ -1772,13 +1796,13 @@ msgstr ""
 "  複数 command にまたがるワークフロー例は %s help usecases を参照してくださ"
 "い\n"
 
-#: src/cli.c:2428
+#: src/cli.c:2438
 #, c-format
 msgid "  bootstrap a new project domain: %s --dir ~/example/project unlock\n"
 msgstr ""
 "  新しい project domain を初期化する: %s --dir ~/example/project unlock\n"
 
-#: src/cli.c:2430
+#: src/cli.c:2440
 #, c-format
 msgid ""
 "  read one secret directly: %s --dir ~/example/project get API_TOKEN --"
@@ -1787,7 +1811,7 @@ msgstr ""
 "  1 つの secret を直接読む: %s --dir ~/example/project get API_TOKEN --"
 "stdout\n"
 
-#: src/cli.c:2432
+#: src/cli.c:2442
 #, c-format
 msgid ""
 "  load shell variables without exposing raw values in exported text: source "
@@ -1796,7 +1820,7 @@ msgstr ""
 "  export テキスト中に生の値を出さず shell 変数へ読み込む: source <(%s --dir "
 "~/example/project export)\n"
 
-#: src/cli.c:2434
+#: src/cli.c:2444
 #, c-format
 msgid ""
 "  inject secrets into one subprocess only: %s --dir ~/example/project exec --"
@@ -1805,7 +1829,7 @@ msgstr ""
 "  1 つの子プロセスにだけ secret を注入する: %s --dir ~/example/project exec "
 "--inject secret:rename='s/^MY_APP_\\(.*\\)$/APP_\\1/' CMD\n"
 
-#: src/cli.c:2436
+#: src/cli.c:2446
 #, c-format
 msgid ""
 "  block automation until a human unlocks the domain elsewhere: %s --dir ~/"
@@ -1814,7 +1838,7 @@ msgstr ""
 "  人が別の場所で domain を unlock するまで automation を待機させる: %s --dir "
 "~/example/project wait-unlock --timeout 900\n"
 
-#: src/cli.c:2438
+#: src/cli.c:2448
 #, c-format
 msgid ""
 "  inspect inheritance and local locks under one branch: %s --dir ~/example/"
@@ -1823,7 +1847,7 @@ msgstr ""
 "  1 つの branch 配下の継承と local lock を確認する: %s --dir ~/example/"
 "project domain ls -l --descendants\n"
 
-#: src/cli.c:2445
+#: src/cli.c:2455
 #, c-format
 msgid ""
 "\n"
@@ -1832,7 +1856,7 @@ msgstr ""
 "\n"
 "概念:\n"
 
-#: src/cli.c:2448
+#: src/cli.c:2458
 #, c-format
 msgid ""
 "  domain: a directory-scoped boundary for inheritance, sessions, and "
@@ -1841,7 +1865,7 @@ msgstr ""
 "  domain: 継承、session、tombstone のための directory 単位の境界です。--dir "
 "で解決し、%s domain status で確認できます\n"
 
-#: src/cli.c:2450
+#: src/cli.c:2460
 msgid ""
 "  store: a domain-local namespace selected by --store; use it to separate "
 "app, ops, or personal keys inside one domain\n"
@@ -1849,7 +1873,7 @@ msgstr ""
 "  store: --store で選ぶ domain ローカル namespace です。1 つの domain 内で "
 "app、ops、personal の key を分けるのに使います\n"
 
-#: src/cli.c:2451
+#: src/cli.c:2461
 msgid ""
 "  inheritance: reads fall back to parent domains until a local value, "
 "tombstone, or local lock changes the effective view\n"
@@ -1857,7 +1881,7 @@ msgstr ""
 "  inheritance: 読み取りは local の値、tombstone、local lock が有効 view を変"
 "えるまで親 domain へフォールバックします\n"
 
-#: src/cli.c:2452
+#: src/cli.c:2462
 msgid ""
 "  local lock: a local override that blocks reuse of an inherited unlock "
 "until the current domain unlocks or inherits again\n"
@@ -1865,7 +1889,7 @@ msgstr ""
 "  local lock: 現在 domain が再び unlock または inherit するまで、継承された "
 "unlock の再利用を止める local override です\n"
 
-#: src/cli.c:2453
+#: src/cli.c:2463
 #, c-format
 msgid ""
 "  local unlock: an authenticated master-key cache scoped to one domain "
@@ -1874,7 +1898,7 @@ msgstr ""
 "  local unlock: 1 つの domain branch に閉じた認証済み master-key cache で"
 "す。%s status で利用可否を見て、%s unlock で更新します\n"
 
-#: src/cli.c:2455
+#: src/cli.c:2465
 msgid ""
 "  KEYREF: [DOMAIN_PATH/]KEY[:STORE]; DOMAIN_PATH may be absolute or relative "
 "and selects only that exact registered domain\n"
@@ -1882,7 +1906,7 @@ msgstr ""
 "  KEYREF: [DOMAIN_PATH/]KEY[:STORE]。DOMAIN_PATH には絶対パスまたは相対パスを"
 "指定でき、その登録済み domain だけを選択します\n"
 
-#: src/cli.c:2456
+#: src/cli.c:2466
 msgid ""
 "  relative KEYREF domains use --domain, then --dir, then the current working "
 "directory as their base; unqualified keys keep inherited lookup\n"
@@ -1890,7 +1914,7 @@ msgstr ""
 "  KEYREF の相対 domain は --domain、--dir、現在の作業ディレクトリの順に基準を"
 "選びます。無修飾 key は継承 lookup を維持します\n"
 
-#: src/cli.c:2462
+#: src/cli.c:2472
 #, c-format
 msgid ""
 "\n"
@@ -1899,7 +1923,7 @@ msgstr ""
 "\n"
 "inject ルール:\n"
 
-#: src/cli.c:2465
+#: src/cli.c:2475
 msgid ""
 "  form: pass repeated --inject LAYER:KIND=SELECTOR rules to exec; use --"
 "inject-file FILE for a YAML policy\n"
@@ -1907,7 +1931,7 @@ msgstr ""
 "  形式: exec に --inject LAYER:KIND=SELECTOR ルールを繰り返し渡します。YAML "
 "ポリシーには --inject-file FILE を使います\n"
 
-#: src/cli.c:2466
+#: src/cli.c:2476
 msgid ""
 "  layers: ambient selects caller environment variables; secret selects store "
 "keys; route resolves ambient/secret name collisions; final validates the "
@@ -1917,7 +1941,7 @@ msgstr ""
 "す。route は ambient/secret の名前衝突を解決し、final は子プロセス環境を検証"
 "します\n"
 
-#: src/cli.c:2467
+#: src/cli.c:2477
 msgid ""
 "  kinds: only is a whitelist, omit excludes matches, require fails when a "
 "match is missing, reject fails when a match is available, rename maps secret "
@@ -1927,7 +1951,7 @@ msgstr ""
 "い場合の失敗、reject は一致対象がある場合の失敗、rename は secret key から環"
 "境変数名への変換、prefer は既定の衝突解決先を設定します\n"
 
-#: src/cli.c:2468
+#: src/cli.c:2478
 msgid ""
 "  selectors: exact names and shell-style globs are allowed; separate "
 "multiple selectors in one value with ':'\n"
@@ -1935,7 +1959,7 @@ msgstr ""
 "  選択子: 完全一致名と shell 形式の glob を使えます。1 つの値に複数の選択子を"
 "書く場合は ':' で区切ります\n"
 
-#: src/cli.c:2469
+#: src/cli.c:2479
 msgid ""
 "  route picks: route:prefer=secret, route:prefer=ambient, route:"
 "prefer=error, or route:GLOB=secret|ambient|error\n"
@@ -1943,7 +1967,7 @@ msgstr ""
 "  route の選択先: route:prefer=secret、route:prefer=ambient、route:"
 "prefer=error、または route:GLOB=secret|ambient|error\n"
 
-#: src/cli.c:2470
+#: src/cli.c:2480
 msgid ""
 "  rename: secret:rename=EXPR uses one sed-style s/// expression; generated "
 "environment names must be valid identifiers\n"
@@ -1951,7 +1975,7 @@ msgstr ""
 "  rename: secret:rename=EXPR は sed 形式の s/// 式を 1 つ使います。生成される"
 "環境変数名は有効な識別子である必要があります\n"
 
-#: src/cli.c:2471
+#: src/cli.c:2481
 msgid ""
 "  files: --inject-file accepts a small YAML subset: bulk_gate, "
 "profile_required, profiles, supply, route, demand, scalar values, inline "
@@ -1961,7 +1985,7 @@ msgstr ""
 "profile_required、profiles、supply、route、demand、scalar 値、inline array、"
 "block list\n"
 
-#: src/cli.c:2472
+#: src/cli.c:2482
 msgid ""
 "  profiles: profiles.NAME.match.command matches CMD path or basename; match."
 "argv_prefix matches CMD arguments from the start\n"
@@ -1969,7 +1993,7 @@ msgstr ""
 "  profiles: profiles.NAME.match.command は CMD path または basename に一致し"
 "ます。match.argv_prefix は CMD 引数の先頭に一致します\n"
 
-#: src/cli.c:2473
+#: src/cli.c:2483
 msgid ""
 "  profile safety: profile_required: true fails when no profile matches, and "
 "multiple matching profiles fail closed\n"
@@ -1977,7 +2001,7 @@ msgstr ""
 "  profile 安全性: profile_required: true は profile 未一致で失敗します。複数 "
 "profile 一致も fail closed します\n"
 
-#: src/cli.c:2474
+#: src/cli.c:2484
 msgid ""
 "  file limits: unsupported YAML syntax fails closed; use block lists for "
 "large selector sets instead of long inline arrays\n"
@@ -1985,7 +2009,7 @@ msgstr ""
 "  ファイル制約: 未対応の YAML 構文は fail closed します。大きな selector set "
 "には長い inline array ではなく block list を使ってください\n"
 
-#: src/cli.c:2475
+#: src/cli.c:2485
 msgid ""
 "  gate: --bulk-gate applies the key bulk_select pre-filter before secret "
 "supply; list and export can also use --bulk-gate but do not inject into a "
@@ -1995,7 +2019,7 @@ msgstr ""
 "を適用します。list と export でも --bulk-gate を使えますが、子プロセスへの注"
 "入は行いません\n"
 
-#: src/cli.c:2476
+#: src/cli.c:2486
 msgid ""
 "  ptyterm handoff: secdat can be an optional stdin secret provider for "
 "ptyterm; neither tool requires the other\n"
@@ -2003,14 +2027,14 @@ msgstr ""
 "  ptyterm 受け渡し: secdat は ptyterm 向けの任意の stdin secret provider にな"
 "れます。どちらの tool も相手を必須とはしません\n"
 
-#: src/cli.c:2477
+#: src/cli.c:2487
 #, c-format
 msgid ""
 "  preflight: %s exec --inject secret:only=APP_* --dry-run --json -- CMD\n"
 msgstr ""
 "  事前検証: %s exec --inject secret:only=APP_* --dry-run --json -- CMD\n"
 
-#: src/cli.c:2479
+#: src/cli.c:2489
 #, c-format
 msgid ""
 "  example: %s exec --inject ambient:omit=SECDAT_* --inject secret:only=APP_* "
@@ -2019,7 +2043,7 @@ msgstr ""
 "  例: %s exec --inject ambient:omit=SECDAT_* --inject secret:only=APP_* --"
 "inject route:prefer=secret --inject final:reject=SECDAT_* -- CMD\n"
 
-#: src/cli.c:2481
+#: src/cli.c:2491
 #, c-format
 msgid ""
 "  terminal handoff: %s get ROUTER_PASSWORD --stdout | ptyterm --session=1 --"
@@ -2028,7 +2052,7 @@ msgstr ""
 "  terminal 受け渡し: %s get ROUTER_PASSWORD --stdout | ptyterm --session=1 --"
 "send-stdin --send-eol=cr --redact-sent\n"
 
-#: src/cli.c:2488
+#: src/cli.c:2498
 #, c-format
 msgid ""
 "\n"
@@ -2037,7 +2061,7 @@ msgstr ""
 "\n"
 "セマンティクス:\n"
 
-#: src/cli.c:2489
+#: src/cli.c:2499
 msgid ""
 "  DIR: base directory used for domain resolution; defaults to the current "
 "working directory\n"
@@ -2045,13 +2069,13 @@ msgstr ""
 "  DIR: domain 解決の基準ディレクトリです。省略時は現在の作業ディレクトリを使"
 "います\n"
 
-#: src/cli.c:2490
+#: src/cli.c:2500
 msgid ""
 "  DOMAIN: directory-scoped configuration boundary used for inheritance and "
 "tombstones\n"
 msgstr "  DOMAIN: 継承と tombstone に使う、ディレクトリ単位の設定境界です\n"
 
-#: src/cli.c:2491
+#: src/cli.c:2501
 msgid ""
 "  STORE: domain-local namespace selected by --store; defaults to the default "
 "store\n"
@@ -2059,7 +2083,7 @@ msgstr ""
 "  STORE: --store で選ぶ domain ローカルな名前空間です。省略時は default "
 "store を使います\n"
 
-#: src/cli.c:2492
+#: src/cli.c:2502
 msgid ""
 "  KEY / KEYREF: logical secret name, optionally qualified as "
 "[DOMAIN_PATH/]KEY[:STORE]; qualified lookup is exact-local\n"
@@ -2067,7 +2091,7 @@ msgstr ""
 "  KEY / KEYREF: 論理的な secret 名です。必要なら [DOMAIN_PATH/]KEY[:STORE] で"
 "修飾できます。修飾された lookup は exact-local です\n"
 
-#: src/cli.c:2493
+#: src/cli.c:2503
 msgid ""
 "  migration hints: v2-only errors suggest store migrate; set "
 "SECDAT_SUPPRESS_MIGRATION_HINTS=1 to hide those hints\n"
@@ -2075,42 +2099,42 @@ msgstr ""
 "  migration hint: v2 専用エラーでは store migrate を提案します。非表示にする"
 "には SECDAT_SUPPRESS_MIGRATION_HINTS=1 を設定します\n"
 
-#: src/cli.c:2521
+#: src/cli.c:2531
 #, c-format
 msgid "unknown store subcommand: %s\n"
 msgstr "不明な store サブコマンドです: %s\n"
 
-#: src/cli.c:2523
+#: src/cli.c:2533
 #, c-format
 msgid "unknown meta subcommand: %s\n"
 msgstr "不明な meta サブコマンドです: %s\n"
 
-#: src/cli.c:2525
+#: src/cli.c:2535
 #, c-format
 msgid "unknown relation subcommand: %s\n"
 msgstr "不明な relation サブコマンドです: %s\n"
 
-#: src/cli.c:2527
+#: src/cli.c:2537
 #, c-format
 msgid "unknown secret subcommand: %s\n"
 msgstr "不明な secret サブコマンドです: %s\n"
 
-#: src/cli.c:2529
+#: src/cli.c:2539
 #, c-format
 msgid "unknown domain subcommand: %s\n"
 msgstr "不明な domain サブコマンドです: %s\n"
 
-#: src/cli.c:2674 src/cli.c:2690 src/cli.c:2722 src/cli.c:2744
+#: src/cli.c:2684 src/cli.c:2700 src/cli.c:2732 src/cli.c:2754
 #, c-format
 msgid "Usage:\n"
 msgstr "使い方:\n"
 
-#: src/cli.c:2700
+#: src/cli.c:2710
 #, c-format
 msgid "\n"
 msgstr "\n"
 
-#: src/cli.c:2701
+#: src/cli.c:2711
 msgid ""
 "  KEYREF syntax: [DOMAIN_PATH/]KEY[:STORE] (absolute or relative; qualified "
 "lookup is exact-local)\n"
@@ -2118,12 +2142,12 @@ msgstr ""
 "  KEYREF 構文: [DOMAIN_PATH/]KEY[:STORE]（絶対または相対。修飾された lookup "
 "は exact-local）\n"
 
-#: src/cli.c:2777
+#: src/cli.c:2787
 #, c-format
 msgid "Try: %s help %s\n"
 msgstr "試してください: %s help %s\n"
 
-#: src/cli.c:2781
+#: src/cli.c:2791
 #, c-format
 msgid "Try: %s help\n"
 msgstr "試してください: %s help\n"
@@ -2143,38 +2167,38 @@ msgstr "試してください: %s help\n"
 #: src/exec_inject_policy_file.c:60 src/exec_inject_policy_file.c:103
 #: src/exec_inject_policy_file.c:128 src/exec_inject_policy_file.c:202
 #: src/exec_inject_policy_file.c:245 src/exec_inject_policy_file.c:283
-#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1528
-#: src/store.c:1544 src/store.c:1685 src/store.c:1720 src/store.c:1769
-#: src/store.c:1884 src/store.c:1893 src/store.c:1910 src/store.c:1919
-#: src/store.c:1933 src/store.c:1939 src/store.c:4525 src/store.c:4571
-#: src/store.c:4598 src/store.c:4644 src/store.c:4679 src/store.c:5098
-#: src/store.c:5555 src/store.c:5595 src/store.c:9646 src/store.c:10244
-#: src/store.c:10348 src/store.c:10398 src/store.c:10482 src/store.c:10490
-#: src/store.c:11020 src/store.c:11332 src/store.c:11441 src/store.c:11502
-#: src/store.c:11760 src/store.c:11869 src/store.c:11910 src/store.c:11983
-#: src/store.c:13198 src/store.c:13320 src/store.c:13341 src/store.c:13423
-#: src/store.c:13535 src/store.c:13703 src/store.c:13758 src/store.c:15101
-#: src/store.c:15578 src/store.c:15722 src/store.c:16119 src/store.c:16441
-#: src/store.c:16875 src/store.c:17114 src/store.c:17152 src/store.c:17466
-#: src/store.c:17572 src/store.c:17650 src/store.c:17664 src/store.c:17673
-#: src/store.c:17730 src/store.c:17743 src/store.c:17752 src/store.c:17873
-#: src/store.c:18009 src/store.c:18049 src/store.c:18060 src/store.c:18094
-#: src/store.c:18225 src/store.c:19129 src/store.c:19928 src/store.c:21113
-#: src/store.c:21139 src/store.c:21393 src/store.c:21443 src/store.c:21469
-#: src/store.c:21838 src/store.c:22242 src/store.c:22367 src/store.c:22396
-#: src/store.c:22447 src/store.c:22742 src/store.c:23320 src/store.c:23807
-#: src/store.c:24426 src/store.c:24960 src/store.c:25560 src/store.c:25597
-#: src/store.c:25846 src/store.c:25888 src/store.c:25995 src/store.c:26026
-#: src/store.c:29401 src/store.c:29436 src/store.c:29584 src/store.c:29783
-#: src/store.c:30829 src/store.c:30961 src/store.c:31577 src/store.c:36331
-#: src/store.c:36336 src/store.c:36673 src/store.c:36733 src/store.c:36739
-#: src/store.c:36814 src/store.c:36827 src/store.c:37875 src/store.c:37956
-#: src/store.c:38055 src/store.c:38093 src/store.c:39938 src/store.c:40026
-#: src/store.c:40076 src/store.c:41338 src/store.c:41499 src/store.c:43440
-#: src/store.c:44996 src/store.c:45171 src/store.c:45413 src/store.c:45438
-#: src/store.c:45462 src/store.c:45542 src/store.c:45593 src/store.c:45642
-#: src/store.c:45682 src/store.c:45976 src/store.c:46201 src/store.c:47368
-#: src/store.c:47376
+#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1571
+#: src/store.c:1587 src/store.c:1728 src/store.c:1763 src/store.c:1812
+#: src/store.c:1927 src/store.c:1936 src/store.c:1953 src/store.c:1962
+#: src/store.c:1976 src/store.c:1982 src/store.c:4568 src/store.c:4614
+#: src/store.c:4641 src/store.c:4687 src/store.c:4722 src/store.c:5141
+#: src/store.c:5598 src/store.c:5638 src/store.c:9689 src/store.c:10287
+#: src/store.c:10391 src/store.c:10441 src/store.c:10525 src/store.c:10533
+#: src/store.c:11063 src/store.c:11375 src/store.c:11484 src/store.c:11545
+#: src/store.c:11803 src/store.c:11912 src/store.c:11953 src/store.c:12026
+#: src/store.c:13241 src/store.c:13363 src/store.c:13384 src/store.c:13466
+#: src/store.c:13578 src/store.c:13746 src/store.c:13801 src/store.c:15144
+#: src/store.c:15621 src/store.c:15765 src/store.c:16162 src/store.c:16484
+#: src/store.c:16918 src/store.c:17157 src/store.c:17195 src/store.c:17509
+#: src/store.c:17615 src/store.c:17693 src/store.c:17707 src/store.c:17716
+#: src/store.c:17773 src/store.c:17786 src/store.c:17795 src/store.c:17916
+#: src/store.c:18052 src/store.c:18092 src/store.c:18103 src/store.c:18137
+#: src/store.c:18268 src/store.c:19172 src/store.c:19971 src/store.c:21156
+#: src/store.c:21182 src/store.c:21436 src/store.c:21486 src/store.c:21512
+#: src/store.c:21881 src/store.c:22285 src/store.c:22410 src/store.c:22439
+#: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
+#: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
+#: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
+#: src/store.c:29444 src/store.c:29479 src/store.c:29627 src/store.c:29826
+#: src/store.c:30872 src/store.c:31004 src/store.c:31620 src/store.c:36374
+#: src/store.c:36379 src/store.c:36716 src/store.c:36776 src/store.c:36782
+#: src/store.c:36857 src/store.c:36870 src/store.c:37918 src/store.c:37999
+#: src/store.c:38098 src/store.c:38136 src/store.c:39981 src/store.c:40069
+#: src/store.c:40119 src/store.c:41381 src/store.c:41542 src/store.c:41749
+#: src/store.c:43959 src/store.c:45515 src/store.c:45690 src/store.c:45932
+#: src/store.c:45957 src/store.c:45981 src/store.c:46061 src/store.c:46112
+#: src/store.c:46161 src/store.c:46201 src/store.c:46495 src/store.c:46803
+#: src/store.c:48101 src/store.c:48109
 #, c-format
 msgid "out of memory\n"
 msgstr "メモリ不足です\n"
@@ -2185,18 +2209,18 @@ msgstr "メモリ不足です\n"
 #: src/domain.c:955 src/domain.c:990 src/domain.c:1002 src/domain.c:1006
 #: src/domain.c:1101 src/domain.c:1234 src/domain.c:1356 src/domain.c:1364
 #: src/domain.c:1451 src/domain.c:1513 src/domain.c:1590 src/secdat-fuse.c:186
-#: src/store.c:1960 src/store.c:1978 src/store.c:3449 src/store.c:3456
-#: src/store.c:3474 src/store.c:4423 src/store.c:4693 src/store.c:4797
-#: src/store.c:4824 src/store.c:4851 src/store.c:5277 src/store.c:5475
-#: src/store.c:5645 src/store.c:5668 src/store.c:5684 src/store.c:6366
-#: src/store.c:7806 src/store.c:8311 src/store.c:8335 src/store.c:10187
-#: src/store.c:10513 src/store.c:14258 src/store.c:14268 src/store.c:14286
-#: src/store.c:14321 src/store.c:14374 src/store.c:15827 src/store.c:17814
-#: src/store.c:17833 src/store.c:18723 src/store.c:18737 src/store.c:18751
-#: src/store.c:19177 src/store.c:19538 src/store.c:30789 src/store.c:30911
-#: src/store.c:31216 src/store.c:33929 src/store.c:34136 src/store.c:34175
-#: src/store.c:34236 src/store.c:34461 src/store.c:34529 src/store.c:38768
-#: src/store.c:39682 src/store.c:40601
+#: src/store.c:2003 src/store.c:2021 src/store.c:3492 src/store.c:3499
+#: src/store.c:3517 src/store.c:4466 src/store.c:4736 src/store.c:4840
+#: src/store.c:4867 src/store.c:4894 src/store.c:5320 src/store.c:5518
+#: src/store.c:5688 src/store.c:5711 src/store.c:5727 src/store.c:6409
+#: src/store.c:7849 src/store.c:8354 src/store.c:8378 src/store.c:10230
+#: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
+#: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
+#: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
+#: src/store.c:19220 src/store.c:19581 src/store.c:30832 src/store.c:30954
+#: src/store.c:31259 src/store.c:33972 src/store.c:34179 src/store.c:34218
+#: src/store.c:34279 src/store.c:34504 src/store.c:34572 src/store.c:38811
+#: src/store.c:39725 src/store.c:40644
 #, c-format
 msgid "path is too long\n"
 msgstr "パスが長すぎます\n"
@@ -2217,17 +2241,17 @@ msgstr "local-unlock"
 msgid "local-lock"
 msgstr "local-lock"
 
-#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12667
+#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12710
 msgid "locked"
 msgstr "ロック中"
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12633 src/store.c:12651
-#: src/store.c:12668
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
+#: src/store.c:12711
 msgid "wrapped master key: present"
 msgstr "ラップ済み master key: あり"
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12633 src/store.c:12651
-#: src/store.c:12668
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
+#: src/store.c:12711
 msgid "wrapped master key: absent"
 msgstr "ラップ済み master key: なし"
 
@@ -2239,7 +2263,7 @@ msgstr "orphaned"
 msgid "session"
 msgstr "session"
 
-#: src/domain.c:383 src/store.c:12631 src/store.c:12641
+#: src/domain.c:383 src/store.c:12674 src/store.c:12684
 msgid "unlocked"
 msgstr "アンロック済み"
 
@@ -2275,18 +2299,18 @@ msgstr "WRAPPED"
 msgid "DOMAIN"
 msgstr "DOMAIN"
 
-#: src/domain.c:639 src/store.c:5663
+#: src/domain.c:639 src/store.c:5706
 #, c-format
 msgid "HOME is not set\n"
 msgstr "HOME が設定されていません\n"
 
-#: src/domain.c:795 src/store.c:5548 src/store.c:5569
+#: src/domain.c:795 src/store.c:5591 src/store.c:5612
 #, c-format
 msgid "failed to open file: %s\n"
 msgstr "ファイルのオープンに失敗しました: %s\n"
 
-#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5602
-#: src/store.c:19946
+#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5645
+#: src/store.c:19989
 #, c-format
 msgid "failed to read file: %s\n"
 msgstr "ファイルの読み取りに失敗しました: %s\n"
@@ -2302,13 +2326,13 @@ msgid "domain root identity mismatch for: %s\n"
 msgstr "domain root identity が一致しません: %s\n"
 
 #: src/domain.c:911 src/domain.c:995 src/domain.c:1447 src/secdat-fuse.c:182
-#: src/store.c:1973
+#: src/store.c:2016
 #, c-format
 msgid "failed to resolve directory: %s\n"
 msgstr "ディレクトリの解決に失敗しました: %s\n"
 
-#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5254
-#: src/store.c:5301
+#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5297
+#: src/store.c:5344
 #, c-format
 msgid "not a directory: %s\n"
 msgstr "ディレクトリではありません: %s\n"
@@ -2328,7 +2352,7 @@ msgstr "domain が見つかりません: %s\n"
 msgid "failed to generate domain id\n"
 msgstr "domain id の生成に失敗しました\n"
 
-#: src/domain.c:1268 src/store.c:4731 src/store.c:13806 src/store.c:43388
+#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43907
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr "ディレクトリのオープンに失敗しました: %s\n"
@@ -2381,8 +2405,8 @@ msgstr "DOMAIN\tKEY_SOURCE\tEFFECTIVE\tREMAINING\tSTATE_SOURCE\tSTORES\tVISIBLE\
 msgid "invalid arguments for domain status\n"
 msgstr "domain status の引数が不正です\n"
 
-#: src/domain.c:2288 src/store.c:2223 src/store.c:2229 src/store.c:9994
-#: src/store.c:12752
+#: src/domain.c:2288 src/store.c:2266 src/store.c:2272 src/store.c:10037
+#: src/store.c:12795
 #, c-format
 msgid "resolved domain: %s\n"
 msgstr "解決された domain: %s\n"
@@ -2456,7 +2480,7 @@ msgstr "有効な取得元: inherited lock"
 msgid "effective source: locked"
 msgstr "実効取得元: locked"
 
-#: src/domain.c:2355 src/store.c:45862
+#: src/domain.c:2355 src/store.c:46381
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr "コマンドは未実装です: %s\n"
@@ -2524,7 +2548,7 @@ msgstr "不正な secret rename 式です\n"
 msgid "invalid secret rename regex: %s\n"
 msgstr "不正な secret rename 正規表現です: %s\n"
 
-#: src/exec_inject.c:834 src/store.c:3498 src/store.c:45109 src/store.c:45179
+#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45628 src/store.c:45698
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr "key は有効な環境変数名ではありません: %s\n"
@@ -2895,38 +2919,38 @@ msgstr "secdat-fuse mountpoint の unmount に失敗しました: %s\n"
 msgid "failed to create pipe\n"
 msgstr "pipe の作成に失敗しました\n"
 
-#: src/store.c:1587
+#: src/store.c:1630
 #, c-format
 msgid ""
 "deferred GC remains queued because the owner agent could not be upgraded\n"
 msgstr ""
 
-#: src/store.c:1596
+#: src/store.c:1639
 #, c-format
 msgid "deferred GC remains queued because the owner agent lacks GC_WORKER_V1\n"
 msgstr ""
 
-#: src/store.c:2018
+#: src/store.c:2061
 #, c-format
 msgid "writes to the default domain are not supported\n"
 msgstr "default domain への書き込みはサポートされていません\n"
 
-#: src/store.c:2095 src/store.c:5446
+#: src/store.c:2138 src/store.c:5489
 #, c-format
 msgid "failed to remove file: %s\n"
 msgstr "ファイルの削除に失敗しました: %s\n"
 
-#: src/store.c:2155
+#: src/store.c:2198
 #, c-format
 msgid "note: %zu descendant domains can now reuse this session\n"
 msgstr "補足: %zu 個の descendant domain がこの session を再利用できます\n"
 
-#: src/store.c:2158 src/store.c:2195
+#: src/store.c:2201 src/store.c:2238
 #, c-format
 msgid "note: %zu orphaned descendant domains are not affected by unlock\n"
 msgstr "補足: %zu 個の orphaned descendant domain は unlock の対象外です\n"
 
-#: src/store.c:2160 src/store.c:2197
+#: src/store.c:2203 src/store.c:2240
 #, c-format
 msgid ""
 "recover or delete orphaned descendant: secdat domain move --from %s --to "
@@ -2935,68 +2959,68 @@ msgstr ""
 "orphaned descendant を復旧または削除: secdat domain move --from %s --to "
 "NEW_ROOT\n"
 
-#: src/store.c:2161 src/store.c:2198
+#: src/store.c:2204 src/store.c:2241
 #, c-format
 msgid "discard orphaned descendant: secdat --dir %s domain delete\n"
 msgstr "orphaned descendant を破棄: secdat --dir %s domain delete\n"
 
-#: src/store.c:2168
+#: src/store.c:2211
 #, c-format
 msgid "note: %zu descendant domains remain locked under this branch\n"
 msgstr ""
 "補足: この branch 配下では %zu 個の descendant domain がまだ locked のままで"
 "す\n"
 
-#: src/store.c:2169
+#: src/store.c:2212
 msgid "affected descendants:"
 msgstr "影響を受ける descendant:"
 
-#: src/store.c:2188
+#: src/store.c:2231
 #, c-format
 msgid "  %s\n"
 msgstr "  %s\n"
 
-#: src/store.c:2192
+#: src/store.c:2235
 #, c-format
 msgid "  ... and %zu more\n"
 msgstr "  ... さらに %zu 個\n"
 
-#: src/store.c:2202
+#: src/store.c:2245
 #, c-format
 msgid "inspect descendants: secdat --dir %s domain ls -l --descendants\n"
 msgstr "descendant を確認: secdat --dir %s domain ls -l --descendants\n"
 
-#: src/store.c:2204
+#: src/store.c:2247
 #, c-format
 msgid "inspect one descendant: secdat --dir %s domain status\n"
 msgstr "1 つの descendant を確認: secdat --dir %s domain status\n"
 
-#: src/store.c:2205
+#: src/store.c:2248
 #, c-format
 msgid "unlock one descendant: secdat --dir %s unlock\n"
 msgstr "1 つの descendant を unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2224
+#: src/store.c:2267
 #, c-format
 msgid "inspect current domain: secdat domain status\n"
 msgstr "現在の domain を確認: secdat domain status\n"
 
-#: src/store.c:2225
+#: src/store.c:2268
 #, c-format
 msgid "unlock current domain: secdat unlock\n"
 msgstr "現在の domain を unlock: secdat unlock\n"
 
-#: src/store.c:2230
+#: src/store.c:2273
 #, c-format
 msgid "inspect current domain: secdat --dir %s domain status\n"
 msgstr "現在の domain を確認: secdat --dir %s domain status\n"
 
-#: src/store.c:2231
+#: src/store.c:2274
 #, c-format
 msgid "unlock current domain: secdat --dir %s unlock\n"
 msgstr "現在の domain を unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2327
+#: src/store.c:2370
 #, c-format
 msgid ""
 "Hint: inspect migration first with `%s store migrate %s --to-format v2 --dry-"
@@ -3005,90 +3029,90 @@ msgstr ""
 "ヒント: 先に `%s store migrate %s --to-format v2 --dry-run` で migration を確"
 "認してください\n"
 
-#: src/store.c:2328
+#: src/store.c:2371
 #, c-format
 msgid "Hint: suppress migration hints with %s=1\n"
 msgstr "ヒント: migration hint を抑制するには %s=1 を設定してください\n"
 
-#: src/store.c:2359
+#: src/store.c:2402
 #, c-format
 msgid "invalid value for --unlock-timeout: %s\n"
 msgstr "--unlock-timeout の値が不正です: %s\n"
 
-#: src/store.c:2807
+#: src/store.c:2850
 #, c-format
 msgid "missing value for --unlock-timeout\n"
 msgstr "--unlock-timeout に値が必要です\n"
 
-#: src/store.c:2812 src/store.c:2821 src/store.c:2833
+#: src/store.c:2855 src/store.c:2864 src/store.c:2876
 #, c-format
 msgid "invalid arguments for get\n"
 msgstr "get の引数が不正です\n"
 
-#: src/store.c:2842
+#: src/store.c:2885
 #, c-format
 msgid "missing key for get\n"
 msgstr "get のキーが不足しています\n"
 
-#: src/store.c:2847
+#: src/store.c:2890
 #, c-format
 msgid "--unlock-timeout requires --on-demand-unlock or %s\n"
 msgstr "--unlock-timeout を使うには --on-demand-unlock または %s が必要です\n"
 
-#: src/store.c:2876
+#: src/store.c:2919
 #, c-format
 msgid "invalid value for --timeout: %s\n"
 msgstr "--timeout の値が不正です: %s\n"
 
-#: src/store.c:2883
+#: src/store.c:2926
 #, c-format
 msgid "missing value for --timeout\n"
 msgstr "--timeout に値が必要です\n"
 
-#: src/store.c:2892 src/store.c:2899 src/store.c:12681
+#: src/store.c:2935 src/store.c:2942 src/store.c:12724
 #, c-format
 msgid "invalid arguments for wait-unlock\n"
 msgstr "wait-unlock の引数が不正です\n"
 
-#: src/store.c:2921
+#: src/store.c:2964
 #, c-format
 msgid ""
 "waiting for another terminal to unlock secrets for resolved domain: %s\n"
 msgstr ""
 "別端末で secrets が unlock されるのを待機しています。解決済み domain: %s\n"
 
-#: src/store.c:2923 src/store.c:2986
+#: src/store.c:2966 src/store.c:3029
 #, c-format
 msgid "unlock from another terminal: secdat unlock\n"
 msgstr "別端末で unlock: secdat unlock\n"
 
-#: src/store.c:2925 src/store.c:2988
+#: src/store.c:2968 src/store.c:3031
 #, c-format
 msgid "unlock from another terminal: secdat --dir %s unlock\n"
 msgstr "別端末で unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2928
+#: src/store.c:2971
 #, c-format
 msgid "unlock wait timeout: %lld seconds\n"
 msgstr "unlock 待機タイムアウト: %lld 秒\n"
 
-#: src/store.c:2959
+#: src/store.c:3002
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock secrets after %lld seconds\n"
 msgstr "別端末での secrets の unlock 待機が %lld 秒でタイムアウトしました\n"
 
-#: src/store.c:2984
+#: src/store.c:3027
 #, c-format
 msgid "waiting for another terminal to unlock resolved domain: %s\n"
 msgstr "別端末で解決済み domain が unlock されるのを待機しています: %s\n"
 
-#: src/store.c:2991
+#: src/store.c:3034
 #, c-format
 msgid "wait-unlock timeout: %lld seconds\n"
 msgstr "wait-unlock タイムアウト: %lld 秒\n"
 
-#: src/store.c:3019
+#: src/store.c:3062
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock resolved domain after %lld "
@@ -3096,38 +3120,38 @@ msgid ""
 msgstr ""
 "別端末での解決済み domain の unlock 待機が %lld 秒でタイムアウトしました\n"
 
-#: src/store.c:3091 src/store.c:3103 src/store.c:3110 src/store.c:3122
-#: src/store.c:3127 src/store.c:3132 src/store.c:12737
+#: src/store.c:3134 src/store.c:3146 src/store.c:3153 src/store.c:3165
+#: src/store.c:3170 src/store.c:3175 src/store.c:12780
 #, c-format
 msgid "invalid arguments for unlock\n"
 msgstr "unlock の引数が不正です\n"
 
-#: src/store.c:3116
+#: src/store.c:3159
 #, c-format
 msgid "--duration and --until cannot be combined\n"
 msgstr "--duration と --until は同時に指定できません\n"
 
-#: src/store.c:3138
+#: src/store.c:3181
 #, c-format
 msgid "invalid value for --duration: %s\n"
 msgstr "--duration の値が不正です: %s\n"
 
-#: src/store.c:3143
+#: src/store.c:3186
 #, c-format
 msgid "invalid value for --until: %s\n"
 msgstr "--until の値が不正です: %s\n"
 
-#: src/store.c:3168 src/store.c:3177 src/store.c:3184 src/store.c:13118
+#: src/store.c:3211 src/store.c:3220 src/store.c:3227 src/store.c:13161
 #, c-format
 msgid "invalid arguments for passwd\n"
 msgstr "passwd の引数が不正です\n"
 
-#: src/store.c:3218 src/store.c:3225 src/store.c:3231 src/store.c:13000
+#: src/store.c:3261 src/store.c:3268 src/store.c:3274 src/store.c:13043
 #, c-format
 msgid "invalid arguments for lock\n"
 msgstr "lock の引数が不正です\n"
 
-#: src/store.c:3250
+#: src/store.c:3293
 #, c-format
 msgid ""
 "cannot unlock descendant domains because an orphaned registered domain is in "
@@ -3136,17 +3160,17 @@ msgstr ""
 "この subtree に orphaned registered domain があるため descendant domain を "
 "unlock できません: %s\n"
 
-#: src/store.c:3251
+#: src/store.c:3294
 #, c-format
 msgid "recover it with: secdat domain move --from %s --to NEW_ROOT\n"
 msgstr "復旧する場合: secdat domain move --from %s --to NEW_ROOT\n"
 
-#: src/store.c:3252
+#: src/store.c:3295
 #, c-format
 msgid "or discard it with: secdat --dir %s domain delete\n"
 msgstr "破棄する場合: secdat --dir %s domain delete\n"
 
-#: src/store.c:3312
+#: src/store.c:3355
 #, c-format
 msgid ""
 "unlock --descendants requires confirmation on a terminal or rerun with --"
@@ -3155,24 +3179,24 @@ msgstr ""
 "unlock --descendants には端末での確認が必要です。非対話では --yes を付けて再"
 "実行してください\n"
 
-#: src/store.c:3319
+#: src/store.c:3362
 #, c-format
 msgid "failed to read confirmation\n"
 msgstr "確認入力の読み取りに失敗しました\n"
 
-#: src/store.c:3339
+#: src/store.c:3382
 msgid ""
 "unlock descendant domains in this subtree? local locks will remain [y/N]: "
 msgstr ""
 "この subtree の descendant domain を unlock しますか? local lock は残ります "
 "[y/N]: "
 
-#: src/store.c:3349
+#: src/store.c:3392
 #, c-format
 msgid "descendant unlock cancelled\n"
 msgstr "descendant unlock を中止しました\n"
 
-#: src/store.c:3382
+#: src/store.c:3425
 #, c-format
 msgid ""
 "note: unlocked %zu descendant domains in this subtree; local locks remain\n"
@@ -3180,22 +3204,22 @@ msgstr ""
 "注: この subtree で %zu 個の descendant domain を unlock しました。local "
 "lock は残ります\n"
 
-#: src/store.c:3408
+#: src/store.c:3451
 #, fuzzy, c-format
 msgid "invalid key reference\n"
 msgstr "不正なキー参照です: %s\n"
 
-#: src/store.c:3417 src/store.c:3443 src/store.c:3488
+#: src/store.c:3460 src/store.c:3486 src/store.c:3531
 #, c-format
 msgid "invalid key reference: %s\n"
 msgstr "不正なキー参照です: %s\n"
 
-#: src/store.c:3564
+#: src/store.c:3607
 #, c-format
 msgid "%s is no longer supported; use %s\n"
 msgstr "%s はサポートされなくなりました。%s を使ってください\n"
 
-#: src/store.c:3571
+#: src/store.c:3614
 #, c-format
 msgid ""
 "--inject is not valid for %s; use --bulk-select to set bulk_select policy "
@@ -3204,206 +3228,206 @@ msgstr ""
 "%s では --inject は使えません。bulk_select policy には --bulk-select を使って"
 "ください (exec の supply ルールには exec で --inject を使います)\n"
 
-#: src/store.c:3651
+#: src/store.c:3694
 #, c-format
 msgid "invalid arguments for ls\n"
 msgstr "ls の引数が不正です\n"
 
-#: src/store.c:3691 src/store.c:3706 src/store.c:3716
+#: src/store.c:3734 src/store.c:3749 src/store.c:3759
 #, c-format
 msgid "invalid arguments for export\n"
 msgstr "export の引数が不正です\n"
 
-#: src/store.c:3789 src/store.c:3796 src/store.c:3802 src/store.c:3808
-#: src/store.c:3814
+#: src/store.c:3832 src/store.c:3839 src/store.c:3845 src/store.c:3851
+#: src/store.c:3857
 #, c-format
 msgid "invalid arguments for list\n"
 msgstr "list の引数が不正です\n"
 
-#: src/store.c:3821
+#: src/store.c:3864
 #, c-format
 msgid "missing state filter for list\n"
 msgstr "list に state filter が必要です\n"
 
-#: src/store.c:3878 src/store.c:3892
+#: src/store.c:3921 src/store.c:3935
 #, c-format
 msgid "invalid arguments for attr\n"
 msgstr "attr の引数が不正です\n"
 
-#: src/store.c:3885
+#: src/store.c:3928
 #, c-format
 msgid "missing key for attr\n"
 msgstr "attr のキーが不足しています\n"
 
-#: src/store.c:3933
+#: src/store.c:3976
 #, c-format
 msgid "invalid fsck format: %s\n"
 msgstr "fsck format が不正です: %s\n"
 
-#: src/store.c:3947 src/store.c:3954
+#: src/store.c:3990 src/store.c:3997
 #, c-format
 msgid "invalid arguments for fsck\n"
 msgstr "fsck の引数が不正です\n"
 
-#: src/store.c:3966
+#: src/store.c:4009
 #, c-format
 msgid "fsck --repair is only supported with --format v2\n"
 msgstr "fsck --repair は --format v2 でのみサポートされています\n"
 
-#: src/store.c:3970
+#: src/store.c:4013
 #, c-format
 msgid "fsck --repair currently requires --refcount\n"
 msgstr "fsck --repair には現在 --refcount が必要です\n"
 
-#: src/store.c:3975
+#: src/store.c:4018
 #, c-format
 msgid "fsck --dependency-index requires --format v2\n"
 msgstr "fsck --dependency-index には --format v2 が必要です\n"
 
-#: src/store.c:3980
+#: src/store.c:4023
 #, c-format
 msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4005
+#: src/store.c:4048
 #, c-format
 msgid "invalid gc format: %s\n"
 msgstr "gc format が不正です: %s\n"
 
-#: src/store.c:4060
+#: src/store.c:4103
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --errors requires --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4064
+#: src/store.c:4107
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --json requires --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4075
+#: src/store.c:4118
 #, fuzzy, c-format
 #| msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgid "gc --status cannot be combined with mutation selectors\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4087
+#: src/store.c:4130
 #, fuzzy, c-format
 #| msgid "invalid arguments for domain ls\n"
 msgid "invalid GC owner domain ID\n"
 msgstr "domain ls の引数が不正です\n"
 
-#: src/store.c:4095
+#: src/store.c:4138
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --owner requires --queued or --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4100
+#: src/store.c:4143
 #, c-format
 msgid "gc --owner cannot select a full-store sweep\n"
 msgstr ""
 
-#: src/store.c:4118
+#: src/store.c:4161
 #, fuzzy, c-format
 #| msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgid "gc --repair-epoch cannot be combined with another selector\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4130 src/store.c:4151
+#: src/store.c:4173 src/store.c:4194
 #, fuzzy, c-format
 #| msgid "invalid transaction directory: %s\n"
 msgid "invalid GC quarantine selectors\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:4141
+#: src/store.c:4184
 #, fuzzy, c-format
 #| msgid "invalid secret bundle\n"
 msgid "invalid GC candidate handle\n"
 msgstr "secret bundle が不正です\n"
 
-#: src/store.c:4207 src/store.c:4214
+#: src/store.c:4250 src/store.c:4257
 #, c-format
 msgid "invalid arguments for gc\n"
 msgstr "gc の引数が不正です\n"
 
-#: src/store.c:4255
+#: src/store.c:4298
 #, c-format
 msgid "invalid migration target format: %s\n"
 msgstr "migration target format が不正です: %s\n"
 
-#: src/store.c:4266 src/store.c:4278
+#: src/store.c:4309 src/store.c:4321
 #, c-format
 msgid "invalid arguments for store migrate\n"
 msgstr "store migrate の引数が不正です\n"
 
-#: src/store.c:4273
+#: src/store.c:4316
 #, c-format
 msgid "missing store name for store migrate\n"
 msgstr "store migrate の store 名が不足しています\n"
 
-#: src/store.c:4283
+#: src/store.c:4326
 #, c-format
 msgid "store migrate requires --to-format v2\n"
 msgstr "store migrate には --to-format v2 が必要です\n"
 
-#: src/store.c:4313
+#: src/store.c:4356
 #, c-format
 msgid "invalid migration source format: %s\n"
 msgstr "migration source format が不正です: %s\n"
 
-#: src/store.c:4324 src/store.c:4336
+#: src/store.c:4367 src/store.c:4379
 #, c-format
 msgid "invalid arguments for store finalize-migration\n"
 msgstr "store finalize-migration の引数が不正です\n"
 
-#: src/store.c:4331
+#: src/store.c:4374
 #, c-format
 msgid "missing store name for store finalize-migration\n"
 msgstr "store finalize-migration の store 名が不足しています\n"
 
-#: src/store.c:4341
+#: src/store.c:4384
 #, c-format
 msgid "store finalize-migration requires --from-format v1\n"
 msgstr "store finalize-migration には --from-format v1 が必要です\n"
 
-#: src/store.c:4367 src/store.c:4378 src/store.c:4388
+#: src/store.c:4410 src/store.c:4421 src/store.c:4431
 #, c-format
 msgid "invalid arguments for store ls\n"
 msgstr "store ls の引数が不正です\n"
 
-#: src/store.c:4566
+#: src/store.c:4609
 #, c-format
 msgid "secret value is too large\n"
 msgstr "secret value が大きすぎます\n"
 
-#: src/store.c:4593 src/store.c:4606
+#: src/store.c:4636 src/store.c:4649
 #, c-format
 msgid "invalid overlay payload\n"
 msgstr "overlay payload が不正です\n"
 
-#: src/store.c:4906 src/store.c:30809
+#: src/store.c:4949 src/store.c:30852
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr "key visibility が不正です: %s\n"
 
-#: src/store.c:4920
+#: src/store.c:4963
 #, c-format
 msgid "invalid value access: %s\n"
 msgstr "value access が不正です: %s\n"
 
-#: src/store.c:4978
+#: src/store.c:5021
 #, c-format
 msgid "invalid bulk select policy: %s; use %s\n"
 msgstr "bulk select policy が不正です: %s。%s を使ってください\n"
 
-#: src/store.c:4981 src/store.c:4990
+#: src/store.c:5024 src/store.c:5033
 #, c-format
 msgid "invalid bulk select policy: %s\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:5022
+#: src/store.c:5065
 #, c-format
 msgid ""
 "key_visibility=unlocked requires store format v2; run store migrate STORE --"
@@ -3412,164 +3436,164 @@ msgstr ""
 "key_visibility=unlocked には store format v2 が必要です。先に store migrate "
 "STORE --to-format v2 --dry-run を実行してください\n"
 
-#: src/store.c:5053 src/store.c:5092
+#: src/store.c:5096 src/store.c:5135
 #, c-format
 msgid "invalid secret metadata\n"
 msgstr "secret metadata が不正です\n"
 
-#: src/store.c:5070
+#: src/store.c:5113
 #, c-format
 msgid "unsupported secret metadata field: %s\n"
 msgstr "サポートされていない secret metadata field です: %s\n"
 
-#: src/store.c:5106
+#: src/store.c:5149
 #, c-format
 msgid "unsupported secret metadata format\n"
 msgstr "サポートされていない secret metadata format です\n"
 
-#: src/store.c:5200 src/store.c:31167 src/store.c:37724
+#: src/store.c:5243 src/store.c:31210 src/store.c:37767
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr "secret value_access が storage mode と一致しません\n"
 
-#: src/store.c:5217 src/store.c:30866 src/store.c:30943 src/store.c:30955
-#: src/store.c:31312
+#: src/store.c:5260 src/store.c:30909 src/store.c:30986 src/store.c:30998
+#: src/store.c:31355
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr "secret metadata が大きすぎます\n"
 
-#: src/store.c:5289 src/store.c:5296
+#: src/store.c:5332 src/store.c:5339
 #, c-format
 msgid "failed to create directory: %s\n"
 msgstr "ディレクトリの作成に失敗しました: %s\n"
 
-#: src/store.c:5470 src/store.c:19487
+#: src/store.c:5513 src/store.c:19530
 #, c-format
 msgid "invalid path: %s\n"
 msgstr "不正なパスです: %s\n"
 
-#: src/store.c:5485
+#: src/store.c:5528
 #, c-format
 msgid "failed to create temporary file for: %s\n"
 msgstr "一時ファイルの作成に失敗しました: %s\n"
 
-#: src/store.c:5490
+#: src/store.c:5533
 #, c-format
 msgid "failed to set permissions on: %s\n"
 msgstr "権限の設定に失敗しました: %s\n"
 
-#: src/store.c:5500
+#: src/store.c:5543
 #, c-format
 msgid "failed to write file: %s\n"
 msgstr "ファイルの書き込みに失敗しました: %s\n"
 
-#: src/store.c:5509
+#: src/store.c:5552
 #, c-format
 msgid "failed to fsync file: %s\n"
 msgstr "ファイルの fsync に失敗しました: %s\n"
 
-#: src/store.c:5516 src/store.c:19954
+#: src/store.c:5559 src/store.c:19997
 #, c-format
 msgid "failed to close file: %s\n"
 msgstr "ファイルのクローズに失敗しました: %s\n"
 
-#: src/store.c:5522
+#: src/store.c:5565
 #, c-format
 msgid "failed to rename file into place: %s\n"
 msgstr "ファイルの配置先への rename に失敗しました: %s\n"
 
-#: src/store.c:5575 src/store.c:5588
+#: src/store.c:5618 src/store.c:5631
 #, c-format
 msgid "failed to seek file: %s\n"
 msgstr "ファイルの seek に失敗しました: %s\n"
 
-#: src/store.c:5582
+#: src/store.c:5625
 #, c-format
 msgid "failed to determine file size: %s\n"
 msgstr "ファイルサイズの取得に失敗しました: %s\n"
 
-#: src/store.c:5701 src/store.c:12103
+#: src/store.c:5744 src/store.c:12146
 #, c-format
 msgid "failed to derive encryption key\n"
 msgstr "暗号化キーの導出に失敗しました\n"
 
-#: src/store.c:5784
+#: src/store.c:5827
 #, c-format
 msgid "%s must be an integer between %u and %u\n"
 msgstr "%s には %u から %u までの整数を指定してください\n"
 
-#: src/store.c:6381 src/store.c:6394 src/store.c:7905 src/store.c:7911
-#: src/store.c:7921 src/store.c:7969
+#: src/store.c:6424 src/store.c:6437 src/store.c:7948 src/store.c:7954
+#: src/store.c:7964 src/store.c:8012
 #, c-format
 msgid "failed to start session agent\n"
 msgstr "セッションエージェントの起動に失敗しました\n"
 
-#: src/store.c:6399 src/store.c:7976
+#: src/store.c:6442 src/store.c:8019
 #, c-format
 msgid "timed out waiting for session agent readiness\n"
 msgstr "セッションエージェントの準備完了待ちがタイムアウトしました\n"
 
-#: src/store.c:6826
+#: src/store.c:6869
 #, c-format
 msgid "failed to open file descriptor\n"
 msgstr "ファイル記述子のオープンに失敗しました\n"
 
-#: src/store.c:7815
+#: src/store.c:7858
 #, c-format
 msgid "failed to bind session agent socket\n"
 msgstr "セッションエージェントのソケット bind に失敗しました\n"
 
-#: src/store.c:7838
+#: src/store.c:7881
 #, c-format
 msgid "failed to listen on session agent socket\n"
 msgstr "セッションエージェントのソケット listen に失敗しました\n"
 
-#: src/store.c:7984
+#: src/store.c:8027
 #, c-format
 msgid "session agent failed before readiness\n"
 msgstr "セッションエージェントは準備完了前に失敗しました\n"
 
-#: src/store.c:8022
+#: src/store.c:8065
 #, c-format
 msgid "empty passphrase is not allowed\n"
 msgstr "空のパスフレーズは許可されません\n"
 
-#: src/store.c:8039
+#: src/store.c:8082
 #, c-format
 msgid "missing askpass provider\n"
 msgstr "askpass provider が不足しています\n"
 
-#: src/store.c:8044
+#: src/store.c:8087
 #, c-format
 msgid "missing askpass provider: %s\n"
 msgstr "askpass provider が見つかりません: %s\n"
 
-#: src/store.c:8046
+#: src/store.c:8089
 #, c-format
 msgid "unsupported askpass provider: %s\n"
 msgstr "サポートされていない askpass provider です: %s\n"
 
-#: src/store.c:8052 src/store.c:8060
+#: src/store.c:8095 src/store.c:8103
 #, c-format
 msgid "failed to start askpass command\n"
 msgstr "askpass コマンドの起動に失敗しました\n"
 
-#: src/store.c:8110
+#: src/store.c:8153
 #, c-format
 msgid "failed to read askpass output\n"
 msgstr "askpass 出力の読み取りに失敗しました\n"
 
-#: src/store.c:8117
+#: src/store.c:8160
 #, c-format
 msgid "askpass prompt cancelled\n"
 msgstr "askpass prompt がキャンセルされました\n"
 
-#: src/store.c:8122
+#: src/store.c:8165
 #, c-format
 msgid "askpass output is too long\n"
 msgstr "askpass 出力が長すぎます\n"
 
-#: src/store.c:8149
+#: src/store.c:8192
 #, c-format
 msgid ""
 "missing askpass provider; --gui requires --askpass, SECDAT_ASKPASS, or "
@@ -3578,7 +3602,7 @@ msgstr ""
 "askpass provider が不足しています。--gui には --askpass、SECDAT_ASKPASS、また"
 "は SSH_ASKPASS が必要です\n"
 
-#: src/store.c:8152
+#: src/store.c:8195
 #, c-format
 msgid ""
 "missing askpass provider; this command requires a terminal for passphrase "
@@ -3587,64 +3611,64 @@ msgstr ""
 "askpass provider が不足しています。このコマンドにはパスフレーズ入力用の端末が"
 "必要です\n"
 
-#: src/store.c:8160
+#: src/store.c:8203
 #, c-format
 msgid "failed to read terminal settings\n"
 msgstr "端末設定の読み取りに失敗しました\n"
 
-#: src/store.c:8167 src/store.c:8183
+#: src/store.c:8210 src/store.c:8226
 #, c-format
 msgid "failed to update terminal settings\n"
 msgstr "端末設定の更新に失敗しました\n"
 
-#: src/store.c:8173
+#: src/store.c:8216
 #, c-format
 msgid "failed to read passphrase\n"
 msgstr "パスフレーズの読み取りに失敗しました\n"
 
-#: src/store.c:8204
+#: src/store.c:8247
 msgid "Create secdat passphrase: "
 msgstr "secdat パスフレーズを作成してください: "
 
-#: src/store.c:8207
+#: src/store.c:8250
 msgid "Confirm secdat passphrase: "
 msgstr "secdat パスフレーズを再入力してください: "
 
-#: src/store.c:8214 src/store.c:8242
+#: src/store.c:8257 src/store.c:8285
 #, c-format
 msgid "passphrase confirmation did not match\n"
 msgstr "確認用パスフレーズが一致しません\n"
 
-#: src/store.c:8270
+#: src/store.c:8313
 msgid "Enter secdat passphrase: "
 msgstr "secdat パスフレーズを入力してください: "
 
-#: src/store.c:8303 src/store.c:8330
+#: src/store.c:8346 src/store.c:8373
 #, c-format
 msgid "failed to create session agent socket\n"
 msgstr "セッションエージェントのソケット作成に失敗しました\n"
 
-#: src/store.c:8340
+#: src/store.c:8383
 #, c-format
 msgid "failed to connect to session agent\n"
 msgstr "セッションエージェントへの接続に失敗しました\n"
 
-#: src/store.c:8722
+#: src/store.c:8765
 #, c-format
 msgid "failed to hand over the active session agent safely\n"
 msgstr "アクティブなセッションエージェントの安全な引継ぎに失敗しました\n"
 
-#: src/store.c:8841 src/store.c:8854 src/store.c:8878
+#: src/store.c:8884 src/store.c:8897 src/store.c:8921
 #, c-format
 msgid "invalid response from the active session agent\n"
 msgstr "アクティブなセッションエージェントから不正な応答が返されました\n"
 
-#: src/store.c:8887 src/store.c:9231 src/store.c:9545
+#: src/store.c:8930 src/store.c:9274 src/store.c:9588
 #, c-format
 msgid "failed to negotiate capabilities with the active session agent\n"
 msgstr "アクティブなセッションエージェントとの機能交渉に失敗しました\n"
 
-#: src/store.c:9015 src/store.c:9019
+#: src/store.c:9058 src/store.c:9062
 #, c-format
 msgid ""
 "failed to purge session-local ephemeral values from an active session agent\n"
@@ -3652,26 +3676,26 @@ msgstr ""
 "アクティブなセッションエージェントから session-local ephemeral 値を purge で"
 "きませんでした\n"
 
-#: src/store.c:9237 src/store.c:9551
+#: src/store.c:9280 src/store.c:9594
 #, c-format
 msgid "the active session agent cannot expose its volatile overlay safely\n"
 msgstr ""
 "アクティブなセッションエージェントは volatile overlay を安全に公開できませ"
 "ん\n"
 
-#: src/store.c:9260 src/store.c:9275 src/store.c:9574 src/store.c:9589
+#: src/store.c:9303 src/store.c:9318 src/store.c:9617 src/store.c:9632
 #, c-format
 msgid "legacy volatile session cannot be read safely by this secdat version\n"
 msgstr ""
 "旧式の volatile session はこの secdat バージョンでは安全に読み取れません\n"
 
-#: src/store.c:9263 src/store.c:9577
+#: src/store.c:9306 src/store.c:9620
 #, c-format
 msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 "アクティブなセッションエージェントが overlay protocol を完了しませんでした\n"
 
-#: src/store.c:9379 src/store.c:11427 src/store.c:11494 src/store.c:37816
+#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37859
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
@@ -3680,7 +3704,7 @@ msgstr ""
 "現在のセッションでは key は ephemeral です。更新には set --ephemeral を使用し"
 "てください: %s\n"
 
-#: src/store.c:9429 src/store.c:37781
+#: src/store.c:9472 src/store.c:37824
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
@@ -3689,7 +3713,7 @@ msgstr ""
 "key には volatile session change があるため ephemeral secret で置き換えられま"
 "せん: %s\n"
 
-#: src/store.c:9471 src/store.c:9510 src/store.c:38757
+#: src/store.c:9514 src/store.c:9553 src/store.c:38800
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
@@ -3698,7 +3722,7 @@ msgstr ""
 "現在のセッションでは key は ephemeral です。削除には rm --ephemeral を使用し"
 "てください: %s\n"
 
-#: src/store.c:9860
+#: src/store.c:9903
 #, c-format
 msgid ""
 "per-key ephemeral secrets require an active secdat session agent; run secdat "
@@ -3707,172 +3731,172 @@ msgstr ""
 "key ごとの ephemeral secret には active secdat session agent が必要です。先"
 "に secdat unlock を実行してください\n"
 
-#: src/store.c:9866
+#: src/store.c:9909
 #, c-format
 msgid "current session is readonly and cannot store an ephemeral secret\n"
 msgstr ""
 "現在のセッションは読み取り専用のため ephemeral secret を保存できません\n"
 
-#: src/store.c:9996
+#: src/store.c:10039
 #, c-format
 msgid "unlock writable session: secdat unlock\n"
 msgstr "書き込み可能セッションを開始: secdat unlock\n"
 
-#: src/store.c:9998
+#: src/store.c:10041
 #, c-format
 msgid "unlock writable session: secdat --dir %s unlock\n"
 msgstr "書き込み可能セッションを開始: secdat --dir %s unlock\n"
 
-#: src/store.c:10007
+#: src/store.c:10050
 #, c-format
 msgid "current session is readonly and cannot run %s\n"
 msgstr "現在のセッションは読み取り専用のため %s を実行できません\n"
 
-#: src/store.c:10069 src/store.c:38723 src/store.c:38869 src/store.c:40926
+#: src/store.c:10112 src/store.c:38766 src/store.c:38912 src/store.c:40969
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr "key の削除に失敗しました: %s\n"
 
-#: src/store.c:10085 src/store.c:10090
+#: src/store.c:10128 src/store.c:10133
 #, c-format
 msgid "lock --save requires a local volatile session\n"
 msgstr "lock --save にはローカルの揮発セッションが必要です\n"
 
-#: src/store.c:10170
+#: src/store.c:10213
 #, c-format
 msgid "invalid wrap key iteration count\n"
 msgstr "wrap key の iteration count が不正です\n"
 
-#: src/store.c:10174
+#: src/store.c:10217
 #, c-format
 msgid "failed to derive wrap key\n"
 msgstr "wrap key の導出に失敗しました\n"
 
-#: src/store.c:10191 src/store.c:10234 src/store.c:11750 src/store.c:13190
-#: src/store.c:13415 src/store.c:30652
+#: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
+#: src/store.c:13458 src/store.c:30695
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr "nonce の生成に失敗しました\n"
 
-#: src/store.c:10260 src/store.c:11776 src/store.c:13212 src/store.c:13437
+#: src/store.c:10303 src/store.c:11819 src/store.c:13255 src/store.c:13480
 #, c-format
 msgid "failed to create encryption context\n"
 msgstr "暗号化 context の作成に失敗しました\n"
 
-#: src/store.c:10266 src/store.c:11782 src/store.c:13219 src/store.c:13443
+#: src/store.c:10309 src/store.c:11825 src/store.c:13262 src/store.c:13486
 #, c-format
 msgid "failed to initialize encryption\n"
 msgstr "暗号化の初期化に失敗しました\n"
 
-#: src/store.c:10276 src/store.c:11796 src/store.c:13230 src/store.c:13447
-#: src/store.c:13457
+#: src/store.c:10319 src/store.c:11839 src/store.c:13273 src/store.c:13490
+#: src/store.c:13500
 #, c-format
 msgid "failed to encrypt value\n"
 msgstr "値の暗号化に失敗しました\n"
 
-#: src/store.c:10284 src/store.c:11804 src/store.c:13235 src/store.c:13461
+#: src/store.c:10327 src/store.c:11847 src/store.c:13278 src/store.c:13504
 #, c-format
 msgid "failed to finalize encryption\n"
 msgstr "暗号化の finalization に失敗しました\n"
 
-#: src/store.c:10289 src/store.c:11809 src/store.c:13241 src/store.c:13466
+#: src/store.c:10332 src/store.c:11852 src/store.c:13284 src/store.c:13509
 #, c-format
 msgid "failed to obtain authentication tag\n"
 msgstr "認証タグの取得に失敗しました\n"
 
-#: src/store.c:10331 src/store.c:10339 src/store.c:12023
+#: src/store.c:10374 src/store.c:10382 src/store.c:12066
 #, c-format
 msgid "invalid wrapped master key\n"
 msgstr "ラップ済み master key が不正です\n"
 
-#: src/store.c:10423 src/store.c:11848 src/store.c:11859 src/store.c:45422
-#: src/store.c:45453 src/store.c:45473 src/store.c:45496 src/store.c:45664
-#: src/store.c:45672 src/store.c:45694 src/store.c:45710
+#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45941
+#: src/store.c:45972 src/store.c:45992 src/store.c:46015 src/store.c:46183
+#: src/store.c:46191 src/store.c:46213 src/store.c:46229
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr "secret bundle が不正です\n"
 
-#: src/store.c:10475
+#: src/store.c:10518
 #, fuzzy, c-format
 msgid "secret bundle has too many objects\n"
 msgstr "secret bundle が大きすぎます\n"
 
-#: src/store.c:10585 src/store.c:10736 src/store.c:14533 src/store.c:14729
-#: src/store.c:18133 src/store.c:18182 src/store.c:35294 src/store.c:35476
-#: src/store.c:37350 src/store.c:38812 src/store.c:38835 src/store.c:38889
-#: src/store.c:39160 src/store.c:39714 src/store.c:39746 src/store.c:41046
-#: src/store.c:42332
+#: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
+#: src/store.c:18176 src/store.c:18225 src/store.c:35337 src/store.c:35519
+#: src/store.c:37393 src/store.c:38855 src/store.c:38878 src/store.c:38932
+#: src/store.c:39203 src/store.c:39757 src/store.c:39789 src/store.c:41089
+#: src/store.c:42776
 #, c-format
 msgid "key not found: %s\n"
 msgstr "key が見つかりません: %s\n"
 
-#: src/store.c:10643
+#: src/store.c:10686
 #, c-format
 msgid "secret bundle entry is too large\n"
 msgstr "secret bundle のエントリが大きすぎます\n"
 
-#: src/store.c:10653
+#: src/store.c:10696
 #, fuzzy, c-format
 msgid "secret bundle value is unavailable for a selected v2 object\n"
 msgstr "secret id は store format v2 でのみ利用できます\n"
 
-#: src/store.c:10743
+#: src/store.c:10786
 #, c-format
 msgid "save is not supported while an ephemeral secret is visible: %s\n"
 msgstr "ephemeral secret が見えている間は save を使用できません: %s\n"
 
-#: src/store.c:11742
+#: src/store.c:11785
 #, c-format
 msgid "bundle file already exists: %s\n"
 msgstr "bundle ファイルは既に存在します: %s\n"
 
-#: src/store.c:11746
+#: src/store.c:11789
 #, c-format
 msgid "secret bundle is too large\n"
 msgstr "secret bundle が大きすぎます\n"
 
-#: src/store.c:11786
+#: src/store.c:11829
 #, fuzzy, c-format
 msgid "failed to encrypt bundle metadata\n"
 msgstr "値の暗号化に失敗しました\n"
 
-#: src/store.c:11915 src/store.c:11989 src/store.c:13351 src/store.c:13545
+#: src/store.c:11958 src/store.c:12032 src/store.c:13394 src/store.c:13588
 #, c-format
 msgid "failed to create decryption context\n"
 msgstr "復号 context の作成に失敗しました\n"
 
-#: src/store.c:11921 src/store.c:11995 src/store.c:13358 src/store.c:13551
+#: src/store.c:11964 src/store.c:12038 src/store.c:13401 src/store.c:13594
 #, c-format
 msgid "failed to initialize decryption\n"
 msgstr "復号の初期化に失敗しました\n"
 
-#: src/store.c:11925
+#: src/store.c:11968
 #, fuzzy, c-format
 msgid "failed to decrypt bundle metadata\n"
 msgstr "値の復号に失敗しました\n"
 
-#: src/store.c:11929 src/store.c:12005 src/store.c:13363 src/store.c:13555
-#: src/store.c:13559
+#: src/store.c:11972 src/store.c:12048 src/store.c:13406 src/store.c:13598
+#: src/store.c:13602
 #, c-format
 msgid "failed to decrypt value\n"
 msgstr "値の復号に失敗しました\n"
 
-#: src/store.c:11933 src/store.c:12014 src/store.c:13368 src/store.c:13563
+#: src/store.c:11976 src/store.c:12057 src/store.c:13411 src/store.c:13606
 #, c-format
 msgid "failed to set authentication tag\n"
 msgstr "認証タグの設定に失敗しました\n"
 
-#: src/store.c:11937
+#: src/store.c:11980
 #, c-format
 msgid "failed to unlock secret bundle\n"
 msgstr "secret bundle の unlock に失敗しました\n"
 
-#: src/store.c:12018
+#: src/store.c:12061
 #, c-format
 msgid "failed to unlock persistent master key\n"
 msgstr "永続 master key の unlock に失敗しました\n"
 
-#: src/store.c:12094 src/store.c:19043 src/store.c:41035
+#: src/store.c:12137 src/store.c:19086 src/store.c:41078
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
@@ -3881,146 +3905,146 @@ msgstr ""
 "SECDAT_MASTER_KEY が未設定で、有効な secdat セッションもありません。secdat "
 "unlock を実行するか SECDAT_MASTER_KEY を export してください\n"
 
-#: src/store.c:12266 src/store.c:12270 src/store.c:12293
+#: src/store.c:12309 src/store.c:12313 src/store.c:12336
 #, c-format
 msgid "no local lock for: %s\n"
 msgstr "%s に local lock はありません\n"
 
-#: src/store.c:12280
+#: src/store.c:12323
 #, c-format
 msgid "refusing to remove local lock for: %s\n"
 msgstr "%s の local lock の削除を拒否しました\n"
 
-#: src/store.c:12281 src/store.c:12329
+#: src/store.c:12324 src/store.c:12372
 #, c-format
 msgid "expected resulting state: %s\n"
 msgstr "期待する結果状態: %s\n"
 
-#: src/store.c:12283
+#: src/store.c:12326
 #, c-format
 msgid "actual resulting state after removing local lock: %s\n"
 msgstr "local lock 削除後の実際の結果状態: %s\n"
 
-#: src/store.c:12298
+#: src/store.c:12341
 msgid "local lock removed; resulting state: unlocked"
 msgstr "local lock を削除しました。結果状態: unlocked"
 
-#: src/store.c:12300
+#: src/store.c:12343
 msgid "local lock removed; resulting state: locked"
 msgstr "local lock を削除しました。結果状態: locked"
 
-#: src/store.c:12302
+#: src/store.c:12345
 msgid "local lock removed"
 msgstr "local lock を削除しました"
 
-#: src/store.c:12318 src/store.c:12364
+#: src/store.c:12361 src/store.c:12407
 #, c-format
 msgid "no local lock or local unlock for: %s\n"
 msgstr "%s に local lock も local unlock もありません\n"
 
-#: src/store.c:12328
+#: src/store.c:12371
 #, c-format
 msgid "refusing to clear local unlock for: %s\n"
 msgstr "%s の local unlock の消去を拒否しました\n"
 
-#: src/store.c:12331
+#: src/store.c:12374
 #, c-format
 msgid "actual resulting state after clearing local unlock: %s\n"
 msgstr "local unlock 消去後の実際の結果状態: %s\n"
 
-#: src/store.c:12342
+#: src/store.c:12385
 msgid "local unlock cleared; resulting state: unlocked"
 msgstr "local unlock を消去しました。結果状態: unlocked"
 
-#: src/store.c:12344
+#: src/store.c:12387
 msgid "local unlock cleared; resulting state: locked"
 msgstr "local unlock を消去しました。結果状態: locked"
 
-#: src/store.c:12346
+#: src/store.c:12389
 msgid "local unlock cleared"
 msgstr "local unlock を消去しました"
 
-#: src/store.c:12601 src/store.c:12608 src/store.c:12614 src/store.c:12620
+#: src/store.c:12644 src/store.c:12651 src/store.c:12657 src/store.c:12663
 #, c-format
 msgid "invalid arguments for status\n"
 msgstr "status の引数が不正です\n"
 
-#: src/store.c:12632
+#: src/store.c:12675
 msgid "source: environment"
 msgstr "取得元: 環境変数"
 
-#: src/store.c:12642
+#: src/store.c:12685
 msgid "source: session agent"
 msgstr "取得元: セッションエージェント"
 
-#: src/store.c:12644
+#: src/store.c:12687
 msgid "overlay: volatile"
 msgstr "overlay: volatile"
 
-#: src/store.c:12647
+#: src/store.c:12690
 msgid "access: readonly"
 msgstr "access: readonly"
 
-#: src/store.c:12650
+#: src/store.c:12693
 #, c-format
 msgid "expires in: %s\n"
 msgstr "残り時間: %s\n"
 
-#: src/store.c:12770
+#: src/store.c:12813
 #, c-format
 msgid "this will unlock %zu descendant domains in the current subtree\n"
 msgstr "現在の subtree で %zu 個の descendant domain を unlock します\n"
 
-#: src/store.c:12771
+#: src/store.c:12814
 #, c-format
 msgid "local locks will remain after local unlock expiry or a later lock\n"
 msgstr "local unlock の期限切れ後や後続の lock 後も local lock は残ります\n"
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "volatile session refreshed"
 msgstr "揮発セッションを延長しました"
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "readonly session refreshed"
 msgstr "読み取り専用セッションを延長しました"
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "session refreshed"
 msgstr "セッションを延長しました"
 
-#: src/store.c:12886
+#: src/store.c:12929
 msgid "readonly session unlocked from environment"
 msgstr "環境変数から読み取り専用セッションをアンロックしました"
 
-#: src/store.c:12887 src/store.c:12979
+#: src/store.c:12930 src/store.c:13022
 msgid "readonly session unlocked"
 msgstr "読み取り専用セッションをアンロックしました"
 
-#: src/store.c:12889 src/store.c:12925
+#: src/store.c:12932 src/store.c:12968
 msgid "volatile session unlocked with an ephemeral master key"
 msgstr "揮発セッションを一時 master key でアンロックしました"
 
-#: src/store.c:12892
+#: src/store.c:12935
 msgid "volatile session unlocked from environment"
 msgstr "環境変数から揮発セッションをアンロックしました"
 
-#: src/store.c:12893 src/store.c:12979
+#: src/store.c:12936 src/store.c:13022
 msgid "volatile session unlocked"
 msgstr "揮発セッションをアンロックしました"
 
-#: src/store.c:12896
+#: src/store.c:12939
 msgid "persistent master key initialized; session unlocked from environment"
 msgstr "永続 master key を初期化し、環境変数からセッションをアンロックしました"
 
-#: src/store.c:12897
+#: src/store.c:12940
 msgid "persistent master key initialized; session unlocked"
 msgstr "永続 master key を初期化し、セッションをアンロックしました"
 
-#: src/store.c:12899
+#: src/store.c:12942
 msgid "session unlocked from environment"
 msgstr "環境変数からセッションをアンロックしました"
 
-#: src/store.c:12932
+#: src/store.c:12975
 #, c-format
 msgid ""
 "no persistent master key is initialized; readonly unlock requires an "
@@ -4029,7 +4053,7 @@ msgstr ""
 "永続 master key が未初期化のため、readonly unlock には既存の master key が必"
 "要です\n"
 
-#: src/store.c:12937 src/store.c:13127
+#: src/store.c:12980 src/store.c:13170
 #, c-format
 msgid ""
 "no persistent master key is initialized; run secdat unlock once to create "
@@ -4038,90 +4062,90 @@ msgstr ""
 "永続 master key が未初期化です。一度 secdat unlock を実行して作成してくださ"
 "い\n"
 
-#: src/store.c:12979
+#: src/store.c:13022
 msgid "session unlocked"
 msgstr "セッションをアンロックしました"
 
-#: src/store.c:13032
+#: src/store.c:13075
 msgid "already locked"
 msgstr "すでにロック中です"
 
-#: src/store.c:13059
+#: src/store.c:13102
 msgid "volatile session saved and locked"
 msgstr "揮発セッションを保存してロックしました"
 
-#: src/store.c:13059
+#: src/store.c:13102
 msgid "session locked"
 msgstr "セッションをロックしました"
 
-#: src/store.c:13092
+#: src/store.c:13135
 #, c-format
 msgid "invalid arguments for inherit\n"
 msgstr "inherit の引数が不正です\n"
 
-#: src/store.c:13139
+#: src/store.c:13182
 msgid "Create new secdat passphrase: "
 msgstr "新しい secdat パスフレーズを作成してください: "
 
-#: src/store.c:13140
+#: src/store.c:13183
 msgid "Confirm new secdat passphrase: "
 msgstr "新しい secdat パスフレーズを再入力してください: "
 
-#: src/store.c:13156
+#: src/store.c:13199
 msgid "persistent master key passphrase updated"
 msgstr "永続 master key のパスフレーズを更新しました"
 
-#: src/store.c:13286 src/store.c:13304 src/store.c:13309 src/store.c:13315
-#: src/store.c:13330 src/store.c:13516 src/store.c:13523 src/store.c:13528
-#: src/store.c:14585 src/store.c:14669
+#: src/store.c:13329 src/store.c:13347 src/store.c:13352 src/store.c:13358
+#: src/store.c:13373 src/store.c:13559 src/store.c:13566 src/store.c:13571
+#: src/store.c:14628 src/store.c:14712
 #, c-format
 msgid "invalid encrypted entry\n"
 msgstr "暗号化エントリが不正です\n"
 
-#: src/store.c:13291 src/store.c:14592 src/store.c:14673
+#: src/store.c:13334 src/store.c:14635 src/store.c:14716
 #, c-format
 msgid "unsupported encrypted entry format\n"
 msgstr "暗号化エントリ形式はサポートされていません\n"
 
-#: src/store.c:13297 src/store.c:14596 src/store.c:14677
+#: src/store.c:13340 src/store.c:14639 src/store.c:14720
 #, c-format
 msgid "unsupported encryption algorithm\n"
 msgstr "暗号化アルゴリズムはサポートされていません\n"
 
-#: src/store.c:13374 src/store.c:13567
+#: src/store.c:13417 src/store.c:13610
 #, c-format
 msgid "failed to authenticate encrypted value\n"
 msgstr "暗号化値の認証に失敗しました\n"
 
-#: src/store.c:13733 src/store.c:14610 src/store.c:14616 src/store.c:18945
-#: src/store.c:18962 src/store.c:19016 src/store.c:19027 src/store.c:29356
-#: src/store.c:29975 src/store.c:30137 src/store.c:30719 src/store.c:30729
-#: src/store.c:31039 src/store.c:31075 src/store.c:31201 src/store.c:40743
-#: src/store.c:40766 src/store.c:42443
+#: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
+#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29399
+#: src/store.c:30018 src/store.c:30180 src/store.c:30762 src/store.c:30772
+#: src/store.c:31082 src/store.c:31118 src/store.c:31244 src/store.c:40786
+#: src/store.c:40809 src/store.c:42907
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr "v2 domain entry が不正です: %s\n"
 
-#: src/store.c:13771
+#: src/store.c:13814
 #, c-format
 msgid "failed to read standard input\n"
 msgstr "標準入力の読み取りに失敗しました\n"
 
-#: src/store.c:13998 src/store.c:14221 src/store.c:14391 src/store.c:30029
-#: src/store.c:30276 src/store.c:33992 src/store.c:34097 src/store.c:34427
-#: src/store.c:37415 src/store.c:37703 src/store.c:38512 src/store.c:38611
-#: src/store.c:38855 src/store.c:41026 src/store.c:43028 src/store.c:43174
-#: src/store.c:43586 src/store.c:44206 src/store.c:44930 src/store.c:45506
+#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30072
+#: src/store.c:30319 src/store.c:34035 src/store.c:34140 src/store.c:34470
+#: src/store.c:37458 src/store.c:37746 src/store.c:38555 src/store.c:38654
+#: src/store.c:38898 src/store.c:41069 src/store.c:43547 src/store.c:43693
+#: src/store.c:44105 src/store.c:44725 src/store.c:45449 src/store.c:46025
 #, c-format
 msgid "invalid store format marker\n"
 msgstr "store format marker が不正です\n"
 
-#: src/store.c:14121
+#: src/store.c:14164
 #, c-format
 msgid "Key candidates:\n"
 msgstr "key 候補:\n"
 
-#: src/store.c:14144
+#: src/store.c:14187
 #, c-format
 msgid ""
 "Hint: use %s get KEY for an explicit key lookup, or %s help COMMAND for "
@@ -4130,7 +4154,7 @@ msgstr ""
 "ヒント: key 探索を明示するには %s get KEY を、コマンド help には %s help "
 "COMMAND を使ってください\n"
 
-#: src/store.c:14156
+#: src/store.c:14199
 #, c-format
 msgid ""
 "Hint: check secdat status, --dir, and --store to confirm the lookup context\n"
@@ -4138,113 +4162,113 @@ msgstr ""
 "ヒント: secdat status、--dir、--store を確認して探索文脈が正しいか確かめてく"
 "ださい\n"
 
-#: src/store.c:14565 src/store.c:30617 src/store.c:31045 src/store.c:31049
-#: src/store.c:31189 src/store.c:38659 src/store.c:38666 src/store.c:40749
+#: src/store.c:14608 src/store.c:30660 src/store.c:31088 src/store.c:31092
+#: src/store.c:31232 src/store.c:38702 src/store.c:38709 src/store.c:40792
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr "v2 secret object が不正です: %s\n"
 
-#: src/store.c:14573
+#: src/store.c:14616
 #, c-format
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr "v2 secret value storage はまだ実装されていません\n"
 
-#: src/store.c:15831 src/store.c:37986
+#: src/store.c:15874 src/store.c:38029
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr "random bytes の生成に失敗しました\n"
 
-#: src/store.c:15923
+#: src/store.c:15966
 #, fuzzy, c-format
 #| msgid "failed to calculate transaction digest\n"
 msgid "failed to calculate GC candidate handle\n"
 msgstr "transaction digest の計算に失敗しました\n"
 
-#: src/store.c:16605
+#: src/store.c:16648
 #, fuzzy, c-format
 #| msgid "failed to create session agent socket\n"
 msgid "failed to read the GC scheduling clock\n"
 msgstr "セッションエージェントのソケット作成に失敗しました\n"
 
-#: src/store.c:16859
+#: src/store.c:16902
 #, c-format
 msgid "invalid deferred GC topology effect\n"
 msgstr ""
 
-#: src/store.c:17005
+#: src/store.c:17048
 #, fuzzy, c-format
 #| msgid "secret bundle entry is too large\n"
 msgid "secret reference count is too large\n"
 msgstr "secret bundle のエントリが大きすぎます\n"
 
-#: src/store.c:17552 src/store.c:17565
+#: src/store.c:17595 src/store.c:17608
 #, c-format
 msgid "metadata is too large\n"
 msgstr "metadata が大きすぎます\n"
 
-#: src/store.c:17644 src/store.c:17687 src/store.c:17736 src/store.c:35500
-#: src/store.c:35620 src/store.c:36876
+#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35543
+#: src/store.c:35663 src/store.c:36919
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr "metadata field が不正です: %s\n"
 
-#: src/store.c:17725
+#: src/store.c:17768
 #, c-format
 msgid "invalid metadata filter: %s\n"
 msgstr "metadata filter が不正です: %s\n"
 
-#: src/store.c:17867 src/store.c:17896 src/store.c:17907
+#: src/store.c:17910 src/store.c:17939 src/store.c:17950
 #, c-format
 msgid "invalid key metadata\n"
 msgstr "key metadata が不正です\n"
 
-#: src/store.c:17882
+#: src/store.c:17925
 #, c-format
 msgid "unsupported key metadata format\n"
 msgstr "サポートされていない key metadata format です\n"
 
-#: src/store.c:18027 src/store.c:18100
+#: src/store.c:18070 src/store.c:18143
 #, c-format
 msgid "invalid relation member role: %s\n"
 msgstr "relation member role が不正です: %s\n"
 
-#: src/store.c:18033
+#: src/store.c:18076
 #, c-format
 msgid "invalid relation member key reference\n"
 msgstr "relation member key reference が不正です\n"
 
-#: src/store.c:18040
+#: src/store.c:18083
 #, c-format
 msgid "duplicate relation member role: %s\n"
 msgstr "relation member role が重複しています: %s\n"
 
-#: src/store.c:18085
+#: src/store.c:18128
 #, c-format
 msgid "invalid relation member: %s\n"
 msgstr "relation member が不正です: %s\n"
 
-#: src/store.c:18210 src/store.c:35779
+#: src/store.c:18253 src/store.c:35822
 #, c-format
 msgid "relation not found: %s\n"
 msgstr "relation が見つかりません: %s\n"
 
-#: src/store.c:18219 src/store.c:18247 src/store.c:18404
+#: src/store.c:18262 src/store.c:18290 src/store.c:18447
 #, c-format
 msgid "invalid relation metadata\n"
 msgstr "relation metadata が不正です\n"
 
-#: src/store.c:18233
+#: src/store.c:18276
 #, c-format
 msgid "unsupported relation metadata format\n"
 msgstr "サポートされていない relation metadata format です\n"
 
-#: src/store.c:18460
+#: src/store.c:18503
 #, c-format
 msgid "key_visibility=unlocked cannot be used while key metadata exists: %s\n"
 msgstr ""
 "key metadata が存在する間は key_visibility=unlocked を使用できません: %s\n"
 
-#: src/store.c:18482
+#: src/store.c:18525
 #, c-format
 msgid ""
 "key_visibility=unlocked cannot be used while relation references key: %s "
@@ -4253,244 +4277,244 @@ msgstr ""
 "relation が key を参照している間は key_visibility=unlocked を使用できません: "
 "%s (%s)\n"
 
-#: src/store.c:19440
+#: src/store.c:19483
 #, c-format
 msgid "failed to calculate transaction digest\n"
 msgstr "transaction digest の計算に失敗しました\n"
 
-#: src/store.c:19462
+#: src/store.c:19505
 #, c-format
 msgid "failed to open directory for fsync: %s\n"
 msgstr "fsync 用のディレクトリを開けませんでした: %s\n"
 
-#: src/store.c:19466
+#: src/store.c:19509
 #, c-format
 msgid "failed to fsync directory: %s\n"
 msgstr "ディレクトリの fsync に失敗しました: %s\n"
 
-#: src/store.c:19471
+#: src/store.c:19514
 #, c-format
 msgid "failed to close directory: %s\n"
 msgstr "ディレクトリを閉じられませんでした: %s\n"
 
-#: src/store.c:19511
+#: src/store.c:19554
 #, c-format
 msgid "invalid transaction directory: %s\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:19549
+#: src/store.c:19592
 #, c-format
 msgid "invalid transaction lock\n"
 msgstr "transaction lock が不正です\n"
 
-#: src/store.c:19566 src/store.c:19583
+#: src/store.c:19609 src/store.c:19626
 #, c-format
 msgid "failed to lock transactions\n"
 msgstr "transaction の lock に失敗しました\n"
 
-#: src/store.c:19912
+#: src/store.c:19955
 #, c-format
 msgid "failed to inspect transaction target: %s\n"
 msgstr "transaction target を確認できませんでした: %s\n"
 
-#: src/store.c:19921
+#: src/store.c:19964
 #, c-format
 msgid "invalid transaction target: %s\n"
 msgstr "transaction target が不正です: %s\n"
 
-#: src/store.c:20691
+#: src/store.c:20734
 #, fuzzy, c-format
 #| msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgid "container tree does not match schema: %s\n"
 msgstr "互換 tombstone が canonical mask と一致しません: %s\n"
 
-#: src/store.c:21237 src/store.c:21243 src/store.c:21364
+#: src/store.c:21280 src/store.c:21286 src/store.c:21407
 #, fuzzy, c-format
 #| msgid "failed to create directory: %s\n"
 msgid "failed to inspect typed directory: %s\n"
 msgstr "ディレクトリの作成に失敗しました: %s\n"
 
-#: src/store.c:21264
+#: src/store.c:21307
 #, fuzzy, c-format
 #| msgid "invalid transaction directory: %s\n"
 msgid "invalid typed directory: %s\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:21660 src/store.c:21751
+#: src/store.c:21703 src/store.c:21794
 #, c-format
 msgid "invalid transaction target directory\n"
 msgstr "transaction target directory が不正です\n"
 
-#: src/store.c:21780 src/store.c:21790 src/store.c:21868
+#: src/store.c:21823 src/store.c:21833 src/store.c:21911
 #, c-format
 msgid "failed to read transaction target\n"
 msgstr "transaction target を読み込めませんでした\n"
 
-#: src/store.c:22236 src/store.c:22427 src/store.c:22438
+#: src/store.c:22279 src/store.c:22470 src/store.c:22481
 #, c-format
 msgid "transaction data is too large\n"
 msgstr "transaction data が大きすぎます\n"
 
-#: src/store.c:22300
+#: src/store.c:22343
 #, c-format
 msgid "transaction has too many targets\n"
 msgstr "transaction の target が多すぎます\n"
 
-#: src/store.c:22312
+#: src/store.c:22355
 #, c-format
 msgid "invalid transaction validation target\n"
 msgstr "transaction validation target が不正です\n"
 
-#: src/store.c:22358 src/store.c:22794
+#: src/store.c:22401 src/store.c:22837
 #, c-format
 msgid "transaction changed since plan\n"
 msgstr "plan 作成後に transaction target が変更されました\n"
 
-#: src/store.c:22381 src/store.c:22839
+#: src/store.c:22424 src/store.c:22882
 #, c-format
 msgid "duplicate transaction target\n"
 msgstr "transaction target が重複しています\n"
 
-#: src/store.c:22825
+#: src/store.c:22868
 #, c-format
 msgid "typed directory guards require transaction manifest v2\n"
 msgstr ""
 
-#: src/store.c:22890
+#: src/store.c:22933
 #, fuzzy, c-format
 #| msgid "prepared write is outside the state directory\n"
 msgid "prepared guard is outside the state directory\n"
 msgstr "準備済みの書き込みが状態ディレクトリの外を指しています\n"
 
-#: src/store.c:22912
+#: src/store.c:22955
 #, c-format
 msgid "prepared write is outside the state directory\n"
 msgstr "準備済みの書き込みが状態ディレクトリの外を指しています\n"
 
-#: src/store.c:23015
+#: src/store.c:23058
 #, fuzzy, c-format
 #| msgid "invalid store format marker\n"
 msgid "invalid move source removal target\n"
 msgstr "store format marker が不正です\n"
 
-#: src/store.c:23187
+#: src/store.c:23230
 #, c-format
 msgid "invalid transaction blob: %s\n"
 msgstr "transaction blob が不正です: %s\n"
 
-#: src/store.c:23989
+#: src/store.c:24032
 #, c-format
 msgid "invalid transaction journal: %s\n"
 msgstr "transaction journal が不正です: %s\n"
 
-#: src/store.c:24056 src/store.c:24097
+#: src/store.c:24099 src/store.c:24140
 #, c-format
 msgid "failed to open transaction directory: %s\n"
 msgstr "transaction directory を開けませんでした: %s\n"
 
-#: src/store.c:24072
+#: src/store.c:24115
 #, c-format
 msgid "unexpected transaction file: %s\n"
 msgstr "予期しない transaction file です: %s\n"
 
-#: src/store.c:24080
+#: src/store.c:24123
 #, c-format
 msgid "failed to close transaction directory\n"
 msgstr "transaction directory を閉じられませんでした\n"
 
-#: src/store.c:24123
+#: src/store.c:24166
 #, c-format
 msgid "invalid transaction temporary file: %s\n"
 msgstr "transaction の一時ファイルが不正です: %s\n"
 
-#: src/store.c:24232
+#: src/store.c:24275
 #, c-format
 msgid "failed to remove completed transaction: %s\n"
 msgstr "完了した transaction を削除できませんでした: %s\n"
 
-#: src/store.c:24286 src/store.c:24298 src/store.c:24303 src/store.c:24309
-#: src/store.c:24405
+#: src/store.c:24329 src/store.c:24341 src/store.c:24346 src/store.c:24352
+#: src/store.c:24448
 #, c-format
 msgid "failed to apply transaction target\n"
 msgstr "transaction target を適用できませんでした\n"
 
-#: src/store.c:24461
+#: src/store.c:24504
 #, c-format
 msgid "transaction target changed during recovery: %s\n"
 msgstr "復旧中に transaction target の変更を検出しました: %s\n"
 
-#: src/store.c:24497
+#: src/store.c:24540
 #, c-format
 msgid "committed transaction target is inconsistent: %s\n"
 msgstr "commit 済み transaction target が不整合です: %s\n"
 
-#: src/store.c:24552
+#: src/store.c:24595
 #, c-format
 msgid "invalid unpublished transaction: %s\n"
 msgstr "未公開 transaction が不正です: %s\n"
 
-#: src/store.c:24576
+#: src/store.c:24619
 #, c-format
 msgid "failed to open transactions directory\n"
 msgstr "transactions directory を開けませんでした\n"
 
-#: src/store.c:24588
+#: src/store.c:24631
 #, c-format
 msgid "invalid transaction entry: %s\n"
 msgstr "transaction entry が不正です: %s\n"
 
-#: src/store.c:24672
+#: src/store.c:24715
 #, c-format
 msgid "failed to inspect transactions directory\n"
 msgstr "transactions directory を確認できませんでした\n"
 
-#: src/store.c:24781
+#: src/store.c:24824
 #, c-format
 msgid "failed to stage transaction\n"
 msgstr "transaction の stage に失敗しました\n"
 
-#: src/store.c:24860
+#: src/store.c:24903
 #, c-format
 msgid "transaction changed since plan: %s\n"
 msgstr "plan 作成後に transaction target が変更されました: %s\n"
 
-#: src/store.c:25122
+#: src/store.c:25165
 #, c-format
 msgid "invalid abandoned mutation stage\n"
 msgstr "放棄された mutation stage が不正です\n"
 
-#: src/store.c:25382 src/store.c:25386
+#: src/store.c:25425 src/store.c:25429
 #, c-format
 msgid "invalid dependency index directory\n"
 msgstr "dependency index directory が不正です\n"
 
-#: src/store.c:25990
+#: src/store.c:26033
 #, c-format
 msgid "dependency index node is too large\n"
 msgstr "dependency index node が大きすぎます\n"
 
-#: src/store.c:26394
+#: src/store.c:26437
 #, c-format
 msgid "cannot index a relation dependency that references a hidden v2 key\n"
 msgstr "hidden v2 key を参照する relation dependency は index 化できません\n"
 
-#: src/store.c:26538
+#: src/store.c:26581
 #, c-format
 msgid "cannot build dependency index from invalid mask record\n"
 msgstr "不正な mask record から dependency index を構築できません\n"
 
-#: src/store.c:26564
+#: src/store.c:26607
 #, c-format
 msgid "cannot build dependency index from invalid relation record\n"
 msgstr "不正な relation record から dependency index を構築できません\n"
 
-#: src/store.c:26584
+#: src/store.c:26627
 #, c-format
 msgid "cannot index relation dependency: %s\n"
 msgstr "relation dependency をindex化できません: %s\n"
 
-#: src/store.c:27662 src/store.c:28057 src/store.c:28159 src/store.c:28686
-#: src/store.c:28796 src/store.c:29154 src/store.c:29169
+#: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
+#: src/store.c:28839 src/store.c:29197 src/store.c:29212
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
@@ -4499,7 +4523,7 @@ msgstr ""
 "dependency index が破損しています。fsck --format v2 --dependency-index --"
 "repair を実行してください\n"
 
-#: src/store.c:28018 src/store.c:28223 src/store.c:29144 src/store.c:42367
+#: src/store.c:28061 src/store.c:28266 src/store.c:29187 src/store.c:42824
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
@@ -4508,13 +4532,13 @@ msgstr ""
 "dependency index が不完全です。fsck --format v2 --dependency-index --repair "
 "を実行してください\n"
 
-#: src/store.c:28348
+#: src/store.c:28391
 #, fuzzy, c-format
 #| msgid "ambiguous legacy mask blocks this mutation\n"
 msgid "ambiguous legacy mask blocks key visibility transition: %s\n"
 msgstr "曖昧な legacy mask がこの mutation を拒否しました\n"
 
-#: src/store.c:28359
+#: src/store.c:28402
 #, fuzzy, c-format
 #| msgid ""
 #| "hidden-name mask cannot be projected to v1 rollback state without "
@@ -4523,12 +4547,12 @@ msgid "hidden-name transition cannot preserve v1 rollback mask state: %s\n"
 msgstr ""
 "hidden-name mask は名前を露出せずに v1 rollback state へ投影できません: %s\n"
 
-#: src/store.c:28947
+#: src/store.c:28990
 #, c-format
 msgid "invalid dependency index node: %s\n"
 msgstr "dependency index node が不正です: %s\n"
 
-#: src/store.c:29282
+#: src/store.c:29325
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
@@ -4536,57 +4560,57 @@ msgstr ""
 "dependency index generation が変更されました: first=%s/%zu/%zu second=%s/%zu/"
 "%zu\n"
 
-#: src/store.c:29330
+#: src/store.c:29373
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr "dependency index の再構築が %s で失敗しました\n"
 
-#: src/store.c:29892
+#: src/store.c:29935
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr "tombstone file が不正です: %s\n"
 
-#: src/store.c:29922 src/store.c:29931 src/store.c:29935
+#: src/store.c:29965 src/store.c:29974 src/store.c:29978
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr "v2 compatibility tombstone が不正です\n"
 
-#: src/store.c:30013
+#: src/store.c:30056
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr "v2 mask の target store が不正です: %s\n"
 
-#: src/store.c:30052
+#: src/store.c:30095 src/store.c:41864
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr "v2 mask の target entry が重複しています: %s\n"
 
-#: src/store.c:30090
+#: src/store.c:30133
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr "暗号化された v2 mask name が不正です: %s\n"
 
-#: src/store.c:30111 src/store.c:30232
+#: src/store.c:30154 src/store.c:30275
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr "v2 mask の target が不正です: %s\n"
 
-#: src/store.c:30151 src/store.c:30157
+#: src/store.c:30194 src/store.c:30200
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr "v2 mask の target name が不正です: %s\n"
 
-#: src/store.c:30196
+#: src/store.c:30239
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr "v2 mask directory が不正です\n"
 
-#: src/store.c:30200 src/store.c:31399
+#: src/store.c:30243 src/store.c:31442
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr "v2 mask directory を確認できませんでした\n"
 
-#: src/store.c:30220
+#: src/store.c:30263
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
@@ -4595,85 +4619,85 @@ msgstr ""
 "不正な v2 mask record です: %s。診断ハンドルを得るには fsck --format v2 --"
 "dangling を実行してください\n"
 
-#: src/store.c:30476 src/store.c:39415
+#: src/store.c:30519 src/store.c:39458
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr "互換 tombstone が canonical mask と一致しません: %s\n"
 
-#: src/store.c:30594
+#: src/store.c:30637
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 "非表示の mask name が lock されているため mask の影響を解析できません\n"
 
-#: src/store.c:31053 src/store.c:31195
+#: src/store.c:31096 src/store.c:31238
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr "secret object が bulk select を除外しています: %s\n"
 
-#: src/store.c:31361
+#: src/store.c:31404
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr "mask 診断ハンドルのエンコードに失敗しました\n"
 
-#: src/store.c:31948
+#: src/store.c:31991
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32673
+#: src/store.c:32716
 #, fuzzy, c-format
 #| msgid "lock --save requires a local volatile session\n"
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr "lock --save にはローカルの揮発セッションが必要です\n"
 
-#: src/store.c:33300
+#: src/store.c:33343
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33715
+#: src/store.c:33758
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:33984 src/store.c:34089
+#: src/store.c:34027 src/store.c:34132
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr "fsck には登録済みの current domain が必要です\n"
 
-#: src/store.c:33996
+#: src/store.c:34039
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr "store format は v2 です。--format v2 を使用してください\n"
 
-#: src/store.c:34101
+#: src/store.c:34144
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr "store format は v1 です。--format v1 を使用してください\n"
 
-#: src/store.c:34412 src/store.c:34802
+#: src/store.c:34455 src/store.c:34845
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr "gc には登録済みの current domain が必要です\n"
 
-#: src/store.c:34431
+#: src/store.c:34474
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr "store format は v1 です。gc には --format v2 が必要です\n"
 
-#: src/store.c:34635
+#: src/store.c:34678
 #, fuzzy, c-format
 #| msgid "mask interaction rejected before mutation\n"
 msgid "GC owner domain must be registered before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:34813
+#: src/store.c:34856
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr "gc は --format v2 でのみサポートされています\n"
 
-#: src/store.c:35219
+#: src/store.c:35262
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
@@ -4682,7 +4706,7 @@ msgstr ""
 "%zu 件の非表示 mask を省略しました。対象ドメインを unlock するか、件数確認に"
 "は --json を使用してください\n"
 
-#: src/store.c:35230
+#: src/store.c:35273
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
@@ -4691,12 +4715,12 @@ msgstr ""
 "ancestor の key name が lock されているため %zu 件の mask 状態が不完全です。"
 "対象 domain を unlock するか、件数確認には --json を使用してください\n"
 
-#: src/store.c:35315 src/store.c:35385
+#: src/store.c:35358 src/store.c:35428
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr "継承された key attributes は更新できません: %s\n"
 
-#: src/store.c:35377
+#: src/store.c:35420
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
@@ -4705,243 +4729,243 @@ msgstr ""
 "ephemeral secret の secret attributes は変更できません。set --ephemeral で作"
 "り直してください\n"
 
-#: src/store.c:35378
+#: src/store.c:35421
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes を変更できません\n"
 
-#: src/store.c:35507 src/store.c:35627
+#: src/store.c:35550 src/store.c:35670
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr "継承された key metadata は更新できません: %s\n"
 
-#: src/store.c:35514 src/store.c:35634
+#: src/store.c:35557 src/store.c:35677
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr "ephemeral secret の key metadata は変更できません\n"
 
-#: src/store.c:35515 src/store.c:35635
+#: src/store.c:35558 src/store.c:35678
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では key metadata を変更できません\n"
 
-#: src/store.c:35520
+#: src/store.c:35563
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を設定できません: %s\n"
 
-#: src/store.c:35552
+#: src/store.c:35595
 #, c-format
 msgid "missing key for meta get\n"
 msgstr "meta get の key が不足しています\n"
 
-#: src/store.c:35552
+#: src/store.c:35595
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr "meta get の引数が不正です\n"
 
-#: src/store.c:35580
+#: src/store.c:35623
 #, c-format
 msgid "missing key for meta set\n"
 msgstr "meta set の key が不足しています\n"
 
-#: src/store.c:35580
+#: src/store.c:35623
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:35592
+#: src/store.c:35635
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr "meta mark-leaked の key が不足しています\n"
 
-#: src/store.c:35592
+#: src/store.c:35635
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr "meta mark-leaked の引数が不正です\n"
 
-#: src/store.c:35615
+#: src/store.c:35658
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr "meta unset の key が不足しています\n"
 
-#: src/store.c:35615
+#: src/store.c:35658
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr "meta unset の引数が不正です\n"
 
-#: src/store.c:35914
+#: src/store.c:35957
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr "relation kind が不正です: %s\n"
 
-#: src/store.c:35958
+#: src/store.c:36001
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr "relation member は ephemeral secret を参照できません: %s\n"
 
-#: src/store.c:35964
+#: src/store.c:36007
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr "relation member は hidden v2 key を参照できません: %s\n"
 
-#: src/store.c:36001 src/store.c:36008
+#: src/store.c:36044 src/store.c:36051
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr "relation set の引数が不正です\n"
 
-#: src/store.c:36008
+#: src/store.c:36051
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr "relation set の relation id が不足しています\n"
 
-#: src/store.c:36014 src/store.c:37208 src/store.c:37257
+#: src/store.c:36057 src/store.c:37251 src/store.c:37300
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr "relation id が不正です: %s\n"
 
-#: src/store.c:36019
+#: src/store.c:36062
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 "relation set には少なくとも 2 つの --member ROLE=KEYREF option が必要です\n"
 
-#: src/store.c:36031 src/store.c:37267
+#: src/store.c:36074 src/store.c:37310
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では relation を変更できません\n"
 
-#: src/store.c:36884 src/store.c:36890
+#: src/store.c:36927 src/store.c:36933
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr "relation suggest-link の引数が不正です\n"
 
-#: src/store.c:37083
+#: src/store.c:37126
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr "relation ls の引数が不正です\n"
 
-#: src/store.c:37102
+#: src/store.c:37145
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr "relation ls には登録済みの current domain が必要です\n"
 
-#: src/store.c:37155
+#: src/store.c:37198
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr "relation search には登録済みの current domain が必要です\n"
 
-#: src/store.c:37188
+#: src/store.c:37231
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の key が不足しています\n"
 
-#: src/store.c:37188
+#: src/store.c:37231
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の引数が不正です\n"
 
-#: src/store.c:37203
+#: src/store.c:37246
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr "relation show の relation id が不足しています\n"
 
-#: src/store.c:37203
+#: src/store.c:37246
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr "relation show の引数が不正です\n"
 
-#: src/store.c:37215
+#: src/store.c:37258
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr "relation show には登録済みの current domain が必要です\n"
 
-#: src/store.c:37252
+#: src/store.c:37295
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr "relation rm の relation id が不足しています\n"
 
-#: src/store.c:37252
+#: src/store.c:37295
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr "relation rm の引数が不正です\n"
 
-#: src/store.c:37297
+#: src/store.c:37340
 #, c-format
 msgid "missing key for exists\n"
 msgstr "exists のキーが不足しています\n"
 
-#: src/store.c:37302
+#: src/store.c:37345
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr "exists の引数が不正です\n"
 
-#: src/store.c:37331
+#: src/store.c:37374
 #, c-format
 msgid "missing key for id\n"
 msgstr "id のキーが不足しています\n"
 
-#: src/store.c:37336
+#: src/store.c:37379
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr "id の引数が不正です\n"
 
-#: src/store.c:37356
+#: src/store.c:37399
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr "secret id は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37384
+#: src/store.c:37427
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr "secret status の UUID が不足しています\n"
 
-#: src/store.c:37394
+#: src/store.c:37437
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:37399
+#: src/store.c:37442
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr "secret status の UUID が不正です: %s\n"
 
-#: src/store.c:37407
+#: src/store.c:37450
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr "secret status には登録済みの current domain が必要です\n"
 
-#: src/store.c:37419
+#: src/store.c:37462
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr "secret status は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37429
+#: src/store.c:37472
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr "secret object が見つかりません: %s\n"
 
-#: src/store.c:37433
+#: src/store.c:37476
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:37563
+#: src/store.c:37606
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr "key の値に NUL バイトが含まれているため shell escaped できません: %s\n"
 
-#: src/store.c:37577 src/store.c:37645
+#: src/store.c:37620 src/store.c:37688
 #, c-format
 msgid "failed to write standard output\n"
 msgstr "標準出力への書き込みに失敗しました\n"
 
-#: src/store.c:37626
+#: src/store.c:37669
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr "secret を端末へ書き出すことを拒否しました\n"
 
-#: src/store.c:37773 src/store.c:38314
+#: src/store.c:37816 src/store.c:38357
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
@@ -4949,96 +4973,96 @@ msgstr ""
 "ephemeral secret には key_visibility=unlocked と value_access=unlocked が必要"
 "です\n"
 
-#: src/store.c:37828 src/store.c:38789 src/store.c:47160
+#: src/store.c:37871 src/store.c:38832 src/store.c:47891
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では mutation planning はサポートされません\n"
 
-#: src/store.c:37843
+#: src/store.c:37886
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes はサポートされません\n"
 
-#: src/store.c:37948 src/store.c:38196 src/store.c:38206 src/store.c:38228
-#: src/store.c:38253 src/store.c:38262 src/store.c:38272 src/store.c:38301
-#: src/store.c:38377 src/store.c:38410 src/store.c:38419
+#: src/store.c:37991 src/store.c:38239 src/store.c:38249 src/store.c:38271
+#: src/store.c:38296 src/store.c:38305 src/store.c:38315 src/store.c:38344
+#: src/store.c:38420 src/store.c:38453 src/store.c:38462
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr "set の引数が不正です\n"
 
-#: src/store.c:37980
+#: src/store.c:38023
 #, fuzzy, c-format
 msgid "invalid generated secret charset\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:38001
+#: src/store.c:38044
 #, fuzzy, c-format
 msgid "generated secret charset is too large\n"
 msgstr "secret value が大きすぎます\n"
 
-#: src/store.c:38049
+#: src/store.c:38092
 #, fuzzy, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:38063 src/store.c:38072
+#: src/store.c:38106 src/store.c:38115
 #, fuzzy, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:38077
+#: src/store.c:38120
 #, fuzzy, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr "secret rename で環境変数名が重複しました: %s\n"
 
-#: src/store.c:38088
+#: src/store.c:38131
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38279
+#: src/store.c:38322
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr "環境変数が設定されていません: %s\n"
 
-#: src/store.c:38323
+#: src/store.c:38366
 #, c-format
 msgid "missing key for set\n"
 msgstr "set のキーが不足しています\n"
 
-#: src/store.c:38333
+#: src/store.c:38376
 #, fuzzy, c-format
 msgid "invalid arguments for generated set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:38359
+#: src/store.c:38402
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38383
+#: src/store.c:38426
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr "set --ephemeral は key を 1 つだけ受け付けます\n"
 
-#: src/store.c:38432
+#: src/store.c:38475
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr "端末から secret を読み取ることを拒否しました\n"
 
-#: src/store.c:38972
+#: src/store.c:39015
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr "key に継承された mask target がありません: %s\n"
 
-#: src/store.c:39081
+#: src/store.c:39124
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 "orphan mask chain が不正です。fsck --format v2 --dangling で確認してくださ"
 "い: %s\n"
 
-#: src/store.c:39090
+#: src/store.c:39133
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
@@ -5046,12 +5070,12 @@ msgstr ""
 "複数の orphan mask chain が key に一致します。list --all-masks --long で確認"
 "してください: %s\n"
 
-#: src/store.c:39119
+#: src/store.c:39162
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr "key に rebind 対象の mask barrier がありません: %s\n"
 
-#: src/store.c:39146
+#: src/store.c:39189
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -5062,27 +5086,27 @@ msgstr ""
 "ancestors と各 ancestor の id KEY で確認し、unmask せずに重複またはアクセス不"
 "能な候補を解消してください: %s\n"
 
-#: src/store.c:39167
+#: src/store.c:39210
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr "canonical mask には継承された v2 entry が必要です: %s\n"
 
-#: src/store.c:39225
+#: src/store.c:39268
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr "orphan mask barrier には mask --rebind が必要です: %s\n"
 
-#: src/store.c:39249
+#: src/store.c:39292
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr "canonical mask target が競合しています: %s\n"
 
-#: src/store.c:39255 src/store.c:39265
+#: src/store.c:39298 src/store.c:39308
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr "canonical mask name が競合しています: %s\n"
 
-#: src/store.c:39276
+#: src/store.c:39319
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
@@ -5091,7 +5115,7 @@ msgstr ""
 "target は別の chain ですでに mask されています。list --all-masks --long で確"
 "認し、unmask --dry-run --mask-chain で chain を選択してください: %s\n"
 
-#: src/store.c:39363
+#: src/store.c:39406
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
@@ -5099,7 +5123,7 @@ msgid ""
 msgstr ""
 "hidden-name mask は名前を露出せずに v1 rollback state へ投影できません: %s\n"
 
-#: src/store.c:39391
+#: src/store.c:39434
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
@@ -5109,38 +5133,38 @@ msgstr ""
 "認し、継承 v2 target が一つだけになってから mask --rebind を実行してくださ"
 "い: %s\n"
 
-#: src/store.c:39498 src/store.c:40306 src/store.c:40341 src/store.c:40348
-#: src/store.c:40445 src/store.c:40451
+#: src/store.c:39541 src/store.c:40349 src/store.c:40384 src/store.c:40391
+#: src/store.c:40488 src/store.c:40494
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr "mask operation plan のエンコードに失敗しました\n"
 
-#: src/store.c:39654
+#: src/store.c:39697
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では %s はサポートされません: %s\n"
 
-#: src/store.c:39704 src/store.c:39736
+#: src/store.c:39747 src/store.c:39779
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr "key はローカルに存在するため mask できません: %s\n"
 
-#: src/store.c:39856
+#: src/store.c:39899
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr "一致する mask state が lock されているため unmask できません\n"
 
-#: src/store.c:39872
+#: src/store.c:39915
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr "曖昧な legacy mask は unmask の前に mask --rebind が必要です: %s\n"
 
-#: src/store.c:39905
+#: src/store.c:39948
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr "mask chain は要求した key を保護していません: %s\n"
 
-#: src/store.c:39913
+#: src/store.c:39956
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
@@ -5149,17 +5173,17 @@ msgstr ""
 "複数の mask chain が key に一致します。list --all-masks --long と --mask-"
 "chain を使ってください: %s\n"
 
-#: src/store.c:39979
+#: src/store.c:40022
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr "plan 作成後に mask state が変更されました\n"
 
-#: src/store.c:39986 src/store.c:40624 src/store.c:40636
+#: src/store.c:40029 src/store.c:40667 src/store.c:40679
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr "key は現在の domain で mask されていません: %s\n"
 
-#: src/store.c:40019
+#: src/store.c:40062
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
@@ -5168,7 +5192,7 @@ msgstr ""
 "mask chain は複数の key name を保護しています。unmask --dry-run --mask-chain "
 "で確認してください: %s\n"
 
-#: src/store.c:40621
+#: src/store.c:40664
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
@@ -5176,59 +5200,59 @@ msgid ""
 msgstr ""
 "揮発セッション overlay が有効な間は永続 tombstone を unmask できません: %s\n"
 
-#: src/store.c:40670
+#: src/store.c:40713
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr "ln の UUID source が不正です: %s\n"
 
-#: src/store.c:40704
+#: src/store.c:40747
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr "secret UUID は現在の context で認可されていません: %s\n"
 
-#: src/store.c:40846 src/store.c:40852
+#: src/store.c:40889 src/store.c:40895
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr "ln の引数が不正です\n"
 
-#: src/store.c:40857
+#: src/store.c:40900
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr "--skip-same-value-check には --replace が必要です\n"
 
-#: src/store.c:40911 src/store.c:41219 src/store.c:42328 src/store.c:42773
-#: src/store.c:45318
+#: src/store.c:40954 src/store.c:41262 src/store.c:42772 src/store.c:43282
+#: src/store.c:45837
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr "destination key はすでに存在します: %s\n"
 
-#: src/store.c:40963
+#: src/store.c:41006
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr "UUID reference は ln source としてのみ有効です: %s\n"
 
-#: src/store.c:40968 src/store.c:41003 src/store.c:41082 src/store.c:41166
-#: src/store.c:41190 src/store.c:42719 src/store.c:42743
+#: src/store.c:41011 src/store.c:41046 src/store.c:41125 src/store.c:41209
+#: src/store.c:41233 src/store.c:43228 src/store.c:43252
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr "source key と destination key は異なる必要があります\n"
 
-#: src/store.c:41019
+#: src/store.c:41062
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では ln はサポートされません\n"
 
-#: src/store.c:41030 src/store.c:41055
+#: src/store.c:41073 src/store.c:41098
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr "ln には v2 store 内の source と destination が必要です\n"
 
-#: src/store.c:41051 src/store.c:41063
+#: src/store.c:41094 src/store.c:41106
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では ln はサポートされません: %s\n"
 
-#: src/store.c:41069
+#: src/store.c:41112
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
@@ -5237,12 +5261,12 @@ msgstr ""
 "destination key はすでに存在します: %s (値確認後に同名 key を置換するには --"
 "replace を使用してください)\n"
 
-#: src/store.c:41075
+#: src/store.c:41118
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr "ln --replace は既存の同名 key reference のみサポートします\n"
 
-#: src/store.c:41102
+#: src/store.c:41145
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
@@ -5251,75 +5275,93 @@ msgstr ""
 "同名 destination の値が異なります: %s (それでも置換するには --replace と --"
 "skip-same-value-check を併用してください)\n"
 
-#: src/store.c:41161
+#: src/store.c:41204
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr "cp の引数が不正です\n"
 
-#: src/store.c:41232
+#: src/store.c:41275
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では cp はサポートされません: %s\n"
 
-#: src/store.c:41256 src/store.c:42471 src/store.c:42847
+#: src/store.c:41299 src/store.c:42935 src/store.c:43366
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を保持できません: %s\n"
 
-#: src/store.c:41331
-#, fuzzy, c-format
-#| msgid "cannot index relation dependency: %s\n"
+#: src/store.c:41374
+#, c-format
 msgid "too many move relation dependencies\n"
-msgstr "relation dependency をindex化できません: %s\n"
+msgstr "mv の relation dependency が多すぎます\n"
 
-#: src/store.c:42334 src/store.c:42799
-#, fuzzy, c-format
-#| msgid "ln requires source and destination in v2 stores\n"
+#: src/store.c:41875
+#, c-format
+msgid "affected descendant mask is inaccessible: %s\n"
+msgstr "影響を受ける descendant mask にアクセスできません: %s\n"
+
+#: src/store.c:42778 src/store.c:43308
+#, c-format
 msgid "mv requires v2 source and destination stores\n"
-msgstr "ln には v2 store 内の source と destination が必要です\n"
+msgstr "mv の source と destination は v2 store である必要があります\n"
 
-#: src/store.c:42430
+#: src/store.c:42798
+#, c-format
+msgid ""
+"mv mutation planning requires a local source in the same v2 domain and "
+"store\n"
+msgstr ""
+"mv の mutation planning には同じ v2 domain/store 内の local source が必要で"
+"す\n"
+
+#: src/store.c:42894
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
+"namespace をまたぐ mv には正規化済み v2 object value storage が必要です\n"
 
-#: src/store.c:42714
+#: src/store.c:43223
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr "mv の引数が不正です\n"
 
-#: src/store.c:42787
+#: src/store.c:43296
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では mv はサポートされません: %s\n"
 
-#: src/store.c:42813
-#, fuzzy, c-format
-#| msgid "ln requires source and destination in v2 stores\n"
-msgid "mv requires matching source and destination store formats\n"
-msgstr "ln には v2 store 内の source と destination が必要です\n"
+#: src/store.c:43325 src/store.c:47921
+#, c-format
+msgid "mask mutation planning requires store format v2\n"
+msgstr "mask mutation planning には store format v2 が必要です\n"
 
-#: src/store.c:42977
+#: src/store.c:43332
+#, c-format
+msgid "mv requires matching source and destination store formats\n"
+msgstr ""
+"mv の source と destination の store format は一致している必要があります\n"
+
+#: src/store.c:43496
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr "%s の引数が不正です\n"
 
-#: src/store.c:43044
+#: src/store.c:43563
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr "mask planning と rebind には永続 v2 store が必要です\n"
 
-#: src/store.c:43073
+#: src/store.c:43592
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr "canonical mask planning には継承された v2 entry が必要です\n"
 
-#: src/store.c:43193
+#: src/store.c:43712
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr "unmask planning には永続 v2 store が必要です\n"
 
-#: src/store.c:43244
+#: src/store.c:43763
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
@@ -5328,7 +5370,7 @@ msgstr ""
 "warning: unmask: mask chain を削除しましたが、%s は他の %zu 個の chain また"
 "は barrier によって mask されたままです\n"
 
-#: src/store.c:43251
+#: src/store.c:43770
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
@@ -5337,274 +5379,269 @@ msgstr ""
 "warning: unmask: %s は local のままです。後で削除すると継承値が露出する可能性"
 "があります\n"
 
-#: src/store.c:43285
+#: src/store.c:43804
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr "ephemeral key が見つかりません: %s\n"
 
-#: src/store.c:43291
+#: src/store.c:43810
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 "継承された ephemeral key は削除できません。source domain を使用してください: "
 "%s\n"
 
-#: src/store.c:43333 src/store.c:43340
+#: src/store.c:43852 src/store.c:43859
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr "rm の引数が不正です\n"
 
-#: src/store.c:43468 src/store.c:43979 src/store.c:44337 src/store.c:44800
-#: src/store.c:44886
+#: src/store.c:43987 src/store.c:44498 src/store.c:44856 src/store.c:45319
+#: src/store.c:45405
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr "--store は store コマンドでは使えません\n"
 
-#: src/store.c:43568
+#: src/store.c:44087
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr "store migrate には登録済みの current domain が必要です\n"
 
-#: src/store.c:43579 src/store.c:44199 src/store.c:44921
+#: src/store.c:44098 src/store.c:44718 src/store.c:45440
 #, c-format
 msgid "store not found: %s\n"
 msgstr "store が見つかりません: %s\n"
 
-#: src/store.c:43590
+#: src/store.c:44109
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr "store format は v2 です。migration は不要です\n"
 
-#: src/store.c:43868
+#: src/store.c:44387
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr "v2 migration artifacts はすでに存在します\n"
 
-#: src/store.c:43937
+#: src/store.c:44456
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr "v2 migration verification に失敗しました\n"
 
-#: src/store.c:44189
+#: src/store.c:44708
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr "store finalize-migration には登録済みの current domain が必要です\n"
 
-#: src/store.c:44210
+#: src/store.c:44729
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 "store format は v1 です。finalize-migration には migrated v2 store が必要で"
 "す\n"
 
-#: src/store.c:44748
+#: src/store.c:45267
 #, fuzzy, c-format
 #| msgid "store is not empty: %s\n"
 msgid "domain is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:44805
+#: src/store.c:45324
 #, c-format
 msgid "missing store name for store create\n"
 msgstr "store create の store 名が不足しています\n"
 
-#: src/store.c:44810
+#: src/store.c:45329
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:44835
+#: src/store.c:45354
 #, c-format
 msgid "store already exists: %s\n"
 msgstr "store はすでに存在します: %s\n"
 
-#: src/store.c:44891
+#: src/store.c:45410
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr "store delete の store 名が不足しています\n"
 
-#: src/store.c:44896
+#: src/store.c:45415
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr "store delete の引数が不正です\n"
 
-#: src/store.c:44937
+#: src/store.c:45456
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:44946
+#: src/store.c:45465
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:44990
+#: src/store.c:45509
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr "key の値に NUL バイトが含まれているため export できません: %s\n"
 
-#: src/store.c:45190 src/store.c:45198
+#: src/store.c:45709 src/store.c:45717
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr "save の引数が不正です\n"
 
-#: src/store.c:45210
+#: src/store.c:45729
 msgid "Create secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを作成してください: "
 
-#: src/store.c:45211
+#: src/store.c:45730
 msgid "Confirm secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを再入力してください: "
 
-#: src/store.c:45267
+#: src/store.c:45786
 #, fuzzy, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45272
+#: src/store.c:45791
 #, fuzzy, c-format
 msgid "conflicting load conflict policies\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45285 src/store.c:45291
+#: src/store.c:45804 src/store.c:45810
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr "load の引数が不正です\n"
 
-#: src/store.c:45350
+#: src/store.c:45869
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45351
+#: src/store.c:45870
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45385
+#: src/store.c:45904
 msgid "Enter secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを入力してください: "
 
-#: src/store.c:45864
+#: src/store.c:46383
 #, c-format
 msgid "  dir=%s\n"
 msgstr "  dir=%s\n"
 
-#: src/store.c:45867
+#: src/store.c:46386
 #, c-format
 msgid "  domain=%s\n"
 msgstr "  domain=%s\n"
 
-#: src/store.c:45870
+#: src/store.c:46389
 #, c-format
 msgid "  store=%s\n"
 msgstr "  store=%s\n"
 
-#: src/store.c:45909
+#: src/store.c:46428
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr "mask action が不正です: %s\n"
 
-#: src/store.c:45913
+#: src/store.c:46432
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr "mask action option が競合しています\n"
 
-#: src/store.c:45927
+#: src/store.c:46446
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr "mask warning option が競合しています\n"
 
-#: src/store.c:46008
+#: src/store.c:46527
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr "--mask-action に値が必要です\n"
 
-#: src/store.c:46038 src/store.c:46070
+#: src/store.c:46557 src/store.c:46589
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr "mask warning policy が不正です: %s\n"
 
-#: src/store.c:46049
+#: src/store.c:46568
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr "--mask-warnings に値が必要です\n"
 
-#: src/store.c:46523
+#: src/store.c:47105
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr "mutation で mask を保持できませんでした\n"
 
-#: src/store.c:46619 src/store.c:46769
+#: src/store.c:47204 src/store.c:47466
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr "mutation plan のエンコードに失敗しました\n"
 
-#: src/store.c:46832
+#: src/store.c:47563
 #, c-format
 msgid "warning: %s: "
 msgstr "warning: %s: "
 
-#: src/store.c:46846
+#: src/store.c:47577
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr "%zu 件の masked key slot に直接影響しました"
 
-#: src/store.c:46850
+#: src/store.c:47581
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr "%zu 件の mask が休眠状態になりました"
 
-#: src/store.c:46854
+#: src/store.c:47585
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr "%zu 件の休眠 mask が再活性化しました"
 
-#: src/store.c:46858
+#: src/store.c:47589
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr "%zu 件の mask が孤児化しました"
 
-#: src/store.c:46862
+#: src/store.c:47593
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr "%zu 件の source mask を作成しました"
 
-#: src/store.c:46866
+#: src/store.c:47597
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr "。'secdat --dir DIR list --all-masks --long' で確認してください\n"
 
-#: src/store.c:46988
+#: src/store.c:47719
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr "曖昧な legacy mask がこの mutation を拒否しました\n"
 
-#: src/store.c:46989
+#: src/store.c:47720
 msgid "mask interaction rejected before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:47172
+#: src/store.c:47903
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr "mutation planning には登録済みの current domain が必要です\n"
 
-#: src/store.c:47190
-#, c-format
-msgid "mask mutation planning requires store format v2\n"
-msgstr "mask mutation planning には store format v2 が必要です\n"
-
-#: src/store.c:47290
+#: src/store.c:48021
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr "mutation planning option は --ephemeral と併用できません\n"
 
-#: src/store.c:47308
+#: src/store.c:48039
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr "--dir と --domain は同時に指定できません\n"
 
-#: src/store.c:47322 src/store.c:47331
+#: src/store.c:48053 src/store.c:48062
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr "保留中 transaction の復旧に失敗しました\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 19:23+0900\n"
+"POT-Creation-Date: 2026-08-31 12:28+0900\n"
 "PO-Revision-Date: 2026-04-13 00:00+0000\n"
 "Last-Translator: GitHub Copilot <noreply@example.invalid>\n"
 "Language-Team: ja\n"
@@ -2167,38 +2167,38 @@ msgstr "試してください: %s help\n"
 #: src/exec_inject_policy_file.c:60 src/exec_inject_policy_file.c:103
 #: src/exec_inject_policy_file.c:128 src/exec_inject_policy_file.c:202
 #: src/exec_inject_policy_file.c:245 src/exec_inject_policy_file.c:283
-#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1571
-#: src/store.c:1587 src/store.c:1728 src/store.c:1763 src/store.c:1812
-#: src/store.c:1927 src/store.c:1936 src/store.c:1953 src/store.c:1962
-#: src/store.c:1976 src/store.c:1982 src/store.c:4568 src/store.c:4614
-#: src/store.c:4641 src/store.c:4687 src/store.c:4722 src/store.c:5141
-#: src/store.c:5598 src/store.c:5638 src/store.c:9689 src/store.c:10287
-#: src/store.c:10391 src/store.c:10441 src/store.c:10525 src/store.c:10533
-#: src/store.c:11063 src/store.c:11375 src/store.c:11484 src/store.c:11545
-#: src/store.c:11803 src/store.c:11912 src/store.c:11953 src/store.c:12026
-#: src/store.c:13241 src/store.c:13363 src/store.c:13384 src/store.c:13466
-#: src/store.c:13578 src/store.c:13746 src/store.c:13801 src/store.c:15144
-#: src/store.c:15621 src/store.c:15765 src/store.c:16162 src/store.c:16484
-#: src/store.c:16918 src/store.c:17157 src/store.c:17195 src/store.c:17509
-#: src/store.c:17615 src/store.c:17693 src/store.c:17707 src/store.c:17716
-#: src/store.c:17773 src/store.c:17786 src/store.c:17795 src/store.c:17916
-#: src/store.c:18052 src/store.c:18092 src/store.c:18103 src/store.c:18137
-#: src/store.c:18268 src/store.c:19172 src/store.c:19971 src/store.c:21156
-#: src/store.c:21182 src/store.c:21436 src/store.c:21486 src/store.c:21512
-#: src/store.c:21881 src/store.c:22285 src/store.c:22410 src/store.c:22439
-#: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
-#: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
-#: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
-#: src/store.c:29465 src/store.c:29500 src/store.c:29648 src/store.c:29847
-#: src/store.c:30893 src/store.c:31025 src/store.c:31641 src/store.c:36395
-#: src/store.c:36400 src/store.c:36737 src/store.c:36797 src/store.c:36803
-#: src/store.c:36878 src/store.c:36891 src/store.c:37939 src/store.c:38020
-#: src/store.c:38119 src/store.c:38157 src/store.c:40002 src/store.c:40090
-#: src/store.c:40140 src/store.c:41402 src/store.c:41563 src/store.c:41770
-#: src/store.c:43980 src/store.c:45536 src/store.c:45711 src/store.c:45953
-#: src/store.c:45978 src/store.c:46002 src/store.c:46082 src/store.c:46133
-#: src/store.c:46182 src/store.c:46222 src/store.c:46516 src/store.c:46824
-#: src/store.c:48122 src/store.c:48130
+#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1577
+#: src/store.c:1593 src/store.c:1734 src/store.c:1769 src/store.c:1818
+#: src/store.c:1933 src/store.c:1942 src/store.c:1959 src/store.c:1968
+#: src/store.c:1982 src/store.c:1988 src/store.c:4574 src/store.c:4620
+#: src/store.c:4647 src/store.c:4693 src/store.c:4728 src/store.c:5147
+#: src/store.c:5604 src/store.c:5644 src/store.c:9695 src/store.c:10293
+#: src/store.c:10397 src/store.c:10447 src/store.c:10531 src/store.c:10539
+#: src/store.c:11069 src/store.c:11381 src/store.c:11490 src/store.c:11551
+#: src/store.c:11809 src/store.c:11918 src/store.c:11959 src/store.c:12032
+#: src/store.c:13247 src/store.c:13369 src/store.c:13390 src/store.c:13472
+#: src/store.c:13584 src/store.c:13752 src/store.c:13807 src/store.c:15150
+#: src/store.c:15627 src/store.c:15771 src/store.c:16168 src/store.c:16490
+#: src/store.c:16924 src/store.c:17163 src/store.c:17201 src/store.c:17515
+#: src/store.c:17621 src/store.c:17699 src/store.c:17713 src/store.c:17722
+#: src/store.c:17779 src/store.c:17792 src/store.c:17801 src/store.c:17922
+#: src/store.c:18058 src/store.c:18098 src/store.c:18109 src/store.c:18143
+#: src/store.c:18274 src/store.c:19178 src/store.c:19977 src/store.c:21162
+#: src/store.c:21188 src/store.c:21442 src/store.c:21492 src/store.c:21518
+#: src/store.c:21887 src/store.c:22291 src/store.c:22416 src/store.c:22445
+#: src/store.c:22496 src/store.c:22791 src/store.c:23394 src/store.c:23881
+#: src/store.c:24500 src/store.c:25034 src/store.c:25638 src/store.c:25675
+#: src/store.c:25924 src/store.c:25966 src/store.c:26073 src/store.c:26104
+#: src/store.c:29500 src/store.c:29535 src/store.c:29683 src/store.c:29882
+#: src/store.c:30928 src/store.c:31060 src/store.c:31676 src/store.c:36430
+#: src/store.c:36435 src/store.c:36772 src/store.c:36832 src/store.c:36838
+#: src/store.c:36913 src/store.c:36926 src/store.c:37974 src/store.c:38055
+#: src/store.c:38154 src/store.c:38192 src/store.c:40037 src/store.c:40125
+#: src/store.c:40175 src/store.c:41437 src/store.c:41598 src/store.c:41805
+#: src/store.c:44067 src/store.c:45623 src/store.c:45798 src/store.c:46040
+#: src/store.c:46065 src/store.c:46089 src/store.c:46169 src/store.c:46220
+#: src/store.c:46269 src/store.c:46309 src/store.c:46603 src/store.c:46913
+#: src/store.c:48216 src/store.c:48224
 #, c-format
 msgid "out of memory\n"
 msgstr "メモリ不足です\n"
@@ -2209,18 +2209,18 @@ msgstr "メモリ不足です\n"
 #: src/domain.c:955 src/domain.c:990 src/domain.c:1002 src/domain.c:1006
 #: src/domain.c:1101 src/domain.c:1234 src/domain.c:1356 src/domain.c:1364
 #: src/domain.c:1451 src/domain.c:1513 src/domain.c:1590 src/secdat-fuse.c:186
-#: src/store.c:2003 src/store.c:2021 src/store.c:3492 src/store.c:3499
-#: src/store.c:3517 src/store.c:4466 src/store.c:4736 src/store.c:4840
-#: src/store.c:4867 src/store.c:4894 src/store.c:5320 src/store.c:5518
-#: src/store.c:5688 src/store.c:5711 src/store.c:5727 src/store.c:6409
-#: src/store.c:7849 src/store.c:8354 src/store.c:8378 src/store.c:10230
-#: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
-#: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
-#: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
-#: src/store.c:19220 src/store.c:19581 src/store.c:30853 src/store.c:30975
-#: src/store.c:31280 src/store.c:33993 src/store.c:34200 src/store.c:34239
-#: src/store.c:34300 src/store.c:34525 src/store.c:34593 src/store.c:38832
-#: src/store.c:39746 src/store.c:40665
+#: src/store.c:2009 src/store.c:2027 src/store.c:3498 src/store.c:3505
+#: src/store.c:3523 src/store.c:4472 src/store.c:4742 src/store.c:4846
+#: src/store.c:4873 src/store.c:4900 src/store.c:5326 src/store.c:5524
+#: src/store.c:5694 src/store.c:5717 src/store.c:5733 src/store.c:6415
+#: src/store.c:7855 src/store.c:8360 src/store.c:8384 src/store.c:10236
+#: src/store.c:10562 src/store.c:14307 src/store.c:14317 src/store.c:14335
+#: src/store.c:14370 src/store.c:14423 src/store.c:15876 src/store.c:17863
+#: src/store.c:17882 src/store.c:18772 src/store.c:18786 src/store.c:18800
+#: src/store.c:19226 src/store.c:19587 src/store.c:30888 src/store.c:31010
+#: src/store.c:31315 src/store.c:34028 src/store.c:34235 src/store.c:34274
+#: src/store.c:34335 src/store.c:34560 src/store.c:34628 src/store.c:38867
+#: src/store.c:39781 src/store.c:40700
 #, c-format
 msgid "path is too long\n"
 msgstr "パスが長すぎます\n"
@@ -2241,17 +2241,17 @@ msgstr "local-unlock"
 msgid "local-lock"
 msgstr "local-lock"
 
-#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12710
+#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12716
 msgid "locked"
 msgstr "ロック中"
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
-#: src/store.c:12711
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12682 src/store.c:12700
+#: src/store.c:12717
 msgid "wrapped master key: present"
 msgstr "ラップ済み master key: あり"
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
-#: src/store.c:12711
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12682 src/store.c:12700
+#: src/store.c:12717
 msgid "wrapped master key: absent"
 msgstr "ラップ済み master key: なし"
 
@@ -2263,7 +2263,7 @@ msgstr "orphaned"
 msgid "session"
 msgstr "session"
 
-#: src/domain.c:383 src/store.c:12674 src/store.c:12684
+#: src/domain.c:383 src/store.c:12680 src/store.c:12690
 msgid "unlocked"
 msgstr "アンロック済み"
 
@@ -2299,18 +2299,18 @@ msgstr "WRAPPED"
 msgid "DOMAIN"
 msgstr "DOMAIN"
 
-#: src/domain.c:639 src/store.c:5706
+#: src/domain.c:639 src/store.c:5712
 #, c-format
 msgid "HOME is not set\n"
 msgstr "HOME が設定されていません\n"
 
-#: src/domain.c:795 src/store.c:5591 src/store.c:5612
+#: src/domain.c:795 src/store.c:5597 src/store.c:5618
 #, c-format
 msgid "failed to open file: %s\n"
 msgstr "ファイルのオープンに失敗しました: %s\n"
 
-#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5645
-#: src/store.c:19989
+#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5651
+#: src/store.c:19995
 #, c-format
 msgid "failed to read file: %s\n"
 msgstr "ファイルの読み取りに失敗しました: %s\n"
@@ -2326,13 +2326,13 @@ msgid "domain root identity mismatch for: %s\n"
 msgstr "domain root identity が一致しません: %s\n"
 
 #: src/domain.c:911 src/domain.c:995 src/domain.c:1447 src/secdat-fuse.c:182
-#: src/store.c:2016
+#: src/store.c:2022
 #, c-format
 msgid "failed to resolve directory: %s\n"
 msgstr "ディレクトリの解決に失敗しました: %s\n"
 
-#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5297
-#: src/store.c:5344
+#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5303
+#: src/store.c:5350
 #, c-format
 msgid "not a directory: %s\n"
 msgstr "ディレクトリではありません: %s\n"
@@ -2352,7 +2352,7 @@ msgstr "domain が見つかりません: %s\n"
 msgid "failed to generate domain id\n"
 msgstr "domain id の生成に失敗しました\n"
 
-#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43928
+#: src/domain.c:1268 src/store.c:4780 src/store.c:13855 src/store.c:44015
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr "ディレクトリのオープンに失敗しました: %s\n"
@@ -2405,8 +2405,8 @@ msgstr "DOMAIN\tKEY_SOURCE\tEFFECTIVE\tREMAINING\tSTATE_SOURCE\tSTORES\tVISIBLE\
 msgid "invalid arguments for domain status\n"
 msgstr "domain status の引数が不正です\n"
 
-#: src/domain.c:2288 src/store.c:2266 src/store.c:2272 src/store.c:10037
-#: src/store.c:12795
+#: src/domain.c:2288 src/store.c:2272 src/store.c:2278 src/store.c:10043
+#: src/store.c:12801
 #, c-format
 msgid "resolved domain: %s\n"
 msgstr "解決された domain: %s\n"
@@ -2480,7 +2480,7 @@ msgstr "有効な取得元: inherited lock"
 msgid "effective source: locked"
 msgstr "実効取得元: locked"
 
-#: src/domain.c:2355 src/store.c:46402
+#: src/domain.c:2355 src/store.c:46489
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr "コマンドは未実装です: %s\n"
@@ -2548,7 +2548,7 @@ msgstr "不正な secret rename 式です\n"
 msgid "invalid secret rename regex: %s\n"
 msgstr "不正な secret rename 正規表現です: %s\n"
 
-#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45649 src/store.c:45719
+#: src/exec_inject.c:834 src/store.c:3547 src/store.c:45736 src/store.c:45806
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr "key は有効な環境変数名ではありません: %s\n"
@@ -2919,38 +2919,38 @@ msgstr "secdat-fuse mountpoint の unmount に失敗しました: %s\n"
 msgid "failed to create pipe\n"
 msgstr "pipe の作成に失敗しました\n"
 
-#: src/store.c:1630
+#: src/store.c:1636
 #, c-format
 msgid ""
 "deferred GC remains queued because the owner agent could not be upgraded\n"
 msgstr ""
 
-#: src/store.c:1639
+#: src/store.c:1645
 #, c-format
 msgid "deferred GC remains queued because the owner agent lacks GC_WORKER_V1\n"
 msgstr ""
 
-#: src/store.c:2061
+#: src/store.c:2067
 #, c-format
 msgid "writes to the default domain are not supported\n"
 msgstr "default domain への書き込みはサポートされていません\n"
 
-#: src/store.c:2138 src/store.c:5489
+#: src/store.c:2144 src/store.c:5495
 #, c-format
 msgid "failed to remove file: %s\n"
 msgstr "ファイルの削除に失敗しました: %s\n"
 
-#: src/store.c:2198
+#: src/store.c:2204
 #, c-format
 msgid "note: %zu descendant domains can now reuse this session\n"
 msgstr "補足: %zu 個の descendant domain がこの session を再利用できます\n"
 
-#: src/store.c:2201 src/store.c:2238
+#: src/store.c:2207 src/store.c:2244
 #, c-format
 msgid "note: %zu orphaned descendant domains are not affected by unlock\n"
 msgstr "補足: %zu 個の orphaned descendant domain は unlock の対象外です\n"
 
-#: src/store.c:2203 src/store.c:2240
+#: src/store.c:2209 src/store.c:2246
 #, c-format
 msgid ""
 "recover or delete orphaned descendant: secdat domain move --from %s --to "
@@ -2959,68 +2959,68 @@ msgstr ""
 "orphaned descendant を復旧または削除: secdat domain move --from %s --to "
 "NEW_ROOT\n"
 
-#: src/store.c:2204 src/store.c:2241
+#: src/store.c:2210 src/store.c:2247
 #, c-format
 msgid "discard orphaned descendant: secdat --dir %s domain delete\n"
 msgstr "orphaned descendant を破棄: secdat --dir %s domain delete\n"
 
-#: src/store.c:2211
+#: src/store.c:2217
 #, c-format
 msgid "note: %zu descendant domains remain locked under this branch\n"
 msgstr ""
 "補足: この branch 配下では %zu 個の descendant domain がまだ locked のままで"
 "す\n"
 
-#: src/store.c:2212
+#: src/store.c:2218
 msgid "affected descendants:"
 msgstr "影響を受ける descendant:"
 
-#: src/store.c:2231
+#: src/store.c:2237
 #, c-format
 msgid "  %s\n"
 msgstr "  %s\n"
 
-#: src/store.c:2235
+#: src/store.c:2241
 #, c-format
 msgid "  ... and %zu more\n"
 msgstr "  ... さらに %zu 個\n"
 
-#: src/store.c:2245
+#: src/store.c:2251
 #, c-format
 msgid "inspect descendants: secdat --dir %s domain ls -l --descendants\n"
 msgstr "descendant を確認: secdat --dir %s domain ls -l --descendants\n"
 
-#: src/store.c:2247
+#: src/store.c:2253
 #, c-format
 msgid "inspect one descendant: secdat --dir %s domain status\n"
 msgstr "1 つの descendant を確認: secdat --dir %s domain status\n"
 
-#: src/store.c:2248
+#: src/store.c:2254
 #, c-format
 msgid "unlock one descendant: secdat --dir %s unlock\n"
 msgstr "1 つの descendant を unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2267
+#: src/store.c:2273
 #, c-format
 msgid "inspect current domain: secdat domain status\n"
 msgstr "現在の domain を確認: secdat domain status\n"
 
-#: src/store.c:2268
+#: src/store.c:2274
 #, c-format
 msgid "unlock current domain: secdat unlock\n"
 msgstr "現在の domain を unlock: secdat unlock\n"
 
-#: src/store.c:2273
+#: src/store.c:2279
 #, c-format
 msgid "inspect current domain: secdat --dir %s domain status\n"
 msgstr "現在の domain を確認: secdat --dir %s domain status\n"
 
-#: src/store.c:2274
+#: src/store.c:2280
 #, c-format
 msgid "unlock current domain: secdat --dir %s unlock\n"
 msgstr "現在の domain を unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2370
+#: src/store.c:2376
 #, c-format
 msgid ""
 "Hint: inspect migration first with `%s store migrate %s --to-format v2 --dry-"
@@ -3029,90 +3029,90 @@ msgstr ""
 "ヒント: 先に `%s store migrate %s --to-format v2 --dry-run` で migration を確"
 "認してください\n"
 
-#: src/store.c:2371
+#: src/store.c:2377
 #, c-format
 msgid "Hint: suppress migration hints with %s=1\n"
 msgstr "ヒント: migration hint を抑制するには %s=1 を設定してください\n"
 
-#: src/store.c:2402
+#: src/store.c:2408
 #, c-format
 msgid "invalid value for --unlock-timeout: %s\n"
 msgstr "--unlock-timeout の値が不正です: %s\n"
 
-#: src/store.c:2850
+#: src/store.c:2856
 #, c-format
 msgid "missing value for --unlock-timeout\n"
 msgstr "--unlock-timeout に値が必要です\n"
 
-#: src/store.c:2855 src/store.c:2864 src/store.c:2876
+#: src/store.c:2861 src/store.c:2870 src/store.c:2882
 #, c-format
 msgid "invalid arguments for get\n"
 msgstr "get の引数が不正です\n"
 
-#: src/store.c:2885
+#: src/store.c:2891
 #, c-format
 msgid "missing key for get\n"
 msgstr "get のキーが不足しています\n"
 
-#: src/store.c:2890
+#: src/store.c:2896
 #, c-format
 msgid "--unlock-timeout requires --on-demand-unlock or %s\n"
 msgstr "--unlock-timeout を使うには --on-demand-unlock または %s が必要です\n"
 
-#: src/store.c:2919
+#: src/store.c:2925
 #, c-format
 msgid "invalid value for --timeout: %s\n"
 msgstr "--timeout の値が不正です: %s\n"
 
-#: src/store.c:2926
+#: src/store.c:2932
 #, c-format
 msgid "missing value for --timeout\n"
 msgstr "--timeout に値が必要です\n"
 
-#: src/store.c:2935 src/store.c:2942 src/store.c:12724
+#: src/store.c:2941 src/store.c:2948 src/store.c:12730
 #, c-format
 msgid "invalid arguments for wait-unlock\n"
 msgstr "wait-unlock の引数が不正です\n"
 
-#: src/store.c:2964
+#: src/store.c:2970
 #, c-format
 msgid ""
 "waiting for another terminal to unlock secrets for resolved domain: %s\n"
 msgstr ""
 "別端末で secrets が unlock されるのを待機しています。解決済み domain: %s\n"
 
-#: src/store.c:2966 src/store.c:3029
+#: src/store.c:2972 src/store.c:3035
 #, c-format
 msgid "unlock from another terminal: secdat unlock\n"
 msgstr "別端末で unlock: secdat unlock\n"
 
-#: src/store.c:2968 src/store.c:3031
+#: src/store.c:2974 src/store.c:3037
 #, c-format
 msgid "unlock from another terminal: secdat --dir %s unlock\n"
 msgstr "別端末で unlock: secdat --dir %s unlock\n"
 
-#: src/store.c:2971
+#: src/store.c:2977
 #, c-format
 msgid "unlock wait timeout: %lld seconds\n"
 msgstr "unlock 待機タイムアウト: %lld 秒\n"
 
-#: src/store.c:3002
+#: src/store.c:3008
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock secrets after %lld seconds\n"
 msgstr "別端末での secrets の unlock 待機が %lld 秒でタイムアウトしました\n"
 
-#: src/store.c:3027
+#: src/store.c:3033
 #, c-format
 msgid "waiting for another terminal to unlock resolved domain: %s\n"
 msgstr "別端末で解決済み domain が unlock されるのを待機しています: %s\n"
 
-#: src/store.c:3034
+#: src/store.c:3040
 #, c-format
 msgid "wait-unlock timeout: %lld seconds\n"
 msgstr "wait-unlock タイムアウト: %lld 秒\n"
 
-#: src/store.c:3062
+#: src/store.c:3068
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock resolved domain after %lld "
@@ -3120,38 +3120,38 @@ msgid ""
 msgstr ""
 "別端末での解決済み domain の unlock 待機が %lld 秒でタイムアウトしました\n"
 
-#: src/store.c:3134 src/store.c:3146 src/store.c:3153 src/store.c:3165
-#: src/store.c:3170 src/store.c:3175 src/store.c:12780
+#: src/store.c:3140 src/store.c:3152 src/store.c:3159 src/store.c:3171
+#: src/store.c:3176 src/store.c:3181 src/store.c:12786
 #, c-format
 msgid "invalid arguments for unlock\n"
 msgstr "unlock の引数が不正です\n"
 
-#: src/store.c:3159
+#: src/store.c:3165
 #, c-format
 msgid "--duration and --until cannot be combined\n"
 msgstr "--duration と --until は同時に指定できません\n"
 
-#: src/store.c:3181
+#: src/store.c:3187
 #, c-format
 msgid "invalid value for --duration: %s\n"
 msgstr "--duration の値が不正です: %s\n"
 
-#: src/store.c:3186
+#: src/store.c:3192
 #, c-format
 msgid "invalid value for --until: %s\n"
 msgstr "--until の値が不正です: %s\n"
 
-#: src/store.c:3211 src/store.c:3220 src/store.c:3227 src/store.c:13161
+#: src/store.c:3217 src/store.c:3226 src/store.c:3233 src/store.c:13167
 #, c-format
 msgid "invalid arguments for passwd\n"
 msgstr "passwd の引数が不正です\n"
 
-#: src/store.c:3261 src/store.c:3268 src/store.c:3274 src/store.c:13043
+#: src/store.c:3267 src/store.c:3274 src/store.c:3280 src/store.c:13049
 #, c-format
 msgid "invalid arguments for lock\n"
 msgstr "lock の引数が不正です\n"
 
-#: src/store.c:3293
+#: src/store.c:3299
 #, c-format
 msgid ""
 "cannot unlock descendant domains because an orphaned registered domain is in "
@@ -3160,17 +3160,17 @@ msgstr ""
 "この subtree に orphaned registered domain があるため descendant domain を "
 "unlock できません: %s\n"
 
-#: src/store.c:3294
+#: src/store.c:3300
 #, c-format
 msgid "recover it with: secdat domain move --from %s --to NEW_ROOT\n"
 msgstr "復旧する場合: secdat domain move --from %s --to NEW_ROOT\n"
 
-#: src/store.c:3295
+#: src/store.c:3301
 #, c-format
 msgid "or discard it with: secdat --dir %s domain delete\n"
 msgstr "破棄する場合: secdat --dir %s domain delete\n"
 
-#: src/store.c:3355
+#: src/store.c:3361
 #, c-format
 msgid ""
 "unlock --descendants requires confirmation on a terminal or rerun with --"
@@ -3179,24 +3179,24 @@ msgstr ""
 "unlock --descendants には端末での確認が必要です。非対話では --yes を付けて再"
 "実行してください\n"
 
-#: src/store.c:3362
+#: src/store.c:3368
 #, c-format
 msgid "failed to read confirmation\n"
 msgstr "確認入力の読み取りに失敗しました\n"
 
-#: src/store.c:3382
+#: src/store.c:3388
 msgid ""
 "unlock descendant domains in this subtree? local locks will remain [y/N]: "
 msgstr ""
 "この subtree の descendant domain を unlock しますか? local lock は残ります "
 "[y/N]: "
 
-#: src/store.c:3392
+#: src/store.c:3398
 #, c-format
 msgid "descendant unlock cancelled\n"
 msgstr "descendant unlock を中止しました\n"
 
-#: src/store.c:3425
+#: src/store.c:3431
 #, c-format
 msgid ""
 "note: unlocked %zu descendant domains in this subtree; local locks remain\n"
@@ -3204,22 +3204,22 @@ msgstr ""
 "注: この subtree で %zu 個の descendant domain を unlock しました。local "
 "lock は残ります\n"
 
-#: src/store.c:3451
+#: src/store.c:3457
 #, fuzzy, c-format
 msgid "invalid key reference\n"
 msgstr "不正なキー参照です: %s\n"
 
-#: src/store.c:3460 src/store.c:3486 src/store.c:3531
+#: src/store.c:3466 src/store.c:3492 src/store.c:3537
 #, c-format
 msgid "invalid key reference: %s\n"
 msgstr "不正なキー参照です: %s\n"
 
-#: src/store.c:3607
+#: src/store.c:3613
 #, c-format
 msgid "%s is no longer supported; use %s\n"
 msgstr "%s はサポートされなくなりました。%s を使ってください\n"
 
-#: src/store.c:3614
+#: src/store.c:3620
 #, c-format
 msgid ""
 "--inject is not valid for %s; use --bulk-select to set bulk_select policy "
@@ -3228,206 +3228,206 @@ msgstr ""
 "%s では --inject は使えません。bulk_select policy には --bulk-select を使って"
 "ください (exec の supply ルールには exec で --inject を使います)\n"
 
-#: src/store.c:3694
+#: src/store.c:3700
 #, c-format
 msgid "invalid arguments for ls\n"
 msgstr "ls の引数が不正です\n"
 
-#: src/store.c:3734 src/store.c:3749 src/store.c:3759
+#: src/store.c:3740 src/store.c:3755 src/store.c:3765
 #, c-format
 msgid "invalid arguments for export\n"
 msgstr "export の引数が不正です\n"
 
-#: src/store.c:3832 src/store.c:3839 src/store.c:3845 src/store.c:3851
-#: src/store.c:3857
+#: src/store.c:3838 src/store.c:3845 src/store.c:3851 src/store.c:3857
+#: src/store.c:3863
 #, c-format
 msgid "invalid arguments for list\n"
 msgstr "list の引数が不正です\n"
 
-#: src/store.c:3864
+#: src/store.c:3870
 #, c-format
 msgid "missing state filter for list\n"
 msgstr "list に state filter が必要です\n"
 
-#: src/store.c:3921 src/store.c:3935
+#: src/store.c:3927 src/store.c:3941
 #, c-format
 msgid "invalid arguments for attr\n"
 msgstr "attr の引数が不正です\n"
 
-#: src/store.c:3928
+#: src/store.c:3934
 #, c-format
 msgid "missing key for attr\n"
 msgstr "attr のキーが不足しています\n"
 
-#: src/store.c:3976
+#: src/store.c:3982
 #, c-format
 msgid "invalid fsck format: %s\n"
 msgstr "fsck format が不正です: %s\n"
 
-#: src/store.c:3990 src/store.c:3997
+#: src/store.c:3996 src/store.c:4003
 #, c-format
 msgid "invalid arguments for fsck\n"
 msgstr "fsck の引数が不正です\n"
 
-#: src/store.c:4009
+#: src/store.c:4015
 #, c-format
 msgid "fsck --repair is only supported with --format v2\n"
 msgstr "fsck --repair は --format v2 でのみサポートされています\n"
 
-#: src/store.c:4013
+#: src/store.c:4019
 #, c-format
 msgid "fsck --repair currently requires --refcount\n"
 msgstr "fsck --repair には現在 --refcount が必要です\n"
 
-#: src/store.c:4018
+#: src/store.c:4024
 #, c-format
 msgid "fsck --dependency-index requires --format v2\n"
 msgstr "fsck --dependency-index には --format v2 が必要です\n"
 
-#: src/store.c:4023
+#: src/store.c:4029
 #, c-format
 msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4048
+#: src/store.c:4054
 #, c-format
 msgid "invalid gc format: %s\n"
 msgstr "gc format が不正です: %s\n"
 
-#: src/store.c:4103
+#: src/store.c:4109
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --errors requires --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4107
+#: src/store.c:4113
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --json requires --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4118
+#: src/store.c:4124
 #, fuzzy, c-format
 #| msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgid "gc --status cannot be combined with mutation selectors\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4130
+#: src/store.c:4136
 #, fuzzy, c-format
 #| msgid "invalid arguments for domain ls\n"
 msgid "invalid GC owner domain ID\n"
 msgstr "domain ls の引数が不正です\n"
 
-#: src/store.c:4138
+#: src/store.c:4144
 #, fuzzy, c-format
 #| msgid "--json requires --dry-run\n"
 msgid "gc --owner requires --queued or --status\n"
 msgstr "--json には --dry-run が必要です\n"
 
-#: src/store.c:4143
+#: src/store.c:4149
 #, c-format
 msgid "gc --owner cannot select a full-store sweep\n"
 msgstr ""
 
-#: src/store.c:4161
+#: src/store.c:4167
 #, fuzzy, c-format
 #| msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgid "gc --repair-epoch cannot be combined with another selector\n"
 msgstr "fsck --dependency-index はstore検査と組み合わせられません\n"
 
-#: src/store.c:4173 src/store.c:4194
+#: src/store.c:4179 src/store.c:4200
 #, fuzzy, c-format
 #| msgid "invalid transaction directory: %s\n"
 msgid "invalid GC quarantine selectors\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:4184
+#: src/store.c:4190
 #, fuzzy, c-format
 #| msgid "invalid secret bundle\n"
 msgid "invalid GC candidate handle\n"
 msgstr "secret bundle が不正です\n"
 
-#: src/store.c:4250 src/store.c:4257
+#: src/store.c:4256 src/store.c:4263
 #, c-format
 msgid "invalid arguments for gc\n"
 msgstr "gc の引数が不正です\n"
 
-#: src/store.c:4298
+#: src/store.c:4304
 #, c-format
 msgid "invalid migration target format: %s\n"
 msgstr "migration target format が不正です: %s\n"
 
-#: src/store.c:4309 src/store.c:4321
+#: src/store.c:4315 src/store.c:4327
 #, c-format
 msgid "invalid arguments for store migrate\n"
 msgstr "store migrate の引数が不正です\n"
 
-#: src/store.c:4316
+#: src/store.c:4322
 #, c-format
 msgid "missing store name for store migrate\n"
 msgstr "store migrate の store 名が不足しています\n"
 
-#: src/store.c:4326
+#: src/store.c:4332
 #, c-format
 msgid "store migrate requires --to-format v2\n"
 msgstr "store migrate には --to-format v2 が必要です\n"
 
-#: src/store.c:4356
+#: src/store.c:4362
 #, c-format
 msgid "invalid migration source format: %s\n"
 msgstr "migration source format が不正です: %s\n"
 
-#: src/store.c:4367 src/store.c:4379
+#: src/store.c:4373 src/store.c:4385
 #, c-format
 msgid "invalid arguments for store finalize-migration\n"
 msgstr "store finalize-migration の引数が不正です\n"
 
-#: src/store.c:4374
+#: src/store.c:4380
 #, c-format
 msgid "missing store name for store finalize-migration\n"
 msgstr "store finalize-migration の store 名が不足しています\n"
 
-#: src/store.c:4384
+#: src/store.c:4390
 #, c-format
 msgid "store finalize-migration requires --from-format v1\n"
 msgstr "store finalize-migration には --from-format v1 が必要です\n"
 
-#: src/store.c:4410 src/store.c:4421 src/store.c:4431
+#: src/store.c:4416 src/store.c:4427 src/store.c:4437
 #, c-format
 msgid "invalid arguments for store ls\n"
 msgstr "store ls の引数が不正です\n"
 
-#: src/store.c:4609
+#: src/store.c:4615
 #, c-format
 msgid "secret value is too large\n"
 msgstr "secret value が大きすぎます\n"
 
-#: src/store.c:4636 src/store.c:4649
+#: src/store.c:4642 src/store.c:4655
 #, c-format
 msgid "invalid overlay payload\n"
 msgstr "overlay payload が不正です\n"
 
-#: src/store.c:4949 src/store.c:30873
+#: src/store.c:4955 src/store.c:30908
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr "key visibility が不正です: %s\n"
 
-#: src/store.c:4963
+#: src/store.c:4969
 #, c-format
 msgid "invalid value access: %s\n"
 msgstr "value access が不正です: %s\n"
 
-#: src/store.c:5021
+#: src/store.c:5027
 #, c-format
 msgid "invalid bulk select policy: %s; use %s\n"
 msgstr "bulk select policy が不正です: %s。%s を使ってください\n"
 
-#: src/store.c:5024 src/store.c:5033
+#: src/store.c:5030 src/store.c:5039
 #, c-format
 msgid "invalid bulk select policy: %s\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:5065
+#: src/store.c:5071
 #, c-format
 msgid ""
 "key_visibility=unlocked requires store format v2; run store migrate STORE --"
@@ -3436,164 +3436,164 @@ msgstr ""
 "key_visibility=unlocked には store format v2 が必要です。先に store migrate "
 "STORE --to-format v2 --dry-run を実行してください\n"
 
-#: src/store.c:5096 src/store.c:5135
+#: src/store.c:5102 src/store.c:5141
 #, c-format
 msgid "invalid secret metadata\n"
 msgstr "secret metadata が不正です\n"
 
-#: src/store.c:5113
+#: src/store.c:5119
 #, c-format
 msgid "unsupported secret metadata field: %s\n"
 msgstr "サポートされていない secret metadata field です: %s\n"
 
-#: src/store.c:5149
+#: src/store.c:5155
 #, c-format
 msgid "unsupported secret metadata format\n"
 msgstr "サポートされていない secret metadata format です\n"
 
-#: src/store.c:5243 src/store.c:31231 src/store.c:37788
+#: src/store.c:5249 src/store.c:31266 src/store.c:37823
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr "secret value_access が storage mode と一致しません\n"
 
-#: src/store.c:5260 src/store.c:30930 src/store.c:31007 src/store.c:31019
-#: src/store.c:31376
+#: src/store.c:5266 src/store.c:30965 src/store.c:31042 src/store.c:31054
+#: src/store.c:31411
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr "secret metadata が大きすぎます\n"
 
-#: src/store.c:5332 src/store.c:5339
+#: src/store.c:5338 src/store.c:5345
 #, c-format
 msgid "failed to create directory: %s\n"
 msgstr "ディレクトリの作成に失敗しました: %s\n"
 
-#: src/store.c:5513 src/store.c:19530
+#: src/store.c:5519 src/store.c:19536
 #, c-format
 msgid "invalid path: %s\n"
 msgstr "不正なパスです: %s\n"
 
-#: src/store.c:5528
+#: src/store.c:5534
 #, c-format
 msgid "failed to create temporary file for: %s\n"
 msgstr "一時ファイルの作成に失敗しました: %s\n"
 
-#: src/store.c:5533
+#: src/store.c:5539
 #, c-format
 msgid "failed to set permissions on: %s\n"
 msgstr "権限の設定に失敗しました: %s\n"
 
-#: src/store.c:5543
+#: src/store.c:5549
 #, c-format
 msgid "failed to write file: %s\n"
 msgstr "ファイルの書き込みに失敗しました: %s\n"
 
-#: src/store.c:5552
+#: src/store.c:5558
 #, c-format
 msgid "failed to fsync file: %s\n"
 msgstr "ファイルの fsync に失敗しました: %s\n"
 
-#: src/store.c:5559 src/store.c:19997
+#: src/store.c:5565 src/store.c:20003
 #, c-format
 msgid "failed to close file: %s\n"
 msgstr "ファイルのクローズに失敗しました: %s\n"
 
-#: src/store.c:5565
+#: src/store.c:5571
 #, c-format
 msgid "failed to rename file into place: %s\n"
 msgstr "ファイルの配置先への rename に失敗しました: %s\n"
 
-#: src/store.c:5618 src/store.c:5631
+#: src/store.c:5624 src/store.c:5637
 #, c-format
 msgid "failed to seek file: %s\n"
 msgstr "ファイルの seek に失敗しました: %s\n"
 
-#: src/store.c:5625
+#: src/store.c:5631
 #, c-format
 msgid "failed to determine file size: %s\n"
 msgstr "ファイルサイズの取得に失敗しました: %s\n"
 
-#: src/store.c:5744 src/store.c:12146
+#: src/store.c:5750 src/store.c:12152
 #, c-format
 msgid "failed to derive encryption key\n"
 msgstr "暗号化キーの導出に失敗しました\n"
 
-#: src/store.c:5827
+#: src/store.c:5833
 #, c-format
 msgid "%s must be an integer between %u and %u\n"
 msgstr "%s には %u から %u までの整数を指定してください\n"
 
-#: src/store.c:6424 src/store.c:6437 src/store.c:7948 src/store.c:7954
-#: src/store.c:7964 src/store.c:8012
+#: src/store.c:6430 src/store.c:6443 src/store.c:7954 src/store.c:7960
+#: src/store.c:7970 src/store.c:8018
 #, c-format
 msgid "failed to start session agent\n"
 msgstr "セッションエージェントの起動に失敗しました\n"
 
-#: src/store.c:6442 src/store.c:8019
+#: src/store.c:6448 src/store.c:8025
 #, c-format
 msgid "timed out waiting for session agent readiness\n"
 msgstr "セッションエージェントの準備完了待ちがタイムアウトしました\n"
 
-#: src/store.c:6869
+#: src/store.c:6875
 #, c-format
 msgid "failed to open file descriptor\n"
 msgstr "ファイル記述子のオープンに失敗しました\n"
 
-#: src/store.c:7858
+#: src/store.c:7864
 #, c-format
 msgid "failed to bind session agent socket\n"
 msgstr "セッションエージェントのソケット bind に失敗しました\n"
 
-#: src/store.c:7881
+#: src/store.c:7887
 #, c-format
 msgid "failed to listen on session agent socket\n"
 msgstr "セッションエージェントのソケット listen に失敗しました\n"
 
-#: src/store.c:8027
+#: src/store.c:8033
 #, c-format
 msgid "session agent failed before readiness\n"
 msgstr "セッションエージェントは準備完了前に失敗しました\n"
 
-#: src/store.c:8065
+#: src/store.c:8071
 #, c-format
 msgid "empty passphrase is not allowed\n"
 msgstr "空のパスフレーズは許可されません\n"
 
-#: src/store.c:8082
+#: src/store.c:8088
 #, c-format
 msgid "missing askpass provider\n"
 msgstr "askpass provider が不足しています\n"
 
-#: src/store.c:8087
+#: src/store.c:8093
 #, c-format
 msgid "missing askpass provider: %s\n"
 msgstr "askpass provider が見つかりません: %s\n"
 
-#: src/store.c:8089
+#: src/store.c:8095
 #, c-format
 msgid "unsupported askpass provider: %s\n"
 msgstr "サポートされていない askpass provider です: %s\n"
 
-#: src/store.c:8095 src/store.c:8103
+#: src/store.c:8101 src/store.c:8109
 #, c-format
 msgid "failed to start askpass command\n"
 msgstr "askpass コマンドの起動に失敗しました\n"
 
-#: src/store.c:8153
+#: src/store.c:8159
 #, c-format
 msgid "failed to read askpass output\n"
 msgstr "askpass 出力の読み取りに失敗しました\n"
 
-#: src/store.c:8160
+#: src/store.c:8166
 #, c-format
 msgid "askpass prompt cancelled\n"
 msgstr "askpass prompt がキャンセルされました\n"
 
-#: src/store.c:8165
+#: src/store.c:8171
 #, c-format
 msgid "askpass output is too long\n"
 msgstr "askpass 出力が長すぎます\n"
 
-#: src/store.c:8192
+#: src/store.c:8198
 #, c-format
 msgid ""
 "missing askpass provider; --gui requires --askpass, SECDAT_ASKPASS, or "
@@ -3602,7 +3602,7 @@ msgstr ""
 "askpass provider が不足しています。--gui には --askpass、SECDAT_ASKPASS、また"
 "は SSH_ASKPASS が必要です\n"
 
-#: src/store.c:8195
+#: src/store.c:8201
 #, c-format
 msgid ""
 "missing askpass provider; this command requires a terminal for passphrase "
@@ -3611,64 +3611,64 @@ msgstr ""
 "askpass provider が不足しています。このコマンドにはパスフレーズ入力用の端末が"
 "必要です\n"
 
-#: src/store.c:8203
+#: src/store.c:8209
 #, c-format
 msgid "failed to read terminal settings\n"
 msgstr "端末設定の読み取りに失敗しました\n"
 
-#: src/store.c:8210 src/store.c:8226
+#: src/store.c:8216 src/store.c:8232
 #, c-format
 msgid "failed to update terminal settings\n"
 msgstr "端末設定の更新に失敗しました\n"
 
-#: src/store.c:8216
+#: src/store.c:8222
 #, c-format
 msgid "failed to read passphrase\n"
 msgstr "パスフレーズの読み取りに失敗しました\n"
 
-#: src/store.c:8247
+#: src/store.c:8253
 msgid "Create secdat passphrase: "
 msgstr "secdat パスフレーズを作成してください: "
 
-#: src/store.c:8250
+#: src/store.c:8256
 msgid "Confirm secdat passphrase: "
 msgstr "secdat パスフレーズを再入力してください: "
 
-#: src/store.c:8257 src/store.c:8285
+#: src/store.c:8263 src/store.c:8291
 #, c-format
 msgid "passphrase confirmation did not match\n"
 msgstr "確認用パスフレーズが一致しません\n"
 
-#: src/store.c:8313
+#: src/store.c:8319
 msgid "Enter secdat passphrase: "
 msgstr "secdat パスフレーズを入力してください: "
 
-#: src/store.c:8346 src/store.c:8373
+#: src/store.c:8352 src/store.c:8379
 #, c-format
 msgid "failed to create session agent socket\n"
 msgstr "セッションエージェントのソケット作成に失敗しました\n"
 
-#: src/store.c:8383
+#: src/store.c:8389
 #, c-format
 msgid "failed to connect to session agent\n"
 msgstr "セッションエージェントへの接続に失敗しました\n"
 
-#: src/store.c:8765
+#: src/store.c:8771
 #, c-format
 msgid "failed to hand over the active session agent safely\n"
 msgstr "アクティブなセッションエージェントの安全な引継ぎに失敗しました\n"
 
-#: src/store.c:8884 src/store.c:8897 src/store.c:8921
+#: src/store.c:8890 src/store.c:8903 src/store.c:8927
 #, c-format
 msgid "invalid response from the active session agent\n"
 msgstr "アクティブなセッションエージェントから不正な応答が返されました\n"
 
-#: src/store.c:8930 src/store.c:9274 src/store.c:9588
+#: src/store.c:8936 src/store.c:9280 src/store.c:9594
 #, c-format
 msgid "failed to negotiate capabilities with the active session agent\n"
 msgstr "アクティブなセッションエージェントとの機能交渉に失敗しました\n"
 
-#: src/store.c:9058 src/store.c:9062
+#: src/store.c:9064 src/store.c:9068
 #, c-format
 msgid ""
 "failed to purge session-local ephemeral values from an active session agent\n"
@@ -3676,26 +3676,26 @@ msgstr ""
 "アクティブなセッションエージェントから session-local ephemeral 値を purge で"
 "きませんでした\n"
 
-#: src/store.c:9280 src/store.c:9594
+#: src/store.c:9286 src/store.c:9600
 #, c-format
 msgid "the active session agent cannot expose its volatile overlay safely\n"
 msgstr ""
 "アクティブなセッションエージェントは volatile overlay を安全に公開できませ"
 "ん\n"
 
-#: src/store.c:9303 src/store.c:9318 src/store.c:9617 src/store.c:9632
+#: src/store.c:9309 src/store.c:9324 src/store.c:9623 src/store.c:9638
 #, c-format
 msgid "legacy volatile session cannot be read safely by this secdat version\n"
 msgstr ""
 "旧式の volatile session はこの secdat バージョンでは安全に読み取れません\n"
 
-#: src/store.c:9306 src/store.c:9620
+#: src/store.c:9312 src/store.c:9626
 #, c-format
 msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 "アクティブなセッションエージェントが overlay protocol を完了しませんでした\n"
 
-#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37880
+#: src/store.c:9428 src/store.c:11476 src/store.c:11543 src/store.c:37915
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
@@ -3704,7 +3704,7 @@ msgstr ""
 "現在のセッションでは key は ephemeral です。更新には set --ephemeral を使用し"
 "てください: %s\n"
 
-#: src/store.c:9472 src/store.c:37845
+#: src/store.c:9478 src/store.c:37880
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
@@ -3713,7 +3713,7 @@ msgstr ""
 "key には volatile session change があるため ephemeral secret で置き換えられま"
 "せん: %s\n"
 
-#: src/store.c:9514 src/store.c:9553 src/store.c:38821
+#: src/store.c:9520 src/store.c:9559 src/store.c:38856
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
@@ -3722,7 +3722,7 @@ msgstr ""
 "現在のセッションでは key は ephemeral です。削除には rm --ephemeral を使用し"
 "てください: %s\n"
 
-#: src/store.c:9903
+#: src/store.c:9909
 #, c-format
 msgid ""
 "per-key ephemeral secrets require an active secdat session agent; run secdat "
@@ -3731,172 +3731,172 @@ msgstr ""
 "key ごとの ephemeral secret には active secdat session agent が必要です。先"
 "に secdat unlock を実行してください\n"
 
-#: src/store.c:9909
+#: src/store.c:9915
 #, c-format
 msgid "current session is readonly and cannot store an ephemeral secret\n"
 msgstr ""
 "現在のセッションは読み取り専用のため ephemeral secret を保存できません\n"
 
-#: src/store.c:10039
+#: src/store.c:10045
 #, c-format
 msgid "unlock writable session: secdat unlock\n"
 msgstr "書き込み可能セッションを開始: secdat unlock\n"
 
-#: src/store.c:10041
+#: src/store.c:10047
 #, c-format
 msgid "unlock writable session: secdat --dir %s unlock\n"
 msgstr "書き込み可能セッションを開始: secdat --dir %s unlock\n"
 
-#: src/store.c:10050
+#: src/store.c:10056
 #, c-format
 msgid "current session is readonly and cannot run %s\n"
 msgstr "現在のセッションは読み取り専用のため %s を実行できません\n"
 
-#: src/store.c:10112 src/store.c:38787 src/store.c:38933 src/store.c:40990
+#: src/store.c:10118 src/store.c:38822 src/store.c:38968 src/store.c:41025
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr "key の削除に失敗しました: %s\n"
 
-#: src/store.c:10128 src/store.c:10133
+#: src/store.c:10134 src/store.c:10139
 #, c-format
 msgid "lock --save requires a local volatile session\n"
 msgstr "lock --save にはローカルの揮発セッションが必要です\n"
 
-#: src/store.c:10213
+#: src/store.c:10219
 #, c-format
 msgid "invalid wrap key iteration count\n"
 msgstr "wrap key の iteration count が不正です\n"
 
-#: src/store.c:10217
+#: src/store.c:10223
 #, c-format
 msgid "failed to derive wrap key\n"
 msgstr "wrap key の導出に失敗しました\n"
 
-#: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
-#: src/store.c:13458 src/store.c:30716
+#: src/store.c:10240 src/store.c:10283 src/store.c:11799 src/store.c:13239
+#: src/store.c:13464 src/store.c:30751
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr "nonce の生成に失敗しました\n"
 
-#: src/store.c:10303 src/store.c:11819 src/store.c:13255 src/store.c:13480
+#: src/store.c:10309 src/store.c:11825 src/store.c:13261 src/store.c:13486
 #, c-format
 msgid "failed to create encryption context\n"
 msgstr "暗号化 context の作成に失敗しました\n"
 
-#: src/store.c:10309 src/store.c:11825 src/store.c:13262 src/store.c:13486
+#: src/store.c:10315 src/store.c:11831 src/store.c:13268 src/store.c:13492
 #, c-format
 msgid "failed to initialize encryption\n"
 msgstr "暗号化の初期化に失敗しました\n"
 
-#: src/store.c:10319 src/store.c:11839 src/store.c:13273 src/store.c:13490
-#: src/store.c:13500
+#: src/store.c:10325 src/store.c:11845 src/store.c:13279 src/store.c:13496
+#: src/store.c:13506
 #, c-format
 msgid "failed to encrypt value\n"
 msgstr "値の暗号化に失敗しました\n"
 
-#: src/store.c:10327 src/store.c:11847 src/store.c:13278 src/store.c:13504
+#: src/store.c:10333 src/store.c:11853 src/store.c:13284 src/store.c:13510
 #, c-format
 msgid "failed to finalize encryption\n"
 msgstr "暗号化の finalization に失敗しました\n"
 
-#: src/store.c:10332 src/store.c:11852 src/store.c:13284 src/store.c:13509
+#: src/store.c:10338 src/store.c:11858 src/store.c:13290 src/store.c:13515
 #, c-format
 msgid "failed to obtain authentication tag\n"
 msgstr "認証タグの取得に失敗しました\n"
 
-#: src/store.c:10374 src/store.c:10382 src/store.c:12066
+#: src/store.c:10380 src/store.c:10388 src/store.c:12072
 #, c-format
 msgid "invalid wrapped master key\n"
 msgstr "ラップ済み master key が不正です\n"
 
-#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45962
-#: src/store.c:45993 src/store.c:46013 src/store.c:46036 src/store.c:46204
-#: src/store.c:46212 src/store.c:46234 src/store.c:46250
+#: src/store.c:10472 src/store.c:11897 src/store.c:11908 src/store.c:46049
+#: src/store.c:46080 src/store.c:46100 src/store.c:46123 src/store.c:46291
+#: src/store.c:46299 src/store.c:46321 src/store.c:46337
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr "secret bundle が不正です\n"
 
-#: src/store.c:10518
+#: src/store.c:10524
 #, fuzzy, c-format
 msgid "secret bundle has too many objects\n"
 msgstr "secret bundle が大きすぎます\n"
 
-#: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
-#: src/store.c:18176 src/store.c:18225 src/store.c:35358 src/store.c:35540
-#: src/store.c:37414 src/store.c:38876 src/store.c:38899 src/store.c:38953
-#: src/store.c:39224 src/store.c:39778 src/store.c:39810 src/store.c:41110
-#: src/store.c:42797
+#: src/store.c:10634 src/store.c:10785 src/store.c:14582 src/store.c:14778
+#: src/store.c:18182 src/store.c:18231 src/store.c:35393 src/store.c:35575
+#: src/store.c:37449 src/store.c:38911 src/store.c:38934 src/store.c:38988
+#: src/store.c:39259 src/store.c:39813 src/store.c:39845 src/store.c:41145
+#: src/store.c:42875
 #, c-format
 msgid "key not found: %s\n"
 msgstr "key が見つかりません: %s\n"
 
-#: src/store.c:10686
+#: src/store.c:10692
 #, c-format
 msgid "secret bundle entry is too large\n"
 msgstr "secret bundle のエントリが大きすぎます\n"
 
-#: src/store.c:10696
+#: src/store.c:10702
 #, fuzzy, c-format
 msgid "secret bundle value is unavailable for a selected v2 object\n"
 msgstr "secret id は store format v2 でのみ利用できます\n"
 
-#: src/store.c:10786
+#: src/store.c:10792
 #, c-format
 msgid "save is not supported while an ephemeral secret is visible: %s\n"
 msgstr "ephemeral secret が見えている間は save を使用できません: %s\n"
 
-#: src/store.c:11785
+#: src/store.c:11791
 #, c-format
 msgid "bundle file already exists: %s\n"
 msgstr "bundle ファイルは既に存在します: %s\n"
 
-#: src/store.c:11789
+#: src/store.c:11795
 #, c-format
 msgid "secret bundle is too large\n"
 msgstr "secret bundle が大きすぎます\n"
 
-#: src/store.c:11829
+#: src/store.c:11835
 #, fuzzy, c-format
 msgid "failed to encrypt bundle metadata\n"
 msgstr "値の暗号化に失敗しました\n"
 
-#: src/store.c:11958 src/store.c:12032 src/store.c:13394 src/store.c:13588
+#: src/store.c:11964 src/store.c:12038 src/store.c:13400 src/store.c:13594
 #, c-format
 msgid "failed to create decryption context\n"
 msgstr "復号 context の作成に失敗しました\n"
 
-#: src/store.c:11964 src/store.c:12038 src/store.c:13401 src/store.c:13594
+#: src/store.c:11970 src/store.c:12044 src/store.c:13407 src/store.c:13600
 #, c-format
 msgid "failed to initialize decryption\n"
 msgstr "復号の初期化に失敗しました\n"
 
-#: src/store.c:11968
+#: src/store.c:11974
 #, fuzzy, c-format
 msgid "failed to decrypt bundle metadata\n"
 msgstr "値の復号に失敗しました\n"
 
-#: src/store.c:11972 src/store.c:12048 src/store.c:13406 src/store.c:13598
-#: src/store.c:13602
+#: src/store.c:11978 src/store.c:12054 src/store.c:13412 src/store.c:13604
+#: src/store.c:13608
 #, c-format
 msgid "failed to decrypt value\n"
 msgstr "値の復号に失敗しました\n"
 
-#: src/store.c:11976 src/store.c:12057 src/store.c:13411 src/store.c:13606
+#: src/store.c:11982 src/store.c:12063 src/store.c:13417 src/store.c:13612
 #, c-format
 msgid "failed to set authentication tag\n"
 msgstr "認証タグの設定に失敗しました\n"
 
-#: src/store.c:11980
+#: src/store.c:11986
 #, c-format
 msgid "failed to unlock secret bundle\n"
 msgstr "secret bundle の unlock に失敗しました\n"
 
-#: src/store.c:12061
+#: src/store.c:12067
 #, c-format
 msgid "failed to unlock persistent master key\n"
 msgstr "永続 master key の unlock に失敗しました\n"
 
-#: src/store.c:12137 src/store.c:19086 src/store.c:41099
+#: src/store.c:12143 src/store.c:19092 src/store.c:41134
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
@@ -3905,146 +3905,146 @@ msgstr ""
 "SECDAT_MASTER_KEY が未設定で、有効な secdat セッションもありません。secdat "
 "unlock を実行するか SECDAT_MASTER_KEY を export してください\n"
 
-#: src/store.c:12309 src/store.c:12313 src/store.c:12336
+#: src/store.c:12315 src/store.c:12319 src/store.c:12342
 #, c-format
 msgid "no local lock for: %s\n"
 msgstr "%s に local lock はありません\n"
 
-#: src/store.c:12323
+#: src/store.c:12329
 #, c-format
 msgid "refusing to remove local lock for: %s\n"
 msgstr "%s の local lock の削除を拒否しました\n"
 
-#: src/store.c:12324 src/store.c:12372
+#: src/store.c:12330 src/store.c:12378
 #, c-format
 msgid "expected resulting state: %s\n"
 msgstr "期待する結果状態: %s\n"
 
-#: src/store.c:12326
+#: src/store.c:12332
 #, c-format
 msgid "actual resulting state after removing local lock: %s\n"
 msgstr "local lock 削除後の実際の結果状態: %s\n"
 
-#: src/store.c:12341
+#: src/store.c:12347
 msgid "local lock removed; resulting state: unlocked"
 msgstr "local lock を削除しました。結果状態: unlocked"
 
-#: src/store.c:12343
+#: src/store.c:12349
 msgid "local lock removed; resulting state: locked"
 msgstr "local lock を削除しました。結果状態: locked"
 
-#: src/store.c:12345
+#: src/store.c:12351
 msgid "local lock removed"
 msgstr "local lock を削除しました"
 
-#: src/store.c:12361 src/store.c:12407
+#: src/store.c:12367 src/store.c:12413
 #, c-format
 msgid "no local lock or local unlock for: %s\n"
 msgstr "%s に local lock も local unlock もありません\n"
 
-#: src/store.c:12371
+#: src/store.c:12377
 #, c-format
 msgid "refusing to clear local unlock for: %s\n"
 msgstr "%s の local unlock の消去を拒否しました\n"
 
-#: src/store.c:12374
+#: src/store.c:12380
 #, c-format
 msgid "actual resulting state after clearing local unlock: %s\n"
 msgstr "local unlock 消去後の実際の結果状態: %s\n"
 
-#: src/store.c:12385
+#: src/store.c:12391
 msgid "local unlock cleared; resulting state: unlocked"
 msgstr "local unlock を消去しました。結果状態: unlocked"
 
-#: src/store.c:12387
+#: src/store.c:12393
 msgid "local unlock cleared; resulting state: locked"
 msgstr "local unlock を消去しました。結果状態: locked"
 
-#: src/store.c:12389
+#: src/store.c:12395
 msgid "local unlock cleared"
 msgstr "local unlock を消去しました"
 
-#: src/store.c:12644 src/store.c:12651 src/store.c:12657 src/store.c:12663
+#: src/store.c:12650 src/store.c:12657 src/store.c:12663 src/store.c:12669
 #, c-format
 msgid "invalid arguments for status\n"
 msgstr "status の引数が不正です\n"
 
-#: src/store.c:12675
+#: src/store.c:12681
 msgid "source: environment"
 msgstr "取得元: 環境変数"
 
-#: src/store.c:12685
+#: src/store.c:12691
 msgid "source: session agent"
 msgstr "取得元: セッションエージェント"
 
-#: src/store.c:12687
+#: src/store.c:12693
 msgid "overlay: volatile"
 msgstr "overlay: volatile"
 
-#: src/store.c:12690
+#: src/store.c:12696
 msgid "access: readonly"
 msgstr "access: readonly"
 
-#: src/store.c:12693
+#: src/store.c:12699
 #, c-format
 msgid "expires in: %s\n"
 msgstr "残り時間: %s\n"
 
-#: src/store.c:12813
+#: src/store.c:12819
 #, c-format
 msgid "this will unlock %zu descendant domains in the current subtree\n"
 msgstr "現在の subtree で %zu 個の descendant domain を unlock します\n"
 
-#: src/store.c:12814
+#: src/store.c:12820
 #, c-format
 msgid "local locks will remain after local unlock expiry or a later lock\n"
 msgstr "local unlock の期限切れ後や後続の lock 後も local lock は残ります\n"
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "volatile session refreshed"
 msgstr "揮発セッションを延長しました"
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "readonly session refreshed"
 msgstr "読み取り専用セッションを延長しました"
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "session refreshed"
 msgstr "セッションを延長しました"
 
-#: src/store.c:12929
+#: src/store.c:12935
 msgid "readonly session unlocked from environment"
 msgstr "環境変数から読み取り専用セッションをアンロックしました"
 
-#: src/store.c:12930 src/store.c:13022
+#: src/store.c:12936 src/store.c:13028
 msgid "readonly session unlocked"
 msgstr "読み取り専用セッションをアンロックしました"
 
-#: src/store.c:12932 src/store.c:12968
+#: src/store.c:12938 src/store.c:12974
 msgid "volatile session unlocked with an ephemeral master key"
 msgstr "揮発セッションを一時 master key でアンロックしました"
 
-#: src/store.c:12935
+#: src/store.c:12941
 msgid "volatile session unlocked from environment"
 msgstr "環境変数から揮発セッションをアンロックしました"
 
-#: src/store.c:12936 src/store.c:13022
+#: src/store.c:12942 src/store.c:13028
 msgid "volatile session unlocked"
 msgstr "揮発セッションをアンロックしました"
 
-#: src/store.c:12939
+#: src/store.c:12945
 msgid "persistent master key initialized; session unlocked from environment"
 msgstr "永続 master key を初期化し、環境変数からセッションをアンロックしました"
 
-#: src/store.c:12940
+#: src/store.c:12946
 msgid "persistent master key initialized; session unlocked"
 msgstr "永続 master key を初期化し、セッションをアンロックしました"
 
-#: src/store.c:12942
+#: src/store.c:12948
 msgid "session unlocked from environment"
 msgstr "環境変数からセッションをアンロックしました"
 
-#: src/store.c:12975
+#: src/store.c:12981
 #, c-format
 msgid ""
 "no persistent master key is initialized; readonly unlock requires an "
@@ -4053,7 +4053,7 @@ msgstr ""
 "永続 master key が未初期化のため、readonly unlock には既存の master key が必"
 "要です\n"
 
-#: src/store.c:12980 src/store.c:13170
+#: src/store.c:12986 src/store.c:13176
 #, c-format
 msgid ""
 "no persistent master key is initialized; run secdat unlock once to create "
@@ -4062,90 +4062,90 @@ msgstr ""
 "永続 master key が未初期化です。一度 secdat unlock を実行して作成してくださ"
 "い\n"
 
-#: src/store.c:13022
+#: src/store.c:13028
 msgid "session unlocked"
 msgstr "セッションをアンロックしました"
 
-#: src/store.c:13075
+#: src/store.c:13081
 msgid "already locked"
 msgstr "すでにロック中です"
 
-#: src/store.c:13102
+#: src/store.c:13108
 msgid "volatile session saved and locked"
 msgstr "揮発セッションを保存してロックしました"
 
-#: src/store.c:13102
+#: src/store.c:13108
 msgid "session locked"
 msgstr "セッションをロックしました"
 
-#: src/store.c:13135
+#: src/store.c:13141
 #, c-format
 msgid "invalid arguments for inherit\n"
 msgstr "inherit の引数が不正です\n"
 
-#: src/store.c:13182
+#: src/store.c:13188
 msgid "Create new secdat passphrase: "
 msgstr "新しい secdat パスフレーズを作成してください: "
 
-#: src/store.c:13183
+#: src/store.c:13189
 msgid "Confirm new secdat passphrase: "
 msgstr "新しい secdat パスフレーズを再入力してください: "
 
-#: src/store.c:13199
+#: src/store.c:13205
 msgid "persistent master key passphrase updated"
 msgstr "永続 master key のパスフレーズを更新しました"
 
-#: src/store.c:13329 src/store.c:13347 src/store.c:13352 src/store.c:13358
-#: src/store.c:13373 src/store.c:13559 src/store.c:13566 src/store.c:13571
-#: src/store.c:14628 src/store.c:14712
+#: src/store.c:13335 src/store.c:13353 src/store.c:13358 src/store.c:13364
+#: src/store.c:13379 src/store.c:13565 src/store.c:13572 src/store.c:13577
+#: src/store.c:14634 src/store.c:14718
 #, c-format
 msgid "invalid encrypted entry\n"
 msgstr "暗号化エントリが不正です\n"
 
-#: src/store.c:13334 src/store.c:14635 src/store.c:14716
+#: src/store.c:13340 src/store.c:14641 src/store.c:14722
 #, c-format
 msgid "unsupported encrypted entry format\n"
 msgstr "暗号化エントリ形式はサポートされていません\n"
 
-#: src/store.c:13340 src/store.c:14639 src/store.c:14720
+#: src/store.c:13346 src/store.c:14645 src/store.c:14726
 #, c-format
 msgid "unsupported encryption algorithm\n"
 msgstr "暗号化アルゴリズムはサポートされていません\n"
 
-#: src/store.c:13417 src/store.c:13610
+#: src/store.c:13423 src/store.c:13616
 #, c-format
 msgid "failed to authenticate encrypted value\n"
 msgstr "暗号化値の認証に失敗しました\n"
 
-#: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
-#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29420
-#: src/store.c:30039 src/store.c:30201 src/store.c:30783 src/store.c:30793
-#: src/store.c:31103 src/store.c:31139 src/store.c:31265 src/store.c:40807
-#: src/store.c:40830 src/store.c:42928
+#: src/store.c:13782 src/store.c:14659 src/store.c:14665 src/store.c:18994
+#: src/store.c:19011 src/store.c:19065 src/store.c:19076 src/store.c:29455
+#: src/store.c:30074 src/store.c:30236 src/store.c:30818 src/store.c:30828
+#: src/store.c:31138 src/store.c:31174 src/store.c:31300 src/store.c:40842
+#: src/store.c:40865 src/store.c:43006
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr "v2 domain entry が不正です: %s\n"
 
-#: src/store.c:13814
+#: src/store.c:13820
 #, c-format
 msgid "failed to read standard input\n"
 msgstr "標準入力の読み取りに失敗しました\n"
 
-#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30093
-#: src/store.c:30340 src/store.c:34056 src/store.c:34161 src/store.c:34491
-#: src/store.c:37479 src/store.c:37767 src/store.c:38576 src/store.c:38675
-#: src/store.c:38919 src/store.c:41090 src/store.c:43568 src/store.c:43714
-#: src/store.c:44126 src/store.c:44746 src/store.c:45470 src/store.c:46046
+#: src/store.c:14047 src/store.c:14270 src/store.c:14440 src/store.c:30128
+#: src/store.c:30375 src/store.c:34091 src/store.c:34196 src/store.c:34526
+#: src/store.c:37514 src/store.c:37802 src/store.c:38611 src/store.c:38710
+#: src/store.c:38954 src/store.c:41125 src/store.c:43655 src/store.c:43801
+#: src/store.c:44213 src/store.c:44833 src/store.c:45557 src/store.c:46133
 #, c-format
 msgid "invalid store format marker\n"
 msgstr "store format marker が不正です\n"
 
-#: src/store.c:14164
+#: src/store.c:14170
 #, c-format
 msgid "Key candidates:\n"
 msgstr "key 候補:\n"
 
-#: src/store.c:14187
+#: src/store.c:14193
 #, c-format
 msgid ""
 "Hint: use %s get KEY for an explicit key lookup, or %s help COMMAND for "
@@ -4154,7 +4154,7 @@ msgstr ""
 "ヒント: key 探索を明示するには %s get KEY を、コマンド help には %s help "
 "COMMAND を使ってください\n"
 
-#: src/store.c:14199
+#: src/store.c:14205
 #, c-format
 msgid ""
 "Hint: check secdat status, --dir, and --store to confirm the lookup context\n"
@@ -4162,113 +4162,113 @@ msgstr ""
 "ヒント: secdat status、--dir、--store を確認して探索文脈が正しいか確かめてく"
 "ださい\n"
 
-#: src/store.c:14608 src/store.c:30681 src/store.c:31109 src/store.c:31113
-#: src/store.c:31253 src/store.c:38723 src/store.c:38730 src/store.c:40813
+#: src/store.c:14614 src/store.c:30716 src/store.c:31144 src/store.c:31148
+#: src/store.c:31288 src/store.c:38758 src/store.c:38765 src/store.c:40848
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr "v2 secret object が不正です: %s\n"
 
-#: src/store.c:14616
+#: src/store.c:14622
 #, c-format
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr "v2 secret value storage はまだ実装されていません\n"
 
-#: src/store.c:15874 src/store.c:38050
+#: src/store.c:15880 src/store.c:38085
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr "random bytes の生成に失敗しました\n"
 
-#: src/store.c:15966
+#: src/store.c:15972
 #, fuzzy, c-format
 #| msgid "failed to calculate transaction digest\n"
 msgid "failed to calculate GC candidate handle\n"
 msgstr "transaction digest の計算に失敗しました\n"
 
-#: src/store.c:16648
+#: src/store.c:16654
 #, fuzzy, c-format
 #| msgid "failed to create session agent socket\n"
 msgid "failed to read the GC scheduling clock\n"
 msgstr "セッションエージェントのソケット作成に失敗しました\n"
 
-#: src/store.c:16902
+#: src/store.c:16908
 #, c-format
 msgid "invalid deferred GC topology effect\n"
 msgstr ""
 
-#: src/store.c:17048
+#: src/store.c:17054
 #, fuzzy, c-format
 #| msgid "secret bundle entry is too large\n"
 msgid "secret reference count is too large\n"
 msgstr "secret bundle のエントリが大きすぎます\n"
 
-#: src/store.c:17595 src/store.c:17608
+#: src/store.c:17601 src/store.c:17614
 #, c-format
 msgid "metadata is too large\n"
 msgstr "metadata が大きすぎます\n"
 
-#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35564
-#: src/store.c:35684 src/store.c:36940
+#: src/store.c:17693 src/store.c:17736 src/store.c:17785 src/store.c:35599
+#: src/store.c:35719 src/store.c:36975
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr "metadata field が不正です: %s\n"
 
-#: src/store.c:17768
+#: src/store.c:17774
 #, c-format
 msgid "invalid metadata filter: %s\n"
 msgstr "metadata filter が不正です: %s\n"
 
-#: src/store.c:17910 src/store.c:17939 src/store.c:17950
+#: src/store.c:17916 src/store.c:17945 src/store.c:17956
 #, c-format
 msgid "invalid key metadata\n"
 msgstr "key metadata が不正です\n"
 
-#: src/store.c:17925
+#: src/store.c:17931
 #, c-format
 msgid "unsupported key metadata format\n"
 msgstr "サポートされていない key metadata format です\n"
 
-#: src/store.c:18070 src/store.c:18143
+#: src/store.c:18076 src/store.c:18149
 #, c-format
 msgid "invalid relation member role: %s\n"
 msgstr "relation member role が不正です: %s\n"
 
-#: src/store.c:18076
+#: src/store.c:18082
 #, c-format
 msgid "invalid relation member key reference\n"
 msgstr "relation member key reference が不正です\n"
 
-#: src/store.c:18083
+#: src/store.c:18089
 #, c-format
 msgid "duplicate relation member role: %s\n"
 msgstr "relation member role が重複しています: %s\n"
 
-#: src/store.c:18128
+#: src/store.c:18134
 #, c-format
 msgid "invalid relation member: %s\n"
 msgstr "relation member が不正です: %s\n"
 
-#: src/store.c:18253 src/store.c:35843
+#: src/store.c:18259 src/store.c:35878
 #, c-format
 msgid "relation not found: %s\n"
 msgstr "relation が見つかりません: %s\n"
 
-#: src/store.c:18262 src/store.c:18290 src/store.c:18447
+#: src/store.c:18268 src/store.c:18296 src/store.c:18453
 #, c-format
 msgid "invalid relation metadata\n"
 msgstr "relation metadata が不正です\n"
 
-#: src/store.c:18276
+#: src/store.c:18282
 #, c-format
 msgid "unsupported relation metadata format\n"
 msgstr "サポートされていない relation metadata format です\n"
 
-#: src/store.c:18503
+#: src/store.c:18509
 #, c-format
 msgid "key_visibility=unlocked cannot be used while key metadata exists: %s\n"
 msgstr ""
 "key metadata が存在する間は key_visibility=unlocked を使用できません: %s\n"
 
-#: src/store.c:18525
+#: src/store.c:18531
 #, c-format
 msgid ""
 "key_visibility=unlocked cannot be used while relation references key: %s "
@@ -4277,244 +4277,244 @@ msgstr ""
 "relation が key を参照している間は key_visibility=unlocked を使用できません: "
 "%s (%s)\n"
 
-#: src/store.c:19483
+#: src/store.c:19489
 #, c-format
 msgid "failed to calculate transaction digest\n"
 msgstr "transaction digest の計算に失敗しました\n"
 
-#: src/store.c:19505
+#: src/store.c:19511
 #, c-format
 msgid "failed to open directory for fsync: %s\n"
 msgstr "fsync 用のディレクトリを開けませんでした: %s\n"
 
-#: src/store.c:19509
+#: src/store.c:19515
 #, c-format
 msgid "failed to fsync directory: %s\n"
 msgstr "ディレクトリの fsync に失敗しました: %s\n"
 
-#: src/store.c:19514
+#: src/store.c:19520
 #, c-format
 msgid "failed to close directory: %s\n"
 msgstr "ディレクトリを閉じられませんでした: %s\n"
 
-#: src/store.c:19554
+#: src/store.c:19560
 #, c-format
 msgid "invalid transaction directory: %s\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:19592
+#: src/store.c:19598
 #, c-format
 msgid "invalid transaction lock\n"
 msgstr "transaction lock が不正です\n"
 
-#: src/store.c:19609 src/store.c:19626
+#: src/store.c:19615 src/store.c:19632
 #, c-format
 msgid "failed to lock transactions\n"
 msgstr "transaction の lock に失敗しました\n"
 
-#: src/store.c:19955
+#: src/store.c:19961
 #, c-format
 msgid "failed to inspect transaction target: %s\n"
 msgstr "transaction target を確認できませんでした: %s\n"
 
-#: src/store.c:19964
+#: src/store.c:19970
 #, c-format
 msgid "invalid transaction target: %s\n"
 msgstr "transaction target が不正です: %s\n"
 
-#: src/store.c:20734
+#: src/store.c:20740
 #, fuzzy, c-format
 #| msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgid "container tree does not match schema: %s\n"
 msgstr "互換 tombstone が canonical mask と一致しません: %s\n"
 
-#: src/store.c:21280 src/store.c:21286 src/store.c:21407
+#: src/store.c:21286 src/store.c:21292 src/store.c:21413
 #, fuzzy, c-format
 #| msgid "failed to create directory: %s\n"
 msgid "failed to inspect typed directory: %s\n"
 msgstr "ディレクトリの作成に失敗しました: %s\n"
 
-#: src/store.c:21307
+#: src/store.c:21313
 #, fuzzy, c-format
 #| msgid "invalid transaction directory: %s\n"
 msgid "invalid typed directory: %s\n"
 msgstr "transaction directory が不正です: %s\n"
 
-#: src/store.c:21703 src/store.c:21794
+#: src/store.c:21709 src/store.c:21800
 #, c-format
 msgid "invalid transaction target directory\n"
 msgstr "transaction target directory が不正です\n"
 
-#: src/store.c:21823 src/store.c:21833 src/store.c:21911
+#: src/store.c:21829 src/store.c:21839 src/store.c:21917
 #, c-format
 msgid "failed to read transaction target\n"
 msgstr "transaction target を読み込めませんでした\n"
 
-#: src/store.c:22279 src/store.c:22470 src/store.c:22481
+#: src/store.c:22285 src/store.c:22476 src/store.c:22487
 #, c-format
 msgid "transaction data is too large\n"
 msgstr "transaction data が大きすぎます\n"
 
-#: src/store.c:22343
+#: src/store.c:22349
 #, c-format
 msgid "transaction has too many targets\n"
 msgstr "transaction の target が多すぎます\n"
 
-#: src/store.c:22355
+#: src/store.c:22361
 #, c-format
 msgid "invalid transaction validation target\n"
 msgstr "transaction validation target が不正です\n"
 
-#: src/store.c:22401 src/store.c:22837
+#: src/store.c:22407 src/store.c:22843
 #, c-format
 msgid "transaction changed since plan\n"
 msgstr "plan 作成後に transaction target が変更されました\n"
 
-#: src/store.c:22424 src/store.c:22882
+#: src/store.c:22430 src/store.c:22888
 #, c-format
 msgid "duplicate transaction target\n"
 msgstr "transaction target が重複しています\n"
 
-#: src/store.c:22868
+#: src/store.c:22874
 #, c-format
 msgid "typed directory guards require transaction manifest v2\n"
 msgstr ""
 
-#: src/store.c:22933
+#: src/store.c:22939
 #, fuzzy, c-format
 #| msgid "prepared write is outside the state directory\n"
 msgid "prepared guard is outside the state directory\n"
 msgstr "準備済みの書き込みが状態ディレクトリの外を指しています\n"
 
-#: src/store.c:22955
+#: src/store.c:22961
 #, c-format
 msgid "prepared write is outside the state directory\n"
 msgstr "準備済みの書き込みが状態ディレクトリの外を指しています\n"
 
-#: src/store.c:23058
+#: src/store.c:23089
 #, fuzzy, c-format
 #| msgid "invalid store format marker\n"
 msgid "invalid move source removal target\n"
 msgstr "store format marker が不正です\n"
 
-#: src/store.c:23230
+#: src/store.c:23261
 #, c-format
 msgid "invalid transaction blob: %s\n"
 msgstr "transaction blob が不正です: %s\n"
 
-#: src/store.c:24032
+#: src/store.c:24063
 #, c-format
 msgid "invalid transaction journal: %s\n"
 msgstr "transaction journal が不正です: %s\n"
 
-#: src/store.c:24099 src/store.c:24140
+#: src/store.c:24130 src/store.c:24171
 #, c-format
 msgid "failed to open transaction directory: %s\n"
 msgstr "transaction directory を開けませんでした: %s\n"
 
-#: src/store.c:24115
+#: src/store.c:24146
 #, c-format
 msgid "unexpected transaction file: %s\n"
 msgstr "予期しない transaction file です: %s\n"
 
-#: src/store.c:24123
+#: src/store.c:24154
 #, c-format
 msgid "failed to close transaction directory\n"
 msgstr "transaction directory を閉じられませんでした\n"
 
-#: src/store.c:24166
+#: src/store.c:24197
 #, c-format
 msgid "invalid transaction temporary file: %s\n"
 msgstr "transaction の一時ファイルが不正です: %s\n"
 
-#: src/store.c:24275
+#: src/store.c:24306
 #, c-format
 msgid "failed to remove completed transaction: %s\n"
 msgstr "完了した transaction を削除できませんでした: %s\n"
 
-#: src/store.c:24329 src/store.c:24341 src/store.c:24346 src/store.c:24352
-#: src/store.c:24448
+#: src/store.c:24360 src/store.c:24372 src/store.c:24377 src/store.c:24383
+#: src/store.c:24479
 #, c-format
 msgid "failed to apply transaction target\n"
 msgstr "transaction target を適用できませんでした\n"
 
-#: src/store.c:24504
+#: src/store.c:24535
 #, c-format
 msgid "transaction target changed during recovery: %s\n"
 msgstr "復旧中に transaction target の変更を検出しました: %s\n"
 
-#: src/store.c:24540
+#: src/store.c:24571
 #, c-format
 msgid "committed transaction target is inconsistent: %s\n"
 msgstr "commit 済み transaction target が不整合です: %s\n"
 
-#: src/store.c:24595
+#: src/store.c:24626
 #, c-format
 msgid "invalid unpublished transaction: %s\n"
 msgstr "未公開 transaction が不正です: %s\n"
 
-#: src/store.c:24619
+#: src/store.c:24650
 #, c-format
 msgid "failed to open transactions directory\n"
 msgstr "transactions directory を開けませんでした\n"
 
-#: src/store.c:24631
+#: src/store.c:24662
 #, c-format
 msgid "invalid transaction entry: %s\n"
 msgstr "transaction entry が不正です: %s\n"
 
-#: src/store.c:24715
+#: src/store.c:24746
 #, c-format
 msgid "failed to inspect transactions directory\n"
 msgstr "transactions directory を確認できませんでした\n"
 
-#: src/store.c:24824
+#: src/store.c:24855
 #, c-format
 msgid "failed to stage transaction\n"
 msgstr "transaction の stage に失敗しました\n"
 
-#: src/store.c:24903
+#: src/store.c:24934
 #, c-format
 msgid "transaction changed since plan: %s\n"
 msgstr "plan 作成後に transaction target が変更されました: %s\n"
 
-#: src/store.c:25165
+#: src/store.c:25196
 #, c-format
 msgid "invalid abandoned mutation stage\n"
 msgstr "放棄された mutation stage が不正です\n"
 
-#: src/store.c:25425 src/store.c:25429
+#: src/store.c:25460 src/store.c:25464
 #, c-format
 msgid "invalid dependency index directory\n"
 msgstr "dependency index directory が不正です\n"
 
-#: src/store.c:26033
+#: src/store.c:26068
 #, c-format
 msgid "dependency index node is too large\n"
 msgstr "dependency index node が大きすぎます\n"
 
-#: src/store.c:26437
+#: src/store.c:26472
 #, c-format
 msgid "cannot index a relation dependency that references a hidden v2 key\n"
 msgstr "hidden v2 key を参照する relation dependency は index 化できません\n"
 
-#: src/store.c:26581
+#: src/store.c:26616
 #, c-format
 msgid "cannot build dependency index from invalid mask record\n"
 msgstr "不正な mask record から dependency index を構築できません\n"
 
-#: src/store.c:26607
+#: src/store.c:26642
 #, c-format
 msgid "cannot build dependency index from invalid relation record\n"
 msgstr "不正な relation record から dependency index を構築できません\n"
 
-#: src/store.c:26627
+#: src/store.c:26662
 #, c-format
 msgid "cannot index relation dependency: %s\n"
 msgstr "relation dependency をindex化できません: %s\n"
 
-#: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
-#: src/store.c:28839 src/store.c:29218 src/store.c:29233
+#: src/store.c:27740 src/store.c:28135 src/store.c:28237 src/store.c:28764
+#: src/store.c:28874 src/store.c:29253 src/store.c:29268
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
@@ -4523,7 +4523,7 @@ msgstr ""
 "dependency index が破損しています。fsck --format v2 --dependency-index --"
 "repair を実行してください\n"
 
-#: src/store.c:28061 src/store.c:28266 src/store.c:29208 src/store.c:42845
+#: src/store.c:28096 src/store.c:28301 src/store.c:29243 src/store.c:42923
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
@@ -4532,13 +4532,13 @@ msgstr ""
 "dependency index が不完全です。fsck --format v2 --dependency-index --repair "
 "を実行してください\n"
 
-#: src/store.c:28391
+#: src/store.c:28426
 #, fuzzy, c-format
 #| msgid "ambiguous legacy mask blocks this mutation\n"
 msgid "ambiguous legacy mask blocks key visibility transition: %s\n"
 msgstr "曖昧な legacy mask がこの mutation を拒否しました\n"
 
-#: src/store.c:28402
+#: src/store.c:28437
 #, fuzzy, c-format
 #| msgid ""
 #| "hidden-name mask cannot be projected to v1 rollback state without "
@@ -4547,12 +4547,12 @@ msgid "hidden-name transition cannot preserve v1 rollback mask state: %s\n"
 msgstr ""
 "hidden-name mask は名前を露出せずに v1 rollback state へ投影できません: %s\n"
 
-#: src/store.c:28990
+#: src/store.c:29025
 #, c-format
 msgid "invalid dependency index node: %s\n"
 msgstr "dependency index node が不正です: %s\n"
 
-#: src/store.c:29346
+#: src/store.c:29381
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
@@ -4560,57 +4560,57 @@ msgstr ""
 "dependency index generation が変更されました: first=%s/%zu/%zu second=%s/%zu/"
 "%zu\n"
 
-#: src/store.c:29394
+#: src/store.c:29429
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr "dependency index の再構築が %s で失敗しました\n"
 
-#: src/store.c:29956
+#: src/store.c:29991
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr "tombstone file が不正です: %s\n"
 
-#: src/store.c:29986 src/store.c:29995 src/store.c:29999
+#: src/store.c:30021 src/store.c:30030 src/store.c:30034
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr "v2 compatibility tombstone が不正です\n"
 
-#: src/store.c:30077
+#: src/store.c:30112
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr "v2 mask の target store が不正です: %s\n"
 
-#: src/store.c:30116 src/store.c:41885
+#: src/store.c:30151 src/store.c:41920
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr "v2 mask の target entry が重複しています: %s\n"
 
-#: src/store.c:30154
+#: src/store.c:30189
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr "暗号化された v2 mask name が不正です: %s\n"
 
-#: src/store.c:30175 src/store.c:30296
+#: src/store.c:30210 src/store.c:30331
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr "v2 mask の target が不正です: %s\n"
 
-#: src/store.c:30215 src/store.c:30221
+#: src/store.c:30250 src/store.c:30256
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr "v2 mask の target name が不正です: %s\n"
 
-#: src/store.c:30260
+#: src/store.c:30295
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr "v2 mask directory が不正です\n"
 
-#: src/store.c:30264 src/store.c:31463
+#: src/store.c:30299 src/store.c:31498
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr "v2 mask directory を確認できませんでした\n"
 
-#: src/store.c:30284
+#: src/store.c:30319
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
@@ -4619,85 +4619,85 @@ msgstr ""
 "不正な v2 mask record です: %s。診断ハンドルを得るには fsck --format v2 --"
 "dangling を実行してください\n"
 
-#: src/store.c:30540 src/store.c:39479
+#: src/store.c:30575 src/store.c:39514
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr "互換 tombstone が canonical mask と一致しません: %s\n"
 
-#: src/store.c:30658
+#: src/store.c:30693
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 "非表示の mask name が lock されているため mask の影響を解析できません\n"
 
-#: src/store.c:31117 src/store.c:31259
+#: src/store.c:31152 src/store.c:31294
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr "secret object が bulk select を除外しています: %s\n"
 
-#: src/store.c:31425
+#: src/store.c:31460
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr "mask 診断ハンドルのエンコードに失敗しました\n"
 
-#: src/store.c:32012
+#: src/store.c:32047
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32737
+#: src/store.c:32772
 #, fuzzy, c-format
 #| msgid "lock --save requires a local volatile session\n"
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr "lock --save にはローカルの揮発セッションが必要です\n"
 
-#: src/store.c:33364
+#: src/store.c:33399
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33779
+#: src/store.c:33814
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:34048 src/store.c:34153
+#: src/store.c:34083 src/store.c:34188
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr "fsck には登録済みの current domain が必要です\n"
 
-#: src/store.c:34060
+#: src/store.c:34095
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr "store format は v2 です。--format v2 を使用してください\n"
 
-#: src/store.c:34165
+#: src/store.c:34200
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr "store format は v1 です。--format v1 を使用してください\n"
 
-#: src/store.c:34476 src/store.c:34866
+#: src/store.c:34511 src/store.c:34901
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr "gc には登録済みの current domain が必要です\n"
 
-#: src/store.c:34495
+#: src/store.c:34530
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr "store format は v1 です。gc には --format v2 が必要です\n"
 
-#: src/store.c:34699
+#: src/store.c:34734
 #, fuzzy, c-format
 #| msgid "mask interaction rejected before mutation\n"
 msgid "GC owner domain must be registered before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:34877
+#: src/store.c:34912
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr "gc は --format v2 でのみサポートされています\n"
 
-#: src/store.c:35283
+#: src/store.c:35318
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
@@ -4706,7 +4706,7 @@ msgstr ""
 "%zu 件の非表示 mask を省略しました。対象ドメインを unlock するか、件数確認に"
 "は --json を使用してください\n"
 
-#: src/store.c:35294
+#: src/store.c:35329
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
@@ -4715,12 +4715,12 @@ msgstr ""
 "ancestor の key name が lock されているため %zu 件の mask 状態が不完全です。"
 "対象 domain を unlock するか、件数確認には --json を使用してください\n"
 
-#: src/store.c:35379 src/store.c:35449
+#: src/store.c:35414 src/store.c:35484
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr "継承された key attributes は更新できません: %s\n"
 
-#: src/store.c:35441
+#: src/store.c:35476
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
@@ -4729,243 +4729,243 @@ msgstr ""
 "ephemeral secret の secret attributes は変更できません。set --ephemeral で作"
 "り直してください\n"
 
-#: src/store.c:35442
+#: src/store.c:35477
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes を変更できません\n"
 
-#: src/store.c:35571 src/store.c:35691
+#: src/store.c:35606 src/store.c:35726
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr "継承された key metadata は更新できません: %s\n"
 
-#: src/store.c:35578 src/store.c:35698
+#: src/store.c:35613 src/store.c:35733
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr "ephemeral secret の key metadata は変更できません\n"
 
-#: src/store.c:35579 src/store.c:35699
+#: src/store.c:35614 src/store.c:35734
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では key metadata を変更できません\n"
 
-#: src/store.c:35584
+#: src/store.c:35619
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を設定できません: %s\n"
 
-#: src/store.c:35616
+#: src/store.c:35651
 #, c-format
 msgid "missing key for meta get\n"
 msgstr "meta get の key が不足しています\n"
 
-#: src/store.c:35616
+#: src/store.c:35651
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr "meta get の引数が不正です\n"
 
-#: src/store.c:35644
+#: src/store.c:35679
 #, c-format
 msgid "missing key for meta set\n"
 msgstr "meta set の key が不足しています\n"
 
-#: src/store.c:35644
+#: src/store.c:35679
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:35656
+#: src/store.c:35691
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr "meta mark-leaked の key が不足しています\n"
 
-#: src/store.c:35656
+#: src/store.c:35691
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr "meta mark-leaked の引数が不正です\n"
 
-#: src/store.c:35679
+#: src/store.c:35714
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr "meta unset の key が不足しています\n"
 
-#: src/store.c:35679
+#: src/store.c:35714
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr "meta unset の引数が不正です\n"
 
-#: src/store.c:35978
+#: src/store.c:36013
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr "relation kind が不正です: %s\n"
 
-#: src/store.c:36022
+#: src/store.c:36057
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr "relation member は ephemeral secret を参照できません: %s\n"
 
-#: src/store.c:36028
+#: src/store.c:36063
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr "relation member は hidden v2 key を参照できません: %s\n"
 
-#: src/store.c:36065 src/store.c:36072
+#: src/store.c:36100 src/store.c:36107
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr "relation set の引数が不正です\n"
 
-#: src/store.c:36072
+#: src/store.c:36107
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr "relation set の relation id が不足しています\n"
 
-#: src/store.c:36078 src/store.c:37272 src/store.c:37321
+#: src/store.c:36113 src/store.c:37307 src/store.c:37356
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr "relation id が不正です: %s\n"
 
-#: src/store.c:36083
+#: src/store.c:36118
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 "relation set には少なくとも 2 つの --member ROLE=KEYREF option が必要です\n"
 
-#: src/store.c:36095 src/store.c:37331
+#: src/store.c:36130 src/store.c:37366
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では relation を変更できません\n"
 
-#: src/store.c:36948 src/store.c:36954
+#: src/store.c:36983 src/store.c:36989
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr "relation suggest-link の引数が不正です\n"
 
-#: src/store.c:37147
+#: src/store.c:37182
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr "relation ls の引数が不正です\n"
 
-#: src/store.c:37166
+#: src/store.c:37201
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr "relation ls には登録済みの current domain が必要です\n"
 
-#: src/store.c:37219
+#: src/store.c:37254
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr "relation search には登録済みの current domain が必要です\n"
 
-#: src/store.c:37252
+#: src/store.c:37287
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の key が不足しています\n"
 
-#: src/store.c:37252
+#: src/store.c:37287
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の引数が不正です\n"
 
-#: src/store.c:37267
+#: src/store.c:37302
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr "relation show の relation id が不足しています\n"
 
-#: src/store.c:37267
+#: src/store.c:37302
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr "relation show の引数が不正です\n"
 
-#: src/store.c:37279
+#: src/store.c:37314
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr "relation show には登録済みの current domain が必要です\n"
 
-#: src/store.c:37316
+#: src/store.c:37351
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr "relation rm の relation id が不足しています\n"
 
-#: src/store.c:37316
+#: src/store.c:37351
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr "relation rm の引数が不正です\n"
 
-#: src/store.c:37361
+#: src/store.c:37396
 #, c-format
 msgid "missing key for exists\n"
 msgstr "exists のキーが不足しています\n"
 
-#: src/store.c:37366
+#: src/store.c:37401
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr "exists の引数が不正です\n"
 
-#: src/store.c:37395
+#: src/store.c:37430
 #, c-format
 msgid "missing key for id\n"
 msgstr "id のキーが不足しています\n"
 
-#: src/store.c:37400
+#: src/store.c:37435
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr "id の引数が不正です\n"
 
-#: src/store.c:37420
+#: src/store.c:37455
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr "secret id は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37448
+#: src/store.c:37483
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr "secret status の UUID が不足しています\n"
 
-#: src/store.c:37458
+#: src/store.c:37493
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:37463
+#: src/store.c:37498
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr "secret status の UUID が不正です: %s\n"
 
-#: src/store.c:37471
+#: src/store.c:37506
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr "secret status には登録済みの current domain が必要です\n"
 
-#: src/store.c:37483
+#: src/store.c:37518
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr "secret status は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37493
+#: src/store.c:37528
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr "secret object が見つかりません: %s\n"
 
-#: src/store.c:37497
+#: src/store.c:37532
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:37627
+#: src/store.c:37662
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr "key の値に NUL バイトが含まれているため shell escaped できません: %s\n"
 
-#: src/store.c:37641 src/store.c:37709
+#: src/store.c:37676 src/store.c:37744
 #, c-format
 msgid "failed to write standard output\n"
 msgstr "標準出力への書き込みに失敗しました\n"
 
-#: src/store.c:37690
+#: src/store.c:37725
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr "secret を端末へ書き出すことを拒否しました\n"
 
-#: src/store.c:37837 src/store.c:38378
+#: src/store.c:37872 src/store.c:38413
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
@@ -4973,96 +4973,96 @@ msgstr ""
 "ephemeral secret には key_visibility=unlocked と value_access=unlocked が必要"
 "です\n"
 
-#: src/store.c:37892 src/store.c:38853 src/store.c:47912
+#: src/store.c:37927 src/store.c:38888 src/store.c:48006
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では mutation planning はサポートされません\n"
 
-#: src/store.c:37907
+#: src/store.c:37942
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes はサポートされません\n"
 
-#: src/store.c:38012 src/store.c:38260 src/store.c:38270 src/store.c:38292
-#: src/store.c:38317 src/store.c:38326 src/store.c:38336 src/store.c:38365
-#: src/store.c:38441 src/store.c:38474 src/store.c:38483
+#: src/store.c:38047 src/store.c:38295 src/store.c:38305 src/store.c:38327
+#: src/store.c:38352 src/store.c:38361 src/store.c:38371 src/store.c:38400
+#: src/store.c:38476 src/store.c:38509 src/store.c:38518
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr "set の引数が不正です\n"
 
-#: src/store.c:38044
+#: src/store.c:38079
 #, fuzzy, c-format
 msgid "invalid generated secret charset\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:38065
+#: src/store.c:38100
 #, fuzzy, c-format
 msgid "generated secret charset is too large\n"
 msgstr "secret value が大きすぎます\n"
 
-#: src/store.c:38113
+#: src/store.c:38148
 #, fuzzy, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:38127 src/store.c:38136
+#: src/store.c:38162 src/store.c:38171
 #, fuzzy, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:38141
+#: src/store.c:38176
 #, fuzzy, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr "secret rename で環境変数名が重複しました: %s\n"
 
-#: src/store.c:38152
+#: src/store.c:38187
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38343
+#: src/store.c:38378
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr "環境変数が設定されていません: %s\n"
 
-#: src/store.c:38387
+#: src/store.c:38422
 #, c-format
 msgid "missing key for set\n"
 msgstr "set のキーが不足しています\n"
 
-#: src/store.c:38397
+#: src/store.c:38432
 #, fuzzy, c-format
 msgid "invalid arguments for generated set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:38423
+#: src/store.c:38458
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38447
+#: src/store.c:38482
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr "set --ephemeral は key を 1 つだけ受け付けます\n"
 
-#: src/store.c:38496
+#: src/store.c:38531
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr "端末から secret を読み取ることを拒否しました\n"
 
-#: src/store.c:39036
+#: src/store.c:39071
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr "key に継承された mask target がありません: %s\n"
 
-#: src/store.c:39145
+#: src/store.c:39180
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 "orphan mask chain が不正です。fsck --format v2 --dangling で確認してくださ"
 "い: %s\n"
 
-#: src/store.c:39154
+#: src/store.c:39189
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
@@ -5070,12 +5070,12 @@ msgstr ""
 "複数の orphan mask chain が key に一致します。list --all-masks --long で確認"
 "してください: %s\n"
 
-#: src/store.c:39183
+#: src/store.c:39218
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr "key に rebind 対象の mask barrier がありません: %s\n"
 
-#: src/store.c:39210
+#: src/store.c:39245
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -5086,27 +5086,27 @@ msgstr ""
 "ancestors と各 ancestor の id KEY で確認し、unmask せずに重複またはアクセス不"
 "能な候補を解消してください: %s\n"
 
-#: src/store.c:39231
+#: src/store.c:39266
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr "canonical mask には継承された v2 entry が必要です: %s\n"
 
-#: src/store.c:39289
+#: src/store.c:39324
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr "orphan mask barrier には mask --rebind が必要です: %s\n"
 
-#: src/store.c:39313
+#: src/store.c:39348
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr "canonical mask target が競合しています: %s\n"
 
-#: src/store.c:39319 src/store.c:39329
+#: src/store.c:39354 src/store.c:39364
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr "canonical mask name が競合しています: %s\n"
 
-#: src/store.c:39340
+#: src/store.c:39375
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
@@ -5115,7 +5115,7 @@ msgstr ""
 "target は別の chain ですでに mask されています。list --all-masks --long で確"
 "認し、unmask --dry-run --mask-chain で chain を選択してください: %s\n"
 
-#: src/store.c:39427
+#: src/store.c:39462
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
@@ -5123,7 +5123,7 @@ msgid ""
 msgstr ""
 "hidden-name mask は名前を露出せずに v1 rollback state へ投影できません: %s\n"
 
-#: src/store.c:39455
+#: src/store.c:39490
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
@@ -5133,38 +5133,38 @@ msgstr ""
 "認し、継承 v2 target が一つだけになってから mask --rebind を実行してくださ"
 "い: %s\n"
 
-#: src/store.c:39562 src/store.c:40370 src/store.c:40405 src/store.c:40412
-#: src/store.c:40509 src/store.c:40515
+#: src/store.c:39597 src/store.c:40405 src/store.c:40440 src/store.c:40447
+#: src/store.c:40544 src/store.c:40550
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr "mask operation plan のエンコードに失敗しました\n"
 
-#: src/store.c:39718
+#: src/store.c:39753
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では %s はサポートされません: %s\n"
 
-#: src/store.c:39768 src/store.c:39800
+#: src/store.c:39803 src/store.c:39835
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr "key はローカルに存在するため mask できません: %s\n"
 
-#: src/store.c:39920
+#: src/store.c:39955
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr "一致する mask state が lock されているため unmask できません\n"
 
-#: src/store.c:39936
+#: src/store.c:39971
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr "曖昧な legacy mask は unmask の前に mask --rebind が必要です: %s\n"
 
-#: src/store.c:39969
+#: src/store.c:40004
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr "mask chain は要求した key を保護していません: %s\n"
 
-#: src/store.c:39977
+#: src/store.c:40012
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
@@ -5173,17 +5173,17 @@ msgstr ""
 "複数の mask chain が key に一致します。list --all-masks --long と --mask-"
 "chain を使ってください: %s\n"
 
-#: src/store.c:40043
+#: src/store.c:40078
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr "plan 作成後に mask state が変更されました\n"
 
-#: src/store.c:40050 src/store.c:40688 src/store.c:40700
+#: src/store.c:40085 src/store.c:40723 src/store.c:40735
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr "key は現在の domain で mask されていません: %s\n"
 
-#: src/store.c:40083
+#: src/store.c:40118
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
@@ -5192,7 +5192,7 @@ msgstr ""
 "mask chain は複数の key name を保護しています。unmask --dry-run --mask-chain "
 "で確認してください: %s\n"
 
-#: src/store.c:40685
+#: src/store.c:40720
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
@@ -5200,59 +5200,59 @@ msgid ""
 msgstr ""
 "揮発セッション overlay が有効な間は永続 tombstone を unmask できません: %s\n"
 
-#: src/store.c:40734
+#: src/store.c:40769
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr "ln の UUID source が不正です: %s\n"
 
-#: src/store.c:40768
+#: src/store.c:40803
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr "secret UUID は現在の context で認可されていません: %s\n"
 
-#: src/store.c:40910 src/store.c:40916
+#: src/store.c:40945 src/store.c:40951
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr "ln の引数が不正です\n"
 
-#: src/store.c:40921
+#: src/store.c:40956
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr "--skip-same-value-check には --replace が必要です\n"
 
-#: src/store.c:40975 src/store.c:41283 src/store.c:42793 src/store.c:43303
-#: src/store.c:45858
+#: src/store.c:41010 src/store.c:41318 src/store.c:42871 src/store.c:43390
+#: src/store.c:45945
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr "destination key はすでに存在します: %s\n"
 
-#: src/store.c:41027
+#: src/store.c:41062
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr "UUID reference は ln source としてのみ有効です: %s\n"
 
-#: src/store.c:41032 src/store.c:41067 src/store.c:41146 src/store.c:41230
-#: src/store.c:41254 src/store.c:43249 src/store.c:43273
+#: src/store.c:41067 src/store.c:41102 src/store.c:41181 src/store.c:41265
+#: src/store.c:41289 src/store.c:43336 src/store.c:43360
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr "source key と destination key は異なる必要があります\n"
 
-#: src/store.c:41083
+#: src/store.c:41118
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では ln はサポートされません\n"
 
-#: src/store.c:41094 src/store.c:41119
+#: src/store.c:41129 src/store.c:41154
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr "ln には v2 store 内の source と destination が必要です\n"
 
-#: src/store.c:41115 src/store.c:41127
+#: src/store.c:41150 src/store.c:41162
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では ln はサポートされません: %s\n"
 
-#: src/store.c:41133
+#: src/store.c:41168
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
@@ -5261,12 +5261,12 @@ msgstr ""
 "destination key はすでに存在します: %s (値確認後に同名 key を置換するには --"
 "replace を使用してください)\n"
 
-#: src/store.c:41139
+#: src/store.c:41174
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr "ln --replace は既存の同名 key reference のみサポートします\n"
 
-#: src/store.c:41166
+#: src/store.c:41201
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
@@ -5275,37 +5275,37 @@ msgstr ""
 "同名 destination の値が異なります: %s (それでも置換するには --replace と --"
 "skip-same-value-check を併用してください)\n"
 
-#: src/store.c:41225
+#: src/store.c:41260
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr "cp の引数が不正です\n"
 
-#: src/store.c:41296
+#: src/store.c:41331
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では cp はサポートされません: %s\n"
 
-#: src/store.c:41320 src/store.c:42956 src/store.c:43387
+#: src/store.c:41355 src/store.c:43034 src/store.c:43474
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を保持できません: %s\n"
 
-#: src/store.c:41395
+#: src/store.c:41430
 #, c-format
 msgid "too many move relation dependencies\n"
 msgstr "mv の relation dependency が多すぎます\n"
 
-#: src/store.c:41896
+#: src/store.c:41931
 #, c-format
 msgid "affected descendant mask is inaccessible: %s\n"
 msgstr "影響を受ける descendant mask にアクセスできません: %s\n"
 
-#: src/store.c:42799 src/store.c:43329
+#: src/store.c:42877 src/store.c:43416
 #, c-format
 msgid "mv requires v2 source and destination stores\n"
 msgstr "mv の source と destination は v2 store である必要があります\n"
 
-#: src/store.c:42819
+#: src/store.c:42897
 #, c-format
 msgid ""
 "mv mutation planning requires a local source in the same v2 domain and "
@@ -5314,54 +5314,54 @@ msgstr ""
 "mv の mutation planning には同じ v2 domain/store 内の local source が必要で"
 "す\n"
 
-#: src/store.c:42915
+#: src/store.c:42993
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
 "namespace をまたぐ mv には正規化済み v2 object value storage が必要です\n"
 
-#: src/store.c:43244
+#: src/store.c:43331
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr "mv の引数が不正です\n"
 
-#: src/store.c:43317
+#: src/store.c:43404
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では mv はサポートされません: %s\n"
 
-#: src/store.c:43346 src/store.c:47942
+#: src/store.c:43433 src/store.c:48036
 #, c-format
 msgid "mask mutation planning requires store format v2\n"
 msgstr "mask mutation planning には store format v2 が必要です\n"
 
-#: src/store.c:43353
+#: src/store.c:43440
 #, c-format
 msgid "mv requires matching source and destination store formats\n"
 msgstr ""
 "mv の source と destination の store format は一致している必要があります\n"
 
-#: src/store.c:43517
+#: src/store.c:43604
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr "%s の引数が不正です\n"
 
-#: src/store.c:43584
+#: src/store.c:43671
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr "mask planning と rebind には永続 v2 store が必要です\n"
 
-#: src/store.c:43613
+#: src/store.c:43700
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr "canonical mask planning には継承された v2 entry が必要です\n"
 
-#: src/store.c:43733
+#: src/store.c:43820
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr "unmask planning には永続 v2 store が必要です\n"
 
-#: src/store.c:43784
+#: src/store.c:43871
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
@@ -5370,7 +5370,7 @@ msgstr ""
 "warning: unmask: mask chain を削除しましたが、%s は他の %zu 個の chain また"
 "は barrier によって mask されたままです\n"
 
-#: src/store.c:43791
+#: src/store.c:43878
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
@@ -5379,269 +5379,274 @@ msgstr ""
 "warning: unmask: %s は local のままです。後で削除すると継承値が露出する可能性"
 "があります\n"
 
-#: src/store.c:43825
+#: src/store.c:43912
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr "ephemeral key が見つかりません: %s\n"
 
-#: src/store.c:43831
+#: src/store.c:43918
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 "継承された ephemeral key は削除できません。source domain を使用してください: "
 "%s\n"
 
-#: src/store.c:43873 src/store.c:43880
+#: src/store.c:43960 src/store.c:43967
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr "rm の引数が不正です\n"
 
-#: src/store.c:44008 src/store.c:44519 src/store.c:44877 src/store.c:45340
-#: src/store.c:45426
+#: src/store.c:44095 src/store.c:44606 src/store.c:44964 src/store.c:45427
+#: src/store.c:45513
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr "--store は store コマンドでは使えません\n"
 
-#: src/store.c:44108
+#: src/store.c:44195
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr "store migrate には登録済みの current domain が必要です\n"
 
-#: src/store.c:44119 src/store.c:44739 src/store.c:45461
+#: src/store.c:44206 src/store.c:44826 src/store.c:45548
 #, c-format
 msgid "store not found: %s\n"
 msgstr "store が見つかりません: %s\n"
 
-#: src/store.c:44130
+#: src/store.c:44217
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr "store format は v2 です。migration は不要です\n"
 
-#: src/store.c:44408
+#: src/store.c:44495
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr "v2 migration artifacts はすでに存在します\n"
 
-#: src/store.c:44477
+#: src/store.c:44564
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr "v2 migration verification に失敗しました\n"
 
-#: src/store.c:44729
+#: src/store.c:44816
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr "store finalize-migration には登録済みの current domain が必要です\n"
 
-#: src/store.c:44750
+#: src/store.c:44837
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 "store format は v1 です。finalize-migration には migrated v2 store が必要で"
 "す\n"
 
-#: src/store.c:45288
+#: src/store.c:45375
 #, fuzzy, c-format
 #| msgid "store is not empty: %s\n"
 msgid "domain is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:45345
+#: src/store.c:45432
 #, c-format
 msgid "missing store name for store create\n"
 msgstr "store create の store 名が不足しています\n"
 
-#: src/store.c:45350
+#: src/store.c:45437
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:45375
+#: src/store.c:45462
 #, c-format
 msgid "store already exists: %s\n"
 msgstr "store はすでに存在します: %s\n"
 
-#: src/store.c:45431
+#: src/store.c:45518
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr "store delete の store 名が不足しています\n"
 
-#: src/store.c:45436
+#: src/store.c:45523
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr "store delete の引数が不正です\n"
 
-#: src/store.c:45477
+#: src/store.c:45564
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:45486
+#: src/store.c:45573
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:45530
+#: src/store.c:45617
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr "key の値に NUL バイトが含まれているため export できません: %s\n"
 
-#: src/store.c:45730 src/store.c:45738
+#: src/store.c:45817 src/store.c:45825
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr "save の引数が不正です\n"
 
-#: src/store.c:45750
+#: src/store.c:45837
 msgid "Create secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを作成してください: "
 
-#: src/store.c:45751
+#: src/store.c:45838
 msgid "Confirm secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを再入力してください: "
 
-#: src/store.c:45807
+#: src/store.c:45894
 #, fuzzy, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45812
+#: src/store.c:45899
 #, fuzzy, c-format
 msgid "conflicting load conflict policies\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45825 src/store.c:45831
+#: src/store.c:45912 src/store.c:45918
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr "load の引数が不正です\n"
 
-#: src/store.c:45890
+#: src/store.c:45977
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45891
+#: src/store.c:45978
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45925
+#: src/store.c:46012
 msgid "Enter secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを入力してください: "
 
-#: src/store.c:46404
+#: src/store.c:46491
 #, c-format
 msgid "  dir=%s\n"
 msgstr "  dir=%s\n"
 
-#: src/store.c:46407
+#: src/store.c:46494
 #, c-format
 msgid "  domain=%s\n"
 msgstr "  domain=%s\n"
 
-#: src/store.c:46410
+#: src/store.c:46497
 #, c-format
 msgid "  store=%s\n"
 msgstr "  store=%s\n"
 
-#: src/store.c:46449
+#: src/store.c:46536
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr "mask action が不正です: %s\n"
 
-#: src/store.c:46453
+#: src/store.c:46540
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr "mask action option が競合しています\n"
 
-#: src/store.c:46467
+#: src/store.c:46554
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr "mask warning option が競合しています\n"
 
-#: src/store.c:46548
+#: src/store.c:46635
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr "--mask-action に値が必要です\n"
 
-#: src/store.c:46578 src/store.c:46610
+#: src/store.c:46665 src/store.c:46697
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr "mask warning policy が不正です: %s\n"
 
-#: src/store.c:46589
+#: src/store.c:46676
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr "--mask-warnings に値が必要です\n"
 
-#: src/store.c:47126
+#: src/store.c:47215
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr "mutation で mask を保持できませんでした\n"
 
-#: src/store.c:47225 src/store.c:47487
+#: src/store.c:47314 src/store.c:47576
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr "mutation plan のエンコードに失敗しました\n"
 
-#: src/store.c:47584
+#: src/store.c:47674
 #, c-format
 msgid "warning: %s: "
 msgstr "warning: %s: "
 
-#: src/store.c:47598
+#: src/store.c:47688
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr "%zu 件の masked key slot に直接影響しました"
 
-#: src/store.c:47602
+#: src/store.c:47692
+#, c-format
+msgid "%zu mask(s) followed preserved entry identity"
+msgstr "保持された entry identity を %zu 件の mask が追従しました"
+
+#: src/store.c:47696
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr "%zu 件の mask が休眠状態になりました"
 
-#: src/store.c:47606
+#: src/store.c:47700
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr "%zu 件の休眠 mask が再活性化しました"
 
-#: src/store.c:47610
+#: src/store.c:47704
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr "%zu 件の mask が孤児化しました"
 
-#: src/store.c:47614
+#: src/store.c:47708
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr "%zu 件の source mask を作成しました"
 
-#: src/store.c:47618
+#: src/store.c:47712
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr "。'secdat --dir DIR list --all-masks --long' で確認してください\n"
 
-#: src/store.c:47740
+#: src/store.c:47834
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr "曖昧な legacy mask がこの mutation を拒否しました\n"
 
-#: src/store.c:47741
+#: src/store.c:47835
 msgid "mask interaction rejected before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:47924
+#: src/store.c:48018
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr "mutation planning には登録済みの current domain が必要です\n"
 
-#: src/store.c:48042
+#: src/store.c:48136
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr "mutation planning option は --ephemeral と併用できません\n"
 
-#: src/store.c:48060
+#: src/store.c:48154
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr "--dir と --domain は同時に指定できません\n"
 
-#: src/store.c:48074 src/store.c:48083
+#: src/store.c:48168 src/store.c:48177
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr "保留中 transaction の復旧に失敗しました\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 17:53+0900\n"
+"POT-Creation-Date: 2026-08-28 19:23+0900\n"
 "PO-Revision-Date: 2026-04-13 00:00+0000\n"
 "Last-Translator: GitHub Copilot <noreply@example.invalid>\n"
 "Language-Team: ja\n"
@@ -2189,16 +2189,16 @@ msgstr "試してください: %s help\n"
 #: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
 #: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
 #: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
-#: src/store.c:29444 src/store.c:29479 src/store.c:29627 src/store.c:29826
-#: src/store.c:30872 src/store.c:31004 src/store.c:31620 src/store.c:36374
-#: src/store.c:36379 src/store.c:36716 src/store.c:36776 src/store.c:36782
-#: src/store.c:36857 src/store.c:36870 src/store.c:37918 src/store.c:37999
-#: src/store.c:38098 src/store.c:38136 src/store.c:39981 src/store.c:40069
-#: src/store.c:40119 src/store.c:41381 src/store.c:41542 src/store.c:41749
-#: src/store.c:43959 src/store.c:45515 src/store.c:45690 src/store.c:45932
-#: src/store.c:45957 src/store.c:45981 src/store.c:46061 src/store.c:46112
-#: src/store.c:46161 src/store.c:46201 src/store.c:46495 src/store.c:46803
-#: src/store.c:48101 src/store.c:48109
+#: src/store.c:29465 src/store.c:29500 src/store.c:29648 src/store.c:29847
+#: src/store.c:30893 src/store.c:31025 src/store.c:31641 src/store.c:36395
+#: src/store.c:36400 src/store.c:36737 src/store.c:36797 src/store.c:36803
+#: src/store.c:36878 src/store.c:36891 src/store.c:37939 src/store.c:38020
+#: src/store.c:38119 src/store.c:38157 src/store.c:40002 src/store.c:40090
+#: src/store.c:40140 src/store.c:41402 src/store.c:41563 src/store.c:41770
+#: src/store.c:43980 src/store.c:45536 src/store.c:45711 src/store.c:45953
+#: src/store.c:45978 src/store.c:46002 src/store.c:46082 src/store.c:46133
+#: src/store.c:46182 src/store.c:46222 src/store.c:46516 src/store.c:46824
+#: src/store.c:48122 src/store.c:48130
 #, c-format
 msgid "out of memory\n"
 msgstr "メモリ不足です\n"
@@ -2217,10 +2217,10 @@ msgstr "メモリ不足です\n"
 #: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
 #: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
 #: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
-#: src/store.c:19220 src/store.c:19581 src/store.c:30832 src/store.c:30954
-#: src/store.c:31259 src/store.c:33972 src/store.c:34179 src/store.c:34218
-#: src/store.c:34279 src/store.c:34504 src/store.c:34572 src/store.c:38811
-#: src/store.c:39725 src/store.c:40644
+#: src/store.c:19220 src/store.c:19581 src/store.c:30853 src/store.c:30975
+#: src/store.c:31280 src/store.c:33993 src/store.c:34200 src/store.c:34239
+#: src/store.c:34300 src/store.c:34525 src/store.c:34593 src/store.c:38832
+#: src/store.c:39746 src/store.c:40665
 #, c-format
 msgid "path is too long\n"
 msgstr "パスが長すぎます\n"
@@ -2352,7 +2352,7 @@ msgstr "domain が見つかりません: %s\n"
 msgid "failed to generate domain id\n"
 msgstr "domain id の生成に失敗しました\n"
 
-#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43907
+#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43928
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr "ディレクトリのオープンに失敗しました: %s\n"
@@ -2480,7 +2480,7 @@ msgstr "有効な取得元: inherited lock"
 msgid "effective source: locked"
 msgstr "実効取得元: locked"
 
-#: src/domain.c:2355 src/store.c:46381
+#: src/domain.c:2355 src/store.c:46402
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr "コマンドは未実装です: %s\n"
@@ -2548,7 +2548,7 @@ msgstr "不正な secret rename 式です\n"
 msgid "invalid secret rename regex: %s\n"
 msgstr "不正な secret rename 正規表現です: %s\n"
 
-#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45628 src/store.c:45698
+#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45649 src/store.c:45719
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr "key は有効な環境変数名ではありません: %s\n"
@@ -3407,7 +3407,7 @@ msgstr "secret value が大きすぎます\n"
 msgid "invalid overlay payload\n"
 msgstr "overlay payload が不正です\n"
 
-#: src/store.c:4949 src/store.c:30852
+#: src/store.c:4949 src/store.c:30873
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr "key visibility が不正です: %s\n"
@@ -3451,13 +3451,13 @@ msgstr "サポートされていない secret metadata field です: %s\n"
 msgid "unsupported secret metadata format\n"
 msgstr "サポートされていない secret metadata format です\n"
 
-#: src/store.c:5243 src/store.c:31210 src/store.c:37767
+#: src/store.c:5243 src/store.c:31231 src/store.c:37788
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr "secret value_access が storage mode と一致しません\n"
 
-#: src/store.c:5260 src/store.c:30909 src/store.c:30986 src/store.c:30998
-#: src/store.c:31355
+#: src/store.c:5260 src/store.c:30930 src/store.c:31007 src/store.c:31019
+#: src/store.c:31376
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr "secret metadata が大きすぎます\n"
@@ -3695,7 +3695,7 @@ msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 "アクティブなセッションエージェントが overlay protocol を完了しませんでした\n"
 
-#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37859
+#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37880
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
@@ -3704,7 +3704,7 @@ msgstr ""
 "現在のセッションでは key は ephemeral です。更新には set --ephemeral を使用し"
 "てください: %s\n"
 
-#: src/store.c:9472 src/store.c:37824
+#: src/store.c:9472 src/store.c:37845
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
@@ -3713,7 +3713,7 @@ msgstr ""
 "key には volatile session change があるため ephemeral secret で置き換えられま"
 "せん: %s\n"
 
-#: src/store.c:9514 src/store.c:9553 src/store.c:38800
+#: src/store.c:9514 src/store.c:9553 src/store.c:38821
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
@@ -3752,7 +3752,7 @@ msgstr "書き込み可能セッションを開始: secdat --dir %s unlock\n"
 msgid "current session is readonly and cannot run %s\n"
 msgstr "現在のセッションは読み取り専用のため %s を実行できません\n"
 
-#: src/store.c:10112 src/store.c:38766 src/store.c:38912 src/store.c:40969
+#: src/store.c:10112 src/store.c:38787 src/store.c:38933 src/store.c:40990
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr "key の削除に失敗しました: %s\n"
@@ -3773,7 +3773,7 @@ msgid "failed to derive wrap key\n"
 msgstr "wrap key の導出に失敗しました\n"
 
 #: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
-#: src/store.c:13458 src/store.c:30695
+#: src/store.c:13458 src/store.c:30716
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr "nonce の生成に失敗しました\n"
@@ -3809,9 +3809,9 @@ msgstr "認証タグの取得に失敗しました\n"
 msgid "invalid wrapped master key\n"
 msgstr "ラップ済み master key が不正です\n"
 
-#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45941
-#: src/store.c:45972 src/store.c:45992 src/store.c:46015 src/store.c:46183
-#: src/store.c:46191 src/store.c:46213 src/store.c:46229
+#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45962
+#: src/store.c:45993 src/store.c:46013 src/store.c:46036 src/store.c:46204
+#: src/store.c:46212 src/store.c:46234 src/store.c:46250
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr "secret bundle が不正です\n"
@@ -3822,10 +3822,10 @@ msgid "secret bundle has too many objects\n"
 msgstr "secret bundle が大きすぎます\n"
 
 #: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
-#: src/store.c:18176 src/store.c:18225 src/store.c:35337 src/store.c:35519
-#: src/store.c:37393 src/store.c:38855 src/store.c:38878 src/store.c:38932
-#: src/store.c:39203 src/store.c:39757 src/store.c:39789 src/store.c:41089
-#: src/store.c:42776
+#: src/store.c:18176 src/store.c:18225 src/store.c:35358 src/store.c:35540
+#: src/store.c:37414 src/store.c:38876 src/store.c:38899 src/store.c:38953
+#: src/store.c:39224 src/store.c:39778 src/store.c:39810 src/store.c:41110
+#: src/store.c:42797
 #, c-format
 msgid "key not found: %s\n"
 msgstr "key が見つかりません: %s\n"
@@ -3896,7 +3896,7 @@ msgstr "secret bundle の unlock に失敗しました\n"
 msgid "failed to unlock persistent master key\n"
 msgstr "永続 master key の unlock に失敗しました\n"
 
-#: src/store.c:12137 src/store.c:19086 src/store.c:41078
+#: src/store.c:12137 src/store.c:19086 src/store.c:41099
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
@@ -4118,10 +4118,10 @@ msgid "failed to authenticate encrypted value\n"
 msgstr "暗号化値の認証に失敗しました\n"
 
 #: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
-#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29399
-#: src/store.c:30018 src/store.c:30180 src/store.c:30762 src/store.c:30772
-#: src/store.c:31082 src/store.c:31118 src/store.c:31244 src/store.c:40786
-#: src/store.c:40809 src/store.c:42907
+#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29420
+#: src/store.c:30039 src/store.c:30201 src/store.c:30783 src/store.c:30793
+#: src/store.c:31103 src/store.c:31139 src/store.c:31265 src/store.c:40807
+#: src/store.c:40830 src/store.c:42928
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr "v2 domain entry が不正です: %s\n"
@@ -4131,11 +4131,11 @@ msgstr "v2 domain entry が不正です: %s\n"
 msgid "failed to read standard input\n"
 msgstr "標準入力の読み取りに失敗しました\n"
 
-#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30072
-#: src/store.c:30319 src/store.c:34035 src/store.c:34140 src/store.c:34470
-#: src/store.c:37458 src/store.c:37746 src/store.c:38555 src/store.c:38654
-#: src/store.c:38898 src/store.c:41069 src/store.c:43547 src/store.c:43693
-#: src/store.c:44105 src/store.c:44725 src/store.c:45449 src/store.c:46025
+#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30093
+#: src/store.c:30340 src/store.c:34056 src/store.c:34161 src/store.c:34491
+#: src/store.c:37479 src/store.c:37767 src/store.c:38576 src/store.c:38675
+#: src/store.c:38919 src/store.c:41090 src/store.c:43568 src/store.c:43714
+#: src/store.c:44126 src/store.c:44746 src/store.c:45470 src/store.c:46046
 #, c-format
 msgid "invalid store format marker\n"
 msgstr "store format marker が不正です\n"
@@ -4162,8 +4162,8 @@ msgstr ""
 "ヒント: secdat status、--dir、--store を確認して探索文脈が正しいか確かめてく"
 "ださい\n"
 
-#: src/store.c:14608 src/store.c:30660 src/store.c:31088 src/store.c:31092
-#: src/store.c:31232 src/store.c:38702 src/store.c:38709 src/store.c:40792
+#: src/store.c:14608 src/store.c:30681 src/store.c:31109 src/store.c:31113
+#: src/store.c:31253 src/store.c:38723 src/store.c:38730 src/store.c:40813
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr "v2 secret object が不正です: %s\n"
@@ -4173,7 +4173,7 @@ msgstr "v2 secret object が不正です: %s\n"
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr "v2 secret value storage はまだ実装されていません\n"
 
-#: src/store.c:15874 src/store.c:38029
+#: src/store.c:15874 src/store.c:38050
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr "random bytes の生成に失敗しました\n"
@@ -4206,8 +4206,8 @@ msgstr "secret bundle のエントリが大きすぎます\n"
 msgid "metadata is too large\n"
 msgstr "metadata が大きすぎます\n"
 
-#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35543
-#: src/store.c:35663 src/store.c:36919
+#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35564
+#: src/store.c:35684 src/store.c:36940
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr "metadata field が不正です: %s\n"
@@ -4247,7 +4247,7 @@ msgstr "relation member role が重複しています: %s\n"
 msgid "invalid relation member: %s\n"
 msgstr "relation member が不正です: %s\n"
 
-#: src/store.c:18253 src/store.c:35822
+#: src/store.c:18253 src/store.c:35843
 #, c-format
 msgid "relation not found: %s\n"
 msgstr "relation が見つかりません: %s\n"
@@ -4514,7 +4514,7 @@ msgid "cannot index relation dependency: %s\n"
 msgstr "relation dependency をindex化できません: %s\n"
 
 #: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
-#: src/store.c:28839 src/store.c:29197 src/store.c:29212
+#: src/store.c:28839 src/store.c:29218 src/store.c:29233
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
@@ -4523,7 +4523,7 @@ msgstr ""
 "dependency index が破損しています。fsck --format v2 --dependency-index --"
 "repair を実行してください\n"
 
-#: src/store.c:28061 src/store.c:28266 src/store.c:29187 src/store.c:42824
+#: src/store.c:28061 src/store.c:28266 src/store.c:29208 src/store.c:42845
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
@@ -4552,7 +4552,7 @@ msgstr ""
 msgid "invalid dependency index node: %s\n"
 msgstr "dependency index node が不正です: %s\n"
 
-#: src/store.c:29325
+#: src/store.c:29346
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
@@ -4560,57 +4560,57 @@ msgstr ""
 "dependency index generation が変更されました: first=%s/%zu/%zu second=%s/%zu/"
 "%zu\n"
 
-#: src/store.c:29373
+#: src/store.c:29394
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr "dependency index の再構築が %s で失敗しました\n"
 
-#: src/store.c:29935
+#: src/store.c:29956
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr "tombstone file が不正です: %s\n"
 
-#: src/store.c:29965 src/store.c:29974 src/store.c:29978
+#: src/store.c:29986 src/store.c:29995 src/store.c:29999
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr "v2 compatibility tombstone が不正です\n"
 
-#: src/store.c:30056
+#: src/store.c:30077
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr "v2 mask の target store が不正です: %s\n"
 
-#: src/store.c:30095 src/store.c:41864
+#: src/store.c:30116 src/store.c:41885
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr "v2 mask の target entry が重複しています: %s\n"
 
-#: src/store.c:30133
+#: src/store.c:30154
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr "暗号化された v2 mask name が不正です: %s\n"
 
-#: src/store.c:30154 src/store.c:30275
+#: src/store.c:30175 src/store.c:30296
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr "v2 mask の target が不正です: %s\n"
 
-#: src/store.c:30194 src/store.c:30200
+#: src/store.c:30215 src/store.c:30221
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr "v2 mask の target name が不正です: %s\n"
 
-#: src/store.c:30239
+#: src/store.c:30260
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr "v2 mask directory が不正です\n"
 
-#: src/store.c:30243 src/store.c:31442
+#: src/store.c:30264 src/store.c:31463
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr "v2 mask directory を確認できませんでした\n"
 
-#: src/store.c:30263
+#: src/store.c:30284
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
@@ -4619,85 +4619,85 @@ msgstr ""
 "不正な v2 mask record です: %s。診断ハンドルを得るには fsck --format v2 --"
 "dangling を実行してください\n"
 
-#: src/store.c:30519 src/store.c:39458
+#: src/store.c:30540 src/store.c:39479
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr "互換 tombstone が canonical mask と一致しません: %s\n"
 
-#: src/store.c:30637
+#: src/store.c:30658
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 "非表示の mask name が lock されているため mask の影響を解析できません\n"
 
-#: src/store.c:31096 src/store.c:31238
+#: src/store.c:31117 src/store.c:31259
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr "secret object が bulk select を除外しています: %s\n"
 
-#: src/store.c:31404
+#: src/store.c:31425
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr "mask 診断ハンドルのエンコードに失敗しました\n"
 
-#: src/store.c:31991
+#: src/store.c:32012
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32716
+#: src/store.c:32737
 #, fuzzy, c-format
 #| msgid "lock --save requires a local volatile session\n"
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr "lock --save にはローカルの揮発セッションが必要です\n"
 
-#: src/store.c:33343
+#: src/store.c:33364
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33758
+#: src/store.c:33779
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:34027 src/store.c:34132
+#: src/store.c:34048 src/store.c:34153
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr "fsck には登録済みの current domain が必要です\n"
 
-#: src/store.c:34039
+#: src/store.c:34060
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr "store format は v2 です。--format v2 を使用してください\n"
 
-#: src/store.c:34144
+#: src/store.c:34165
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr "store format は v1 です。--format v1 を使用してください\n"
 
-#: src/store.c:34455 src/store.c:34845
+#: src/store.c:34476 src/store.c:34866
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr "gc には登録済みの current domain が必要です\n"
 
-#: src/store.c:34474
+#: src/store.c:34495
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr "store format は v1 です。gc には --format v2 が必要です\n"
 
-#: src/store.c:34678
+#: src/store.c:34699
 #, fuzzy, c-format
 #| msgid "mask interaction rejected before mutation\n"
 msgid "GC owner domain must be registered before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:34856
+#: src/store.c:34877
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr "gc は --format v2 でのみサポートされています\n"
 
-#: src/store.c:35262
+#: src/store.c:35283
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
@@ -4706,7 +4706,7 @@ msgstr ""
 "%zu 件の非表示 mask を省略しました。対象ドメインを unlock するか、件数確認に"
 "は --json を使用してください\n"
 
-#: src/store.c:35273
+#: src/store.c:35294
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
@@ -4715,12 +4715,12 @@ msgstr ""
 "ancestor の key name が lock されているため %zu 件の mask 状態が不完全です。"
 "対象 domain を unlock するか、件数確認には --json を使用してください\n"
 
-#: src/store.c:35358 src/store.c:35428
+#: src/store.c:35379 src/store.c:35449
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr "継承された key attributes は更新できません: %s\n"
 
-#: src/store.c:35420
+#: src/store.c:35441
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
@@ -4729,243 +4729,243 @@ msgstr ""
 "ephemeral secret の secret attributes は変更できません。set --ephemeral で作"
 "り直してください\n"
 
-#: src/store.c:35421
+#: src/store.c:35442
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes を変更できません\n"
 
-#: src/store.c:35550 src/store.c:35670
+#: src/store.c:35571 src/store.c:35691
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr "継承された key metadata は更新できません: %s\n"
 
-#: src/store.c:35557 src/store.c:35677
+#: src/store.c:35578 src/store.c:35698
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr "ephemeral secret の key metadata は変更できません\n"
 
-#: src/store.c:35558 src/store.c:35678
+#: src/store.c:35579 src/store.c:35699
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では key metadata を変更できません\n"
 
-#: src/store.c:35563
+#: src/store.c:35584
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を設定できません: %s\n"
 
-#: src/store.c:35595
+#: src/store.c:35616
 #, c-format
 msgid "missing key for meta get\n"
 msgstr "meta get の key が不足しています\n"
 
-#: src/store.c:35595
+#: src/store.c:35616
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr "meta get の引数が不正です\n"
 
-#: src/store.c:35623
+#: src/store.c:35644
 #, c-format
 msgid "missing key for meta set\n"
 msgstr "meta set の key が不足しています\n"
 
-#: src/store.c:35623
+#: src/store.c:35644
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:35635
+#: src/store.c:35656
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr "meta mark-leaked の key が不足しています\n"
 
-#: src/store.c:35635
+#: src/store.c:35656
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr "meta mark-leaked の引数が不正です\n"
 
-#: src/store.c:35658
+#: src/store.c:35679
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr "meta unset の key が不足しています\n"
 
-#: src/store.c:35658
+#: src/store.c:35679
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr "meta unset の引数が不正です\n"
 
-#: src/store.c:35957
+#: src/store.c:35978
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr "relation kind が不正です: %s\n"
 
-#: src/store.c:36001
+#: src/store.c:36022
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr "relation member は ephemeral secret を参照できません: %s\n"
 
-#: src/store.c:36007
+#: src/store.c:36028
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr "relation member は hidden v2 key を参照できません: %s\n"
 
-#: src/store.c:36044 src/store.c:36051
+#: src/store.c:36065 src/store.c:36072
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr "relation set の引数が不正です\n"
 
-#: src/store.c:36051
+#: src/store.c:36072
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr "relation set の relation id が不足しています\n"
 
-#: src/store.c:36057 src/store.c:37251 src/store.c:37300
+#: src/store.c:36078 src/store.c:37272 src/store.c:37321
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr "relation id が不正です: %s\n"
 
-#: src/store.c:36062
+#: src/store.c:36083
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 "relation set には少なくとも 2 つの --member ROLE=KEYREF option が必要です\n"
 
-#: src/store.c:36074 src/store.c:37310
+#: src/store.c:36095 src/store.c:37331
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr "volatile session overlay では relation を変更できません\n"
 
-#: src/store.c:36927 src/store.c:36933
+#: src/store.c:36948 src/store.c:36954
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr "relation suggest-link の引数が不正です\n"
 
-#: src/store.c:37126
+#: src/store.c:37147
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr "relation ls の引数が不正です\n"
 
-#: src/store.c:37145
+#: src/store.c:37166
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr "relation ls には登録済みの current domain が必要です\n"
 
-#: src/store.c:37198
+#: src/store.c:37219
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr "relation search には登録済みの current domain が必要です\n"
 
-#: src/store.c:37231
+#: src/store.c:37252
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の key が不足しています\n"
 
-#: src/store.c:37231
+#: src/store.c:37252
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr "relation suggest-refresh の引数が不正です\n"
 
-#: src/store.c:37246
+#: src/store.c:37267
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr "relation show の relation id が不足しています\n"
 
-#: src/store.c:37246
+#: src/store.c:37267
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr "relation show の引数が不正です\n"
 
-#: src/store.c:37258
+#: src/store.c:37279
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr "relation show には登録済みの current domain が必要です\n"
 
-#: src/store.c:37295
+#: src/store.c:37316
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr "relation rm の relation id が不足しています\n"
 
-#: src/store.c:37295
+#: src/store.c:37316
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr "relation rm の引数が不正です\n"
 
-#: src/store.c:37340
+#: src/store.c:37361
 #, c-format
 msgid "missing key for exists\n"
 msgstr "exists のキーが不足しています\n"
 
-#: src/store.c:37345
+#: src/store.c:37366
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr "exists の引数が不正です\n"
 
-#: src/store.c:37374
+#: src/store.c:37395
 #, c-format
 msgid "missing key for id\n"
 msgstr "id のキーが不足しています\n"
 
-#: src/store.c:37379
+#: src/store.c:37400
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr "id の引数が不正です\n"
 
-#: src/store.c:37399
+#: src/store.c:37420
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr "secret id は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37427
+#: src/store.c:37448
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr "secret status の UUID が不足しています\n"
 
-#: src/store.c:37437
+#: src/store.c:37458
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:37442
+#: src/store.c:37463
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr "secret status の UUID が不正です: %s\n"
 
-#: src/store.c:37450
+#: src/store.c:37471
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr "secret status には登録済みの current domain が必要です\n"
 
-#: src/store.c:37462
+#: src/store.c:37483
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr "secret status は store format v2 でのみ利用できます\n"
 
-#: src/store.c:37472
+#: src/store.c:37493
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr "secret object が見つかりません: %s\n"
 
-#: src/store.c:37476
+#: src/store.c:37497
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:37606
+#: src/store.c:37627
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr "key の値に NUL バイトが含まれているため shell escaped できません: %s\n"
 
-#: src/store.c:37620 src/store.c:37688
+#: src/store.c:37641 src/store.c:37709
 #, c-format
 msgid "failed to write standard output\n"
 msgstr "標準出力への書き込みに失敗しました\n"
 
-#: src/store.c:37669
+#: src/store.c:37690
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr "secret を端末へ書き出すことを拒否しました\n"
 
-#: src/store.c:37816 src/store.c:38357
+#: src/store.c:37837 src/store.c:38378
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
@@ -4973,96 +4973,96 @@ msgstr ""
 "ephemeral secret には key_visibility=unlocked と value_access=unlocked が必要"
 "です\n"
 
-#: src/store.c:37871 src/store.c:38832 src/store.c:47891
+#: src/store.c:37892 src/store.c:38853 src/store.c:47912
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では mutation planning はサポートされません\n"
 
-#: src/store.c:37886
+#: src/store.c:37907
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では secret attributes はサポートされません\n"
 
-#: src/store.c:37991 src/store.c:38239 src/store.c:38249 src/store.c:38271
-#: src/store.c:38296 src/store.c:38305 src/store.c:38315 src/store.c:38344
-#: src/store.c:38420 src/store.c:38453 src/store.c:38462
+#: src/store.c:38012 src/store.c:38260 src/store.c:38270 src/store.c:38292
+#: src/store.c:38317 src/store.c:38326 src/store.c:38336 src/store.c:38365
+#: src/store.c:38441 src/store.c:38474 src/store.c:38483
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr "set の引数が不正です\n"
 
-#: src/store.c:38023
+#: src/store.c:38044
 #, fuzzy, c-format
 msgid "invalid generated secret charset\n"
 msgstr "secret status の引数が不正です\n"
 
-#: src/store.c:38044
+#: src/store.c:38065
 #, fuzzy, c-format
 msgid "generated secret charset is too large\n"
 msgstr "secret value が大きすぎます\n"
 
-#: src/store.c:38092
+#: src/store.c:38113
 #, fuzzy, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:38106 src/store.c:38115
+#: src/store.c:38127 src/store.c:38136
 #, fuzzy, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr "secret object が不正です: %s\n"
 
-#: src/store.c:38120
+#: src/store.c:38141
 #, fuzzy, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr "secret rename で環境変数名が重複しました: %s\n"
 
-#: src/store.c:38131
+#: src/store.c:38152
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38322
+#: src/store.c:38343
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr "環境変数が設定されていません: %s\n"
 
-#: src/store.c:38366
+#: src/store.c:38387
 #, c-format
 msgid "missing key for set\n"
 msgstr "set のキーが不足しています\n"
 
-#: src/store.c:38376
+#: src/store.c:38397
 #, fuzzy, c-format
 msgid "invalid arguments for generated set\n"
 msgstr "meta set の引数が不正です\n"
 
-#: src/store.c:38402
+#: src/store.c:38423
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38426
+#: src/store.c:38447
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr "set --ephemeral は key を 1 つだけ受け付けます\n"
 
-#: src/store.c:38475
+#: src/store.c:38496
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr "端末から secret を読み取ることを拒否しました\n"
 
-#: src/store.c:39015
+#: src/store.c:39036
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr "key に継承された mask target がありません: %s\n"
 
-#: src/store.c:39124
+#: src/store.c:39145
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 "orphan mask chain が不正です。fsck --format v2 --dangling で確認してくださ"
 "い: %s\n"
 
-#: src/store.c:39133
+#: src/store.c:39154
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
@@ -5070,12 +5070,12 @@ msgstr ""
 "複数の orphan mask chain が key に一致します。list --all-masks --long で確認"
 "してください: %s\n"
 
-#: src/store.c:39162
+#: src/store.c:39183
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr "key に rebind 対象の mask barrier がありません: %s\n"
 
-#: src/store.c:39189
+#: src/store.c:39210
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -5086,27 +5086,27 @@ msgstr ""
 "ancestors と各 ancestor の id KEY で確認し、unmask せずに重複またはアクセス不"
 "能な候補を解消してください: %s\n"
 
-#: src/store.c:39210
+#: src/store.c:39231
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr "canonical mask には継承された v2 entry が必要です: %s\n"
 
-#: src/store.c:39268
+#: src/store.c:39289
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr "orphan mask barrier には mask --rebind が必要です: %s\n"
 
-#: src/store.c:39292
+#: src/store.c:39313
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr "canonical mask target が競合しています: %s\n"
 
-#: src/store.c:39298 src/store.c:39308
+#: src/store.c:39319 src/store.c:39329
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr "canonical mask name が競合しています: %s\n"
 
-#: src/store.c:39319
+#: src/store.c:39340
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
@@ -5115,7 +5115,7 @@ msgstr ""
 "target は別の chain ですでに mask されています。list --all-masks --long で確"
 "認し、unmask --dry-run --mask-chain で chain を選択してください: %s\n"
 
-#: src/store.c:39406
+#: src/store.c:39427
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
@@ -5123,7 +5123,7 @@ msgid ""
 msgstr ""
 "hidden-name mask は名前を露出せずに v1 rollback state へ投影できません: %s\n"
 
-#: src/store.c:39434
+#: src/store.c:39455
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
@@ -5133,38 +5133,38 @@ msgstr ""
 "認し、継承 v2 target が一つだけになってから mask --rebind を実行してくださ"
 "い: %s\n"
 
-#: src/store.c:39541 src/store.c:40349 src/store.c:40384 src/store.c:40391
-#: src/store.c:40488 src/store.c:40494
+#: src/store.c:39562 src/store.c:40370 src/store.c:40405 src/store.c:40412
+#: src/store.c:40509 src/store.c:40515
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr "mask operation plan のエンコードに失敗しました\n"
 
-#: src/store.c:39697
+#: src/store.c:39718
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では %s はサポートされません: %s\n"
 
-#: src/store.c:39747 src/store.c:39779
+#: src/store.c:39768 src/store.c:39800
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr "key はローカルに存在するため mask できません: %s\n"
 
-#: src/store.c:39899
+#: src/store.c:39920
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr "一致する mask state が lock されているため unmask できません\n"
 
-#: src/store.c:39915
+#: src/store.c:39936
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr "曖昧な legacy mask は unmask の前に mask --rebind が必要です: %s\n"
 
-#: src/store.c:39948
+#: src/store.c:39969
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr "mask chain は要求した key を保護していません: %s\n"
 
-#: src/store.c:39956
+#: src/store.c:39977
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
@@ -5173,17 +5173,17 @@ msgstr ""
 "複数の mask chain が key に一致します。list --all-masks --long と --mask-"
 "chain を使ってください: %s\n"
 
-#: src/store.c:40022
+#: src/store.c:40043
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr "plan 作成後に mask state が変更されました\n"
 
-#: src/store.c:40029 src/store.c:40667 src/store.c:40679
+#: src/store.c:40050 src/store.c:40688 src/store.c:40700
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr "key は現在の domain で mask されていません: %s\n"
 
-#: src/store.c:40062
+#: src/store.c:40083
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
@@ -5192,7 +5192,7 @@ msgstr ""
 "mask chain は複数の key name を保護しています。unmask --dry-run --mask-chain "
 "で確認してください: %s\n"
 
-#: src/store.c:40664
+#: src/store.c:40685
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
@@ -5200,59 +5200,59 @@ msgid ""
 msgstr ""
 "揮発セッション overlay が有効な間は永続 tombstone を unmask できません: %s\n"
 
-#: src/store.c:40713
+#: src/store.c:40734
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr "ln の UUID source が不正です: %s\n"
 
-#: src/store.c:40747
+#: src/store.c:40768
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr "secret UUID は現在の context で認可されていません: %s\n"
 
-#: src/store.c:40889 src/store.c:40895
+#: src/store.c:40910 src/store.c:40916
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr "ln の引数が不正です\n"
 
-#: src/store.c:40900
+#: src/store.c:40921
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr "--skip-same-value-check には --replace が必要です\n"
 
-#: src/store.c:40954 src/store.c:41262 src/store.c:42772 src/store.c:43282
-#: src/store.c:45837
+#: src/store.c:40975 src/store.c:41283 src/store.c:42793 src/store.c:43303
+#: src/store.c:45858
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr "destination key はすでに存在します: %s\n"
 
-#: src/store.c:41006
+#: src/store.c:41027
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr "UUID reference は ln source としてのみ有効です: %s\n"
 
-#: src/store.c:41011 src/store.c:41046 src/store.c:41125 src/store.c:41209
-#: src/store.c:41233 src/store.c:43228 src/store.c:43252
+#: src/store.c:41032 src/store.c:41067 src/store.c:41146 src/store.c:41230
+#: src/store.c:41254 src/store.c:43249 src/store.c:43273
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr "source key と destination key は異なる必要があります\n"
 
-#: src/store.c:41062
+#: src/store.c:41083
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr "volatile session overlay では ln はサポートされません\n"
 
-#: src/store.c:41073 src/store.c:41098
+#: src/store.c:41094 src/store.c:41119
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr "ln には v2 store 内の source と destination が必要です\n"
 
-#: src/store.c:41094 src/store.c:41106
+#: src/store.c:41115 src/store.c:41127
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では ln はサポートされません: %s\n"
 
-#: src/store.c:41112
+#: src/store.c:41133
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
@@ -5261,12 +5261,12 @@ msgstr ""
 "destination key はすでに存在します: %s (値確認後に同名 key を置換するには --"
 "replace を使用してください)\n"
 
-#: src/store.c:41118
+#: src/store.c:41139
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr "ln --replace は既存の同名 key reference のみサポートします\n"
 
-#: src/store.c:41145
+#: src/store.c:41166
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
@@ -5275,37 +5275,37 @@ msgstr ""
 "同名 destination の値が異なります: %s (それでも置換するには --replace と --"
 "skip-same-value-check を併用してください)\n"
 
-#: src/store.c:41204
+#: src/store.c:41225
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr "cp の引数が不正です\n"
 
-#: src/store.c:41275
+#: src/store.c:41296
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では cp はサポートされません: %s\n"
 
-#: src/store.c:41299 src/store.c:42935 src/store.c:43366
+#: src/store.c:41320 src/store.c:42956 src/store.c:43387
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr "hidden v2 key には key metadata を保持できません: %s\n"
 
-#: src/store.c:41374
+#: src/store.c:41395
 #, c-format
 msgid "too many move relation dependencies\n"
 msgstr "mv の relation dependency が多すぎます\n"
 
-#: src/store.c:41875
+#: src/store.c:41896
 #, c-format
 msgid "affected descendant mask is inaccessible: %s\n"
 msgstr "影響を受ける descendant mask にアクセスできません: %s\n"
 
-#: src/store.c:42778 src/store.c:43308
+#: src/store.c:42799 src/store.c:43329
 #, c-format
 msgid "mv requires v2 source and destination stores\n"
 msgstr "mv の source と destination は v2 store である必要があります\n"
 
-#: src/store.c:42798
+#: src/store.c:42819
 #, c-format
 msgid ""
 "mv mutation planning requires a local source in the same v2 domain and "
@@ -5314,54 +5314,54 @@ msgstr ""
 "mv の mutation planning には同じ v2 domain/store 内の local source が必要で"
 "す\n"
 
-#: src/store.c:42894
+#: src/store.c:42915
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
 "namespace をまたぐ mv には正規化済み v2 object value storage が必要です\n"
 
-#: src/store.c:43223
+#: src/store.c:43244
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr "mv の引数が不正です\n"
 
-#: src/store.c:43296
+#: src/store.c:43317
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr "ephemeral secret では mv はサポートされません: %s\n"
 
-#: src/store.c:43325 src/store.c:47921
+#: src/store.c:43346 src/store.c:47942
 #, c-format
 msgid "mask mutation planning requires store format v2\n"
 msgstr "mask mutation planning には store format v2 が必要です\n"
 
-#: src/store.c:43332
+#: src/store.c:43353
 #, c-format
 msgid "mv requires matching source and destination store formats\n"
 msgstr ""
 "mv の source と destination の store format は一致している必要があります\n"
 
-#: src/store.c:43496
+#: src/store.c:43517
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr "%s の引数が不正です\n"
 
-#: src/store.c:43563
+#: src/store.c:43584
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr "mask planning と rebind には永続 v2 store が必要です\n"
 
-#: src/store.c:43592
+#: src/store.c:43613
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr "canonical mask planning には継承された v2 entry が必要です\n"
 
-#: src/store.c:43712
+#: src/store.c:43733
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr "unmask planning には永続 v2 store が必要です\n"
 
-#: src/store.c:43763
+#: src/store.c:43784
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
@@ -5370,7 +5370,7 @@ msgstr ""
 "warning: unmask: mask chain を削除しましたが、%s は他の %zu 個の chain また"
 "は barrier によって mask されたままです\n"
 
-#: src/store.c:43770
+#: src/store.c:43791
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
@@ -5379,269 +5379,269 @@ msgstr ""
 "warning: unmask: %s は local のままです。後で削除すると継承値が露出する可能性"
 "があります\n"
 
-#: src/store.c:43804
+#: src/store.c:43825
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr "ephemeral key が見つかりません: %s\n"
 
-#: src/store.c:43810
+#: src/store.c:43831
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 "継承された ephemeral key は削除できません。source domain を使用してください: "
 "%s\n"
 
-#: src/store.c:43852 src/store.c:43859
+#: src/store.c:43873 src/store.c:43880
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr "rm の引数が不正です\n"
 
-#: src/store.c:43987 src/store.c:44498 src/store.c:44856 src/store.c:45319
-#: src/store.c:45405
+#: src/store.c:44008 src/store.c:44519 src/store.c:44877 src/store.c:45340
+#: src/store.c:45426
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr "--store は store コマンドでは使えません\n"
 
-#: src/store.c:44087
+#: src/store.c:44108
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr "store migrate には登録済みの current domain が必要です\n"
 
-#: src/store.c:44098 src/store.c:44718 src/store.c:45440
+#: src/store.c:44119 src/store.c:44739 src/store.c:45461
 #, c-format
 msgid "store not found: %s\n"
 msgstr "store が見つかりません: %s\n"
 
-#: src/store.c:44109
+#: src/store.c:44130
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr "store format は v2 です。migration は不要です\n"
 
-#: src/store.c:44387
+#: src/store.c:44408
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr "v2 migration artifacts はすでに存在します\n"
 
-#: src/store.c:44456
+#: src/store.c:44477
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr "v2 migration verification に失敗しました\n"
 
-#: src/store.c:44708
+#: src/store.c:44729
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr "store finalize-migration には登録済みの current domain が必要です\n"
 
-#: src/store.c:44729
+#: src/store.c:44750
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 "store format は v1 です。finalize-migration には migrated v2 store が必要で"
 "す\n"
 
-#: src/store.c:45267
+#: src/store.c:45288
 #, fuzzy, c-format
 #| msgid "store is not empty: %s\n"
 msgid "domain is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:45324
+#: src/store.c:45345
 #, c-format
 msgid "missing store name for store create\n"
 msgstr "store create の store 名が不足しています\n"
 
-#: src/store.c:45329
+#: src/store.c:45350
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr "store create の引数が不正です\n"
 
-#: src/store.c:45354
+#: src/store.c:45375
 #, c-format
 msgid "store already exists: %s\n"
 msgstr "store はすでに存在します: %s\n"
 
-#: src/store.c:45410
+#: src/store.c:45431
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr "store delete の store 名が不足しています\n"
 
-#: src/store.c:45415
+#: src/store.c:45436
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr "store delete の引数が不正です\n"
 
-#: src/store.c:45456
+#: src/store.c:45477
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr "store は空ではありません: %s\n"
 
-#: src/store.c:45465
+#: src/store.c:45486
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:45509
+#: src/store.c:45530
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr "key の値に NUL バイトが含まれているため export できません: %s\n"
 
-#: src/store.c:45709 src/store.c:45717
+#: src/store.c:45730 src/store.c:45738
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr "save の引数が不正です\n"
 
-#: src/store.c:45729
+#: src/store.c:45750
 msgid "Create secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを作成してください: "
 
-#: src/store.c:45730
+#: src/store.c:45751
 msgid "Confirm secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを再入力してください: "
 
-#: src/store.c:45786
+#: src/store.c:45807
 #, fuzzy, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45791
+#: src/store.c:45812
 #, fuzzy, c-format
 msgid "conflicting load conflict policies\n"
 msgstr "bulk select policy が不正です: %s\n"
 
-#: src/store.c:45804 src/store.c:45810
+#: src/store.c:45825 src/store.c:45831
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr "load の引数が不正です\n"
 
-#: src/store.c:45869
+#: src/store.c:45890
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45870
+#: src/store.c:45891
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45904
+#: src/store.c:45925
 msgid "Enter secdat bundle passphrase: "
 msgstr "secdat bundle 用パスフレーズを入力してください: "
 
-#: src/store.c:46383
+#: src/store.c:46404
 #, c-format
 msgid "  dir=%s\n"
 msgstr "  dir=%s\n"
 
-#: src/store.c:46386
+#: src/store.c:46407
 #, c-format
 msgid "  domain=%s\n"
 msgstr "  domain=%s\n"
 
-#: src/store.c:46389
+#: src/store.c:46410
 #, c-format
 msgid "  store=%s\n"
 msgstr "  store=%s\n"
 
-#: src/store.c:46428
+#: src/store.c:46449
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr "mask action が不正です: %s\n"
 
-#: src/store.c:46432
+#: src/store.c:46453
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr "mask action option が競合しています\n"
 
-#: src/store.c:46446
+#: src/store.c:46467
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr "mask warning option が競合しています\n"
 
-#: src/store.c:46527
+#: src/store.c:46548
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr "--mask-action に値が必要です\n"
 
-#: src/store.c:46557 src/store.c:46589
+#: src/store.c:46578 src/store.c:46610
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr "mask warning policy が不正です: %s\n"
 
-#: src/store.c:46568
+#: src/store.c:46589
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr "--mask-warnings に値が必要です\n"
 
-#: src/store.c:47105
+#: src/store.c:47126
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr "mutation で mask を保持できませんでした\n"
 
-#: src/store.c:47204 src/store.c:47466
+#: src/store.c:47225 src/store.c:47487
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr "mutation plan のエンコードに失敗しました\n"
 
-#: src/store.c:47563
+#: src/store.c:47584
 #, c-format
 msgid "warning: %s: "
 msgstr "warning: %s: "
 
-#: src/store.c:47577
+#: src/store.c:47598
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr "%zu 件の masked key slot に直接影響しました"
 
-#: src/store.c:47581
+#: src/store.c:47602
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr "%zu 件の mask が休眠状態になりました"
 
-#: src/store.c:47585
+#: src/store.c:47606
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr "%zu 件の休眠 mask が再活性化しました"
 
-#: src/store.c:47589
+#: src/store.c:47610
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr "%zu 件の mask が孤児化しました"
 
-#: src/store.c:47593
+#: src/store.c:47614
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr "%zu 件の source mask を作成しました"
 
-#: src/store.c:47597
+#: src/store.c:47618
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr "。'secdat --dir DIR list --all-masks --long' で確認してください\n"
 
-#: src/store.c:47719
+#: src/store.c:47740
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr "曖昧な legacy mask がこの mutation を拒否しました\n"
 
-#: src/store.c:47720
+#: src/store.c:47741
 msgid "mask interaction rejected before mutation\n"
 msgstr "mutation 前に mask interaction を拒否しました\n"
 
-#: src/store.c:47903
+#: src/store.c:47924
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr "mutation planning には登録済みの current domain が必要です\n"
 
-#: src/store.c:48021
+#: src/store.c:48042
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr "mutation planning option は --ephemeral と併用できません\n"
 
-#: src/store.c:48039
+#: src/store.c:48060
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr "--dir と --domain は同時に指定できません\n"
 
-#: src/store.c:48053 src/store.c:48062
+#: src/store.c:48074 src/store.c:48083
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr "保留中 transaction の復旧に失敗しました\n"

--- a/po/secdat.pot
+++ b/po/secdat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 17:53+0900\n"
+"POT-Creation-Date: 2026-08-28 19:23+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1762,16 +1762,16 @@ msgstr ""
 #: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
 #: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
 #: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
-#: src/store.c:29444 src/store.c:29479 src/store.c:29627 src/store.c:29826
-#: src/store.c:30872 src/store.c:31004 src/store.c:31620 src/store.c:36374
-#: src/store.c:36379 src/store.c:36716 src/store.c:36776 src/store.c:36782
-#: src/store.c:36857 src/store.c:36870 src/store.c:37918 src/store.c:37999
-#: src/store.c:38098 src/store.c:38136 src/store.c:39981 src/store.c:40069
-#: src/store.c:40119 src/store.c:41381 src/store.c:41542 src/store.c:41749
-#: src/store.c:43959 src/store.c:45515 src/store.c:45690 src/store.c:45932
-#: src/store.c:45957 src/store.c:45981 src/store.c:46061 src/store.c:46112
-#: src/store.c:46161 src/store.c:46201 src/store.c:46495 src/store.c:46803
-#: src/store.c:48101 src/store.c:48109
+#: src/store.c:29465 src/store.c:29500 src/store.c:29648 src/store.c:29847
+#: src/store.c:30893 src/store.c:31025 src/store.c:31641 src/store.c:36395
+#: src/store.c:36400 src/store.c:36737 src/store.c:36797 src/store.c:36803
+#: src/store.c:36878 src/store.c:36891 src/store.c:37939 src/store.c:38020
+#: src/store.c:38119 src/store.c:38157 src/store.c:40002 src/store.c:40090
+#: src/store.c:40140 src/store.c:41402 src/store.c:41563 src/store.c:41770
+#: src/store.c:43980 src/store.c:45536 src/store.c:45711 src/store.c:45953
+#: src/store.c:45978 src/store.c:46002 src/store.c:46082 src/store.c:46133
+#: src/store.c:46182 src/store.c:46222 src/store.c:46516 src/store.c:46824
+#: src/store.c:48122 src/store.c:48130
 #, c-format
 msgid "out of memory\n"
 msgstr ""
@@ -1790,10 +1790,10 @@ msgstr ""
 #: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
 #: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
 #: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
-#: src/store.c:19220 src/store.c:19581 src/store.c:30832 src/store.c:30954
-#: src/store.c:31259 src/store.c:33972 src/store.c:34179 src/store.c:34218
-#: src/store.c:34279 src/store.c:34504 src/store.c:34572 src/store.c:38811
-#: src/store.c:39725 src/store.c:40644
+#: src/store.c:19220 src/store.c:19581 src/store.c:30853 src/store.c:30975
+#: src/store.c:31280 src/store.c:33993 src/store.c:34200 src/store.c:34239
+#: src/store.c:34300 src/store.c:34525 src/store.c:34593 src/store.c:38832
+#: src/store.c:39746 src/store.c:40665
 #, c-format
 msgid "path is too long\n"
 msgstr ""
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "failed to generate domain id\n"
 msgstr ""
 
-#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43907
+#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43928
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr ""
@@ -2051,7 +2051,7 @@ msgstr ""
 msgid "effective source: locked"
 msgstr ""
 
-#: src/domain.c:2355 src/store.c:46381
+#: src/domain.c:2355 src/store.c:46402
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "invalid secret rename regex: %s\n"
 msgstr ""
 
-#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45628 src/store.c:45698
+#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45649 src/store.c:45719
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr ""
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "invalid overlay payload\n"
 msgstr ""
 
-#: src/store.c:4949 src/store.c:30852
+#: src/store.c:4949 src/store.c:30873
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr ""
@@ -2963,13 +2963,13 @@ msgstr ""
 msgid "unsupported secret metadata format\n"
 msgstr ""
 
-#: src/store.c:5243 src/store.c:31210 src/store.c:37767
+#: src/store.c:5243 src/store.c:31231 src/store.c:37788
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr ""
 
-#: src/store.c:5260 src/store.c:30909 src/store.c:30986 src/store.c:30998
-#: src/store.c:31355
+#: src/store.c:5260 src/store.c:30930 src/store.c:31007 src/store.c:31019
+#: src/store.c:31376
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr ""
@@ -3197,21 +3197,21 @@ msgstr ""
 msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 
-#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37859
+#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37880
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
 "%s\n"
 msgstr ""
 
-#: src/store.c:9472 src/store.c:37824
+#: src/store.c:9472 src/store.c:37845
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
 "secret: %s\n"
 msgstr ""
 
-#: src/store.c:9514 src/store.c:9553 src/store.c:38800
+#: src/store.c:9514 src/store.c:9553 src/store.c:38821
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
@@ -3245,7 +3245,7 @@ msgstr ""
 msgid "current session is readonly and cannot run %s\n"
 msgstr ""
 
-#: src/store.c:10112 src/store.c:38766 src/store.c:38912 src/store.c:40969
+#: src/store.c:10112 src/store.c:38787 src/store.c:38933 src/store.c:40990
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr ""
@@ -3266,7 +3266,7 @@ msgid "failed to derive wrap key\n"
 msgstr ""
 
 #: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
-#: src/store.c:13458 src/store.c:30695
+#: src/store.c:13458 src/store.c:30716
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr ""
@@ -3302,9 +3302,9 @@ msgstr ""
 msgid "invalid wrapped master key\n"
 msgstr ""
 
-#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45941
-#: src/store.c:45972 src/store.c:45992 src/store.c:46015 src/store.c:46183
-#: src/store.c:46191 src/store.c:46213 src/store.c:46229
+#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45962
+#: src/store.c:45993 src/store.c:46013 src/store.c:46036 src/store.c:46204
+#: src/store.c:46212 src/store.c:46234 src/store.c:46250
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr ""
@@ -3315,10 +3315,10 @@ msgid "secret bundle has too many objects\n"
 msgstr ""
 
 #: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
-#: src/store.c:18176 src/store.c:18225 src/store.c:35337 src/store.c:35519
-#: src/store.c:37393 src/store.c:38855 src/store.c:38878 src/store.c:38932
-#: src/store.c:39203 src/store.c:39757 src/store.c:39789 src/store.c:41089
-#: src/store.c:42776
+#: src/store.c:18176 src/store.c:18225 src/store.c:35358 src/store.c:35540
+#: src/store.c:37414 src/store.c:38876 src/store.c:38899 src/store.c:38953
+#: src/store.c:39224 src/store.c:39778 src/store.c:39810 src/store.c:41110
+#: src/store.c:42797
 #, c-format
 msgid "key not found: %s\n"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "failed to unlock persistent master key\n"
 msgstr ""
 
-#: src/store.c:12137 src/store.c:19086 src/store.c:41078
+#: src/store.c:12137 src/store.c:19086 src/store.c:41099
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
@@ -3605,10 +3605,10 @@ msgid "failed to authenticate encrypted value\n"
 msgstr ""
 
 #: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
-#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29399
-#: src/store.c:30018 src/store.c:30180 src/store.c:30762 src/store.c:30772
-#: src/store.c:31082 src/store.c:31118 src/store.c:31244 src/store.c:40786
-#: src/store.c:40809 src/store.c:42907
+#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29420
+#: src/store.c:30039 src/store.c:30201 src/store.c:30783 src/store.c:30793
+#: src/store.c:31103 src/store.c:31139 src/store.c:31265 src/store.c:40807
+#: src/store.c:40830 src/store.c:42928
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr ""
@@ -3618,11 +3618,11 @@ msgstr ""
 msgid "failed to read standard input\n"
 msgstr ""
 
-#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30072
-#: src/store.c:30319 src/store.c:34035 src/store.c:34140 src/store.c:34470
-#: src/store.c:37458 src/store.c:37746 src/store.c:38555 src/store.c:38654
-#: src/store.c:38898 src/store.c:41069 src/store.c:43547 src/store.c:43693
-#: src/store.c:44105 src/store.c:44725 src/store.c:45449 src/store.c:46025
+#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30093
+#: src/store.c:30340 src/store.c:34056 src/store.c:34161 src/store.c:34491
+#: src/store.c:37479 src/store.c:37767 src/store.c:38576 src/store.c:38675
+#: src/store.c:38919 src/store.c:41090 src/store.c:43568 src/store.c:43714
+#: src/store.c:44126 src/store.c:44746 src/store.c:45470 src/store.c:46046
 #, c-format
 msgid "invalid store format marker\n"
 msgstr ""
@@ -3645,8 +3645,8 @@ msgid ""
 "Hint: check secdat status, --dir, and --store to confirm the lookup context\n"
 msgstr ""
 
-#: src/store.c:14608 src/store.c:30660 src/store.c:31088 src/store.c:31092
-#: src/store.c:31232 src/store.c:38702 src/store.c:38709 src/store.c:40792
+#: src/store.c:14608 src/store.c:30681 src/store.c:31109 src/store.c:31113
+#: src/store.c:31253 src/store.c:38723 src/store.c:38730 src/store.c:40813
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr ""
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr ""
 
-#: src/store.c:15874 src/store.c:38029
+#: src/store.c:15874 src/store.c:38050
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr ""
@@ -3686,8 +3686,8 @@ msgstr ""
 msgid "metadata is too large\n"
 msgstr ""
 
-#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35543
-#: src/store.c:35663 src/store.c:36919
+#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35564
+#: src/store.c:35684 src/store.c:36940
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr ""
@@ -3727,7 +3727,7 @@ msgstr ""
 msgid "invalid relation member: %s\n"
 msgstr ""
 
-#: src/store.c:18253 src/store.c:35822
+#: src/store.c:18253 src/store.c:35843
 #, c-format
 msgid "relation not found: %s\n"
 msgstr ""
@@ -3986,14 +3986,14 @@ msgid "cannot index relation dependency: %s\n"
 msgstr ""
 
 #: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
-#: src/store.c:28839 src/store.c:29197 src/store.c:29212
+#: src/store.c:28839 src/store.c:29218 src/store.c:29233
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
 "repair\n"
 msgstr ""
 
-#: src/store.c:28061 src/store.c:28266 src/store.c:29187 src/store.c:42824
+#: src/store.c:28061 src/store.c:28266 src/store.c:29208 src/store.c:42845
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
@@ -4015,510 +4015,510 @@ msgstr ""
 msgid "invalid dependency index node: %s\n"
 msgstr ""
 
-#: src/store.c:29325
+#: src/store.c:29346
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
 msgstr ""
 
-#: src/store.c:29373
+#: src/store.c:29394
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr ""
 
-#: src/store.c:29935
+#: src/store.c:29956
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr ""
 
-#: src/store.c:29965 src/store.c:29974 src/store.c:29978
+#: src/store.c:29986 src/store.c:29995 src/store.c:29999
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr ""
 
-#: src/store.c:30056
+#: src/store.c:30077
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr ""
 
-#: src/store.c:30095 src/store.c:41864
+#: src/store.c:30116 src/store.c:41885
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr ""
 
-#: src/store.c:30133
+#: src/store.c:30154
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr ""
 
-#: src/store.c:30154 src/store.c:30275
+#: src/store.c:30175 src/store.c:30296
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr ""
 
-#: src/store.c:30194 src/store.c:30200
+#: src/store.c:30215 src/store.c:30221
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr ""
 
-#: src/store.c:30239
+#: src/store.c:30260
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30243 src/store.c:31442
+#: src/store.c:30264 src/store.c:31463
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30263
+#: src/store.c:30284
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
 "handle\n"
 msgstr ""
 
-#: src/store.c:30519 src/store.c:39458
+#: src/store.c:30540 src/store.c:39479
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr ""
 
-#: src/store.c:30637
+#: src/store.c:30658
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 
-#: src/store.c:31096 src/store.c:31238
+#: src/store.c:31117 src/store.c:31259
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr ""
 
-#: src/store.c:31404
+#: src/store.c:31425
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr ""
 
-#: src/store.c:31991
+#: src/store.c:32012
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32716
+#: src/store.c:32737
 #, c-format
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr ""
 
-#: src/store.c:33343
+#: src/store.c:33364
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33758
+#: src/store.c:33779
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:34027 src/store.c:34132
+#: src/store.c:34048 src/store.c:34153
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:34039
+#: src/store.c:34060
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr ""
 
-#: src/store.c:34144
+#: src/store.c:34165
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr ""
 
-#: src/store.c:34455 src/store.c:34845
+#: src/store.c:34476 src/store.c:34866
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:34474
+#: src/store.c:34495
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr ""
 
-#: src/store.c:34678
+#: src/store.c:34699
 #, c-format
 msgid "GC owner domain must be registered before mutation\n"
 msgstr ""
 
-#: src/store.c:34856
+#: src/store.c:34877
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr ""
 
-#: src/store.c:35262
+#: src/store.c:35283
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
 "counts\n"
 msgstr ""
 
-#: src/store.c:35273
+#: src/store.c:35294
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
 "the affected domains or use --json for counts\n"
 msgstr ""
 
-#: src/store.c:35358 src/store.c:35428
+#: src/store.c:35379 src/store.c:35449
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr ""
 
-#: src/store.c:35420
+#: src/store.c:35441
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
 "with set --ephemeral\n"
 msgstr ""
 
-#: src/store.c:35421
+#: src/store.c:35442
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35550 src/store.c:35670
+#: src/store.c:35571 src/store.c:35691
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr ""
 
-#: src/store.c:35557 src/store.c:35677
+#: src/store.c:35578 src/store.c:35698
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr ""
 
-#: src/store.c:35558 src/store.c:35678
+#: src/store.c:35579 src/store.c:35699
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35563
+#: src/store.c:35584
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:35595
+#: src/store.c:35616
 #, c-format
 msgid "missing key for meta get\n"
 msgstr ""
 
-#: src/store.c:35595
+#: src/store.c:35616
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr ""
 
-#: src/store.c:35623
+#: src/store.c:35644
 #, c-format
 msgid "missing key for meta set\n"
 msgstr ""
 
-#: src/store.c:35623
+#: src/store.c:35644
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr ""
 
-#: src/store.c:35635
+#: src/store.c:35656
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35635
+#: src/store.c:35656
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35658
+#: src/store.c:35679
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr ""
 
-#: src/store.c:35658
+#: src/store.c:35679
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr ""
 
-#: src/store.c:35957
+#: src/store.c:35978
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr ""
 
-#: src/store.c:36001
+#: src/store.c:36022
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:36007
+#: src/store.c:36028
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:36044 src/store.c:36051
+#: src/store.c:36065 src/store.c:36072
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr ""
 
-#: src/store.c:36051
+#: src/store.c:36072
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr ""
 
-#: src/store.c:36057 src/store.c:37251 src/store.c:37300
+#: src/store.c:36078 src/store.c:37272 src/store.c:37321
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr ""
 
-#: src/store.c:36062
+#: src/store.c:36083
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 
-#: src/store.c:36074 src/store.c:37310
+#: src/store.c:36095 src/store.c:37331
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:36927 src/store.c:36933
+#: src/store.c:36948 src/store.c:36954
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr ""
 
-#: src/store.c:37126
+#: src/store.c:37147
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr ""
 
-#: src/store.c:37145
+#: src/store.c:37166
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37198
+#: src/store.c:37219
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37231
+#: src/store.c:37252
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37231
+#: src/store.c:37252
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37246
+#: src/store.c:37267
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr ""
 
-#: src/store.c:37246
+#: src/store.c:37267
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr ""
 
-#: src/store.c:37258
+#: src/store.c:37279
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37295
+#: src/store.c:37316
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr ""
 
-#: src/store.c:37295
+#: src/store.c:37316
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr ""
 
-#: src/store.c:37340
+#: src/store.c:37361
 #, c-format
 msgid "missing key for exists\n"
 msgstr ""
 
-#: src/store.c:37345
+#: src/store.c:37366
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr ""
 
-#: src/store.c:37374
+#: src/store.c:37395
 #, c-format
 msgid "missing key for id\n"
 msgstr ""
 
-#: src/store.c:37379
+#: src/store.c:37400
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr ""
 
-#: src/store.c:37399
+#: src/store.c:37420
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37427
+#: src/store.c:37448
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr ""
 
-#: src/store.c:37437
+#: src/store.c:37458
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr ""
 
-#: src/store.c:37442
+#: src/store.c:37463
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr ""
 
-#: src/store.c:37450
+#: src/store.c:37471
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37462
+#: src/store.c:37483
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37472
+#: src/store.c:37493
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr ""
 
-#: src/store.c:37476
+#: src/store.c:37497
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr ""
 
-#: src/store.c:37606
+#: src/store.c:37627
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr ""
 
-#: src/store.c:37620 src/store.c:37688
+#: src/store.c:37641 src/store.c:37709
 #, c-format
 msgid "failed to write standard output\n"
 msgstr ""
 
-#: src/store.c:37669
+#: src/store.c:37690
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr ""
 
-#: src/store.c:37816 src/store.c:38357
+#: src/store.c:37837 src/store.c:38378
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
 msgstr ""
 
-#: src/store.c:37871 src/store.c:38832 src/store.c:47891
+#: src/store.c:37892 src/store.c:38853 src/store.c:47912
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:37886
+#: src/store.c:37907
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:37991 src/store.c:38239 src/store.c:38249 src/store.c:38271
-#: src/store.c:38296 src/store.c:38305 src/store.c:38315 src/store.c:38344
-#: src/store.c:38420 src/store.c:38453 src/store.c:38462
+#: src/store.c:38012 src/store.c:38260 src/store.c:38270 src/store.c:38292
+#: src/store.c:38317 src/store.c:38326 src/store.c:38336 src/store.c:38365
+#: src/store.c:38441 src/store.c:38474 src/store.c:38483
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr ""
 
-#: src/store.c:38023
+#: src/store.c:38044
 #, c-format
 msgid "invalid generated secret charset\n"
 msgstr ""
 
-#: src/store.c:38044
+#: src/store.c:38065
 #, c-format
 msgid "generated secret charset is too large\n"
 msgstr ""
 
-#: src/store.c:38092
+#: src/store.c:38113
 #, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr ""
 
-#: src/store.c:38106 src/store.c:38115
+#: src/store.c:38127 src/store.c:38136
 #, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr ""
 
-#: src/store.c:38120
+#: src/store.c:38141
 #, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr ""
 
-#: src/store.c:38131
+#: src/store.c:38152
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38322
+#: src/store.c:38343
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr ""
 
-#: src/store.c:38366
+#: src/store.c:38387
 #, c-format
 msgid "missing key for set\n"
 msgstr ""
 
-#: src/store.c:38376
+#: src/store.c:38397
 #, c-format
 msgid "invalid arguments for generated set\n"
 msgstr ""
 
-#: src/store.c:38402
+#: src/store.c:38423
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38426
+#: src/store.c:38447
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr ""
 
-#: src/store.c:38475
+#: src/store.c:38496
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr ""
 
-#: src/store.c:39015
+#: src/store.c:39036
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39124
+#: src/store.c:39145
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 
-#: src/store.c:39133
+#: src/store.c:39154
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
 msgstr ""
 
-#: src/store.c:39162
+#: src/store.c:39183
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39189
+#: src/store.c:39210
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -4526,534 +4526,534 @@ msgid ""
 "inaccessible candidates without unmasking: %s\n"
 msgstr ""
 
-#: src/store.c:39210
+#: src/store.c:39231
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr ""
 
-#: src/store.c:39268
+#: src/store.c:39289
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39292
+#: src/store.c:39313
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39298 src/store.c:39308
+#: src/store.c:39319 src/store.c:39329
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr ""
 
-#: src/store.c:39319
+#: src/store.c:39340
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
 "and choose a chain with unmask --dry-run --mask-chain: %s\n"
 msgstr ""
 
-#: src/store.c:39406
+#: src/store.c:39427
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
 "its name: %s\n"
 msgstr ""
 
-#: src/store.c:39434
+#: src/store.c:39455
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
 "use mask --rebind after exactly one inherited v2 target remains: %s\n"
 msgstr ""
 
-#: src/store.c:39541 src/store.c:40349 src/store.c:40384 src/store.c:40391
-#: src/store.c:40488 src/store.c:40494
+#: src/store.c:39562 src/store.c:40370 src/store.c:40405 src/store.c:40412
+#: src/store.c:40509 src/store.c:40515
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr ""
 
-#: src/store.c:39697
+#: src/store.c:39718
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:39747 src/store.c:39779
+#: src/store.c:39768 src/store.c:39800
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr ""
 
-#: src/store.c:39899
+#: src/store.c:39920
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr ""
 
-#: src/store.c:39915
+#: src/store.c:39936
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr ""
 
-#: src/store.c:39948
+#: src/store.c:39969
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr ""
 
-#: src/store.c:39956
+#: src/store.c:39977
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:40022
+#: src/store.c:40043
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr ""
 
-#: src/store.c:40029 src/store.c:40667 src/store.c:40679
+#: src/store.c:40050 src/store.c:40688 src/store.c:40700
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr ""
 
-#: src/store.c:40062
+#: src/store.c:40083
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:40664
+#: src/store.c:40685
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
 "active: %s\n"
 msgstr ""
 
-#: src/store.c:40713
+#: src/store.c:40734
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr ""
 
-#: src/store.c:40747
+#: src/store.c:40768
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr ""
 
-#: src/store.c:40889 src/store.c:40895
+#: src/store.c:40910 src/store.c:40916
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr ""
 
-#: src/store.c:40900
+#: src/store.c:40921
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr ""
 
-#: src/store.c:40954 src/store.c:41262 src/store.c:42772 src/store.c:43282
-#: src/store.c:45837
+#: src/store.c:40975 src/store.c:41283 src/store.c:42793 src/store.c:43303
+#: src/store.c:45858
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr ""
 
-#: src/store.c:41006
+#: src/store.c:41027
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr ""
 
-#: src/store.c:41011 src/store.c:41046 src/store.c:41125 src/store.c:41209
-#: src/store.c:41233 src/store.c:43228 src/store.c:43252
+#: src/store.c:41032 src/store.c:41067 src/store.c:41146 src/store.c:41230
+#: src/store.c:41254 src/store.c:43249 src/store.c:43273
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr ""
 
-#: src/store.c:41062
+#: src/store.c:41083
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:41073 src/store.c:41098
+#: src/store.c:41094 src/store.c:41119
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr ""
 
-#: src/store.c:41094 src/store.c:41106
+#: src/store.c:41115 src/store.c:41127
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41112
+#: src/store.c:41133
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
 "after value confirmation)\n"
 msgstr ""
 
-#: src/store.c:41118
+#: src/store.c:41139
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr ""
 
-#: src/store.c:41145
+#: src/store.c:41166
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
 "replace to replace anyway)\n"
 msgstr ""
 
-#: src/store.c:41204
+#: src/store.c:41225
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr ""
 
-#: src/store.c:41275
+#: src/store.c:41296
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41299 src/store.c:42935 src/store.c:43366
+#: src/store.c:41320 src/store.c:42956 src/store.c:43387
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:41374
+#: src/store.c:41395
 #, c-format
 msgid "too many move relation dependencies\n"
 msgstr ""
 
-#: src/store.c:41875
+#: src/store.c:41896
 #, c-format
 msgid "affected descendant mask is inaccessible: %s\n"
 msgstr ""
 
-#: src/store.c:42778 src/store.c:43308
+#: src/store.c:42799 src/store.c:43329
 #, c-format
 msgid "mv requires v2 source and destination stores\n"
 msgstr ""
 
-#: src/store.c:42798
+#: src/store.c:42819
 #, c-format
 msgid ""
 "mv mutation planning requires a local source in the same v2 domain and "
 "store\n"
 msgstr ""
 
-#: src/store.c:42894
+#: src/store.c:42915
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
 
-#: src/store.c:43223
+#: src/store.c:43244
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr ""
 
-#: src/store.c:43296
+#: src/store.c:43317
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:43325 src/store.c:47921
+#: src/store.c:43346 src/store.c:47942
 #, c-format
 msgid "mask mutation planning requires store format v2\n"
 msgstr ""
 
-#: src/store.c:43332
+#: src/store.c:43353
 #, c-format
 msgid "mv requires matching source and destination store formats\n"
 msgstr ""
 
-#: src/store.c:43496
+#: src/store.c:43517
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr ""
 
-#: src/store.c:43563
+#: src/store.c:43584
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43592
+#: src/store.c:43613
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr ""
 
-#: src/store.c:43712
+#: src/store.c:43733
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43763
+#: src/store.c:43784
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
 "barrier\n"
 msgstr ""
 
-#: src/store.c:43770
+#: src/store.c:43791
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
 "inherited value\n"
 msgstr ""
 
-#: src/store.c:43804
+#: src/store.c:43825
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr ""
 
-#: src/store.c:43810
+#: src/store.c:43831
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 
-#: src/store.c:43852 src/store.c:43859
+#: src/store.c:43873 src/store.c:43880
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr ""
 
-#: src/store.c:43987 src/store.c:44498 src/store.c:44856 src/store.c:45319
-#: src/store.c:45405
+#: src/store.c:44008 src/store.c:44519 src/store.c:44877 src/store.c:45340
+#: src/store.c:45426
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr ""
 
-#: src/store.c:44087
+#: src/store.c:44108
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:44098 src/store.c:44718 src/store.c:45440
+#: src/store.c:44119 src/store.c:44739 src/store.c:45461
 #, c-format
 msgid "store not found: %s\n"
 msgstr ""
 
-#: src/store.c:44109
+#: src/store.c:44130
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr ""
 
-#: src/store.c:44387
+#: src/store.c:44408
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr ""
 
-#: src/store.c:44456
+#: src/store.c:44477
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr ""
 
-#: src/store.c:44708
+#: src/store.c:44729
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:44729
+#: src/store.c:44750
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 
-#: src/store.c:45267
+#: src/store.c:45288
 #, c-format
 msgid "domain is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:45324
+#: src/store.c:45345
 #, c-format
 msgid "missing store name for store create\n"
 msgstr ""
 
-#: src/store.c:45329
+#: src/store.c:45350
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr ""
 
-#: src/store.c:45354
+#: src/store.c:45375
 #, c-format
 msgid "store already exists: %s\n"
 msgstr ""
 
-#: src/store.c:45410
+#: src/store.c:45431
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr ""
 
-#: src/store.c:45415
+#: src/store.c:45436
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr ""
 
-#: src/store.c:45456
+#: src/store.c:45477
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:45465
+#: src/store.c:45486
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:45509
+#: src/store.c:45530
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr ""
 
-#: src/store.c:45709 src/store.c:45717
+#: src/store.c:45730 src/store.c:45738
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr ""
 
-#: src/store.c:45729
+#: src/store.c:45750
 msgid "Create secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45730
+#: src/store.c:45751
 msgid "Confirm secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45786
+#: src/store.c:45807
 #, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr ""
 
-#: src/store.c:45791
+#: src/store.c:45812
 #, c-format
 msgid "conflicting load conflict policies\n"
 msgstr ""
 
-#: src/store.c:45804 src/store.c:45810
+#: src/store.c:45825 src/store.c:45831
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr ""
 
-#: src/store.c:45869
+#: src/store.c:45890
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45870
+#: src/store.c:45891
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45904
+#: src/store.c:45925
 msgid "Enter secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:46383
+#: src/store.c:46404
 #, c-format
 msgid "  dir=%s\n"
 msgstr ""
 
-#: src/store.c:46386
+#: src/store.c:46407
 #, c-format
 msgid "  domain=%s\n"
 msgstr ""
 
-#: src/store.c:46389
+#: src/store.c:46410
 #, c-format
 msgid "  store=%s\n"
 msgstr ""
 
-#: src/store.c:46428
+#: src/store.c:46449
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr ""
 
-#: src/store.c:46432
+#: src/store.c:46453
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr ""
 
-#: src/store.c:46446
+#: src/store.c:46467
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr ""
 
-#: src/store.c:46527
+#: src/store.c:46548
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr ""
 
-#: src/store.c:46557 src/store.c:46589
+#: src/store.c:46578 src/store.c:46610
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr ""
 
-#: src/store.c:46568
+#: src/store.c:46589
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr ""
 
-#: src/store.c:47105
+#: src/store.c:47126
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr ""
 
-#: src/store.c:47204 src/store.c:47466
+#: src/store.c:47225 src/store.c:47487
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr ""
 
-#: src/store.c:47563
+#: src/store.c:47584
 #, c-format
 msgid "warning: %s: "
 msgstr ""
 
-#: src/store.c:47577
+#: src/store.c:47598
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr ""
 
-#: src/store.c:47581
+#: src/store.c:47602
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr ""
 
-#: src/store.c:47585
+#: src/store.c:47606
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr ""
 
-#: src/store.c:47589
+#: src/store.c:47610
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr ""
 
-#: src/store.c:47593
+#: src/store.c:47614
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr ""
 
-#: src/store.c:47597
+#: src/store.c:47618
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr ""
 
-#: src/store.c:47719
+#: src/store.c:47740
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr ""
 
-#: src/store.c:47720
+#: src/store.c:47741
 msgid "mask interaction rejected before mutation\n"
 msgstr ""
 
-#: src/store.c:47903
+#: src/store.c:47924
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:48021
+#: src/store.c:48042
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr ""
 
-#: src/store.c:48039
+#: src/store.c:48060
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr ""
 
-#: src/store.c:48053 src/store.c:48062
+#: src/store.c:48074 src/store.c:48083
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr ""

--- a/po/secdat.pot
+++ b/po/secdat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 15:15+0900\n"
+"POT-Creation-Date: 2026-08-28 17:53+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,282 +64,282 @@ msgstr ""
 msgid "unknown option: %s\n"
 msgstr ""
 
-#: src/cli.c:1759
+#: src/cli.c:1766
 #, c-format
 msgid "  %s [options] subcommand ...\n"
 msgstr ""
 
-#: src/cli.c:1764
+#: src/cli.c:1771
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 msgstr ""
 
-#: src/cli.c:1765
+#: src/cli.c:1772
 msgid ""
 "  -d, --dir DIR      set the base directory used for domain resolution\n"
 msgstr ""
 
-#: src/cli.c:1766
+#: src/cli.c:1773
 msgid ""
 "      --domain DIR   require one exact registered domain root instead of "
 "discovery\n"
 msgstr ""
 
-#: src/cli.c:1767
+#: src/cli.c:1774
 msgid ""
 "  -s, --store STORE  select the store namespace inside the resolved domain\n"
 msgstr ""
 
-#: src/cli.c:1768
+#: src/cli.c:1775
 msgid ""
 "  -h, --help         show global help, or combine with COMMAND or TOPIC for "
 "detailed help\n"
 msgstr ""
 
-#: src/cli.c:1769
+#: src/cli.c:1776
 msgid "  -V, --version      print the secdat version\n"
 msgstr ""
 
-#: src/cli.c:1803
+#: src/cli.c:1810
 #, c-format
 msgid ""
 "\n"
 "Help:\n"
 msgstr ""
 
-#: src/cli.c:1804
+#: src/cli.c:1811
 #, c-format
 msgid "  %s --help\n"
 msgstr ""
 
-#: src/cli.c:1805
+#: src/cli.c:1812
 #, c-format
 msgid "  %s help [COMMAND...]\n"
 msgstr ""
 
-#: src/cli.c:1806
+#: src/cli.c:1813
 #, c-format
 msgid "  %s help usecases\n"
 msgstr ""
 
-#: src/cli.c:1807
+#: src/cli.c:1814
 #, c-format
 msgid "  %s help concepts\n"
 msgstr ""
 
-#: src/cli.c:1808
+#: src/cli.c:1815
 #, c-format
 msgid "  %s help inject\n"
 msgstr ""
 
-#: src/cli.c:1810
+#: src/cli.c:1817
 #, c-format
 msgid "  %s --help COMMAND...\n"
 msgstr ""
 
-#: src/cli.c:1811
+#: src/cli.c:1818
 #, c-format
 msgid "  %s COMMAND --help\n"
 msgstr ""
 
-#: src/cli.c:1813 src/cli.c:1815
+#: src/cli.c:1820 src/cli.c:1822
 #, c-format
 msgid "  %s --help %s\n"
 msgstr ""
 
-#: src/cli.c:1816
+#: src/cli.c:1823
 #, c-format
 msgid "  %s %s --help\n"
 msgstr ""
 
-#: src/cli.c:1818
+#: src/cli.c:1825
 #, c-format
 msgid "  %s --version\n"
 msgstr ""
 
-#: src/cli.c:1819
+#: src/cli.c:1826
 #, c-format
 msgid "  %s version\n"
 msgstr ""
 
-#: src/cli.c:1824
+#: src/cli.c:1831
 #, c-format
 msgid ""
 "\n"
 "Shell:\n"
 msgstr ""
 
-#: src/cli.c:1827
+#: src/cli.c:1834
 #, c-format
 msgid "  bash load current shell vars: source <(%s export)\n"
 msgstr ""
 
-#: src/cli.c:1829
+#: src/cli.c:1836
 #, c-format
 msgid "  bash alternative: eval \"$(%s export)\"\n"
 msgstr ""
 
-#: src/cli.c:1832
+#: src/cli.c:1839
 msgid "  bash completion script: completions/secdat.bash\n"
 msgstr ""
 
-#: src/cli.c:1833
+#: src/cli.c:1840
 msgid "  man page source: docs/secdat.1\n"
 msgstr ""
 
-#: src/cli.c:1838
+#: src/cli.c:1845
 #, c-format
 msgid ""
 "\n"
 "Support:\n"
 msgstr ""
 
-#: src/cli.c:1839
+#: src/cli.c:1846
 msgid "  issues: https://github.com/mako10k/secdat/issues\n"
 msgstr ""
 
-#: src/cli.c:1840
+#: src/cli.c:1847
 msgid "  repository: https://github.com/mako10k/secdat\n"
 msgstr ""
 
-#: src/cli.c:1841
+#: src/cli.c:1848
 msgid "  author: Makoto Katsumata <mako10k@mk10.org>\n"
 msgstr ""
 
-#: src/cli.c:1846
+#: src/cli.c:1853
 #, c-format
 msgid ""
 "\n"
 "Groups:\n"
 msgstr ""
 
-#: src/cli.c:1847
+#: src/cli.c:1854
 msgid ""
 "  store: manage store namespaces and v1 to v2 migration inside the resolved "
 "current domain\n"
 msgstr ""
 
-#: src/cli.c:1848
+#: src/cli.c:1855
 msgid "  meta: manage non-secret searchable metadata attached to keys\n"
 msgstr ""
 
-#: src/cli.c:1849
+#: src/cli.c:1856
 msgid ""
 "  relation: connect keys into semantic groups with non-secret security "
 "meaning\n"
 msgstr ""
 
-#: src/cli.c:1850 src/cli.c:2164
+#: src/cli.c:1857 src/cli.c:2174
 msgid ""
 "  secret: inspect v2 secret-object metadata by UUID without reading secret "
 "values\n"
 msgstr ""
 
-#: src/cli.c:1851 src/cli.c:2173
+#: src/cli.c:1858 src/cli.c:2183
 msgid "  domain: manage domain roots and domain discovery scope\n"
 msgstr ""
 
-#: src/cli.c:1856
+#: src/cli.c:1863
 #, c-format
 msgid ""
 "\n"
 "Commands:\n"
 msgstr ""
 
-#: src/cli.c:1857 src/cli.c:1906
+#: src/cli.c:1864 src/cli.c:1913
 msgid "  help: show global help or detailed help for one command\n"
 msgstr ""
 
-#: src/cli.c:1858 src/cli.c:1910
+#: src/cli.c:1865 src/cli.c:1917
 msgid ""
 "  ls: list effective keys visible from the current domain view, optionally "
 "filtered by safe or unsafe storage\n"
 msgstr ""
 
-#: src/cli.c:1859 src/cli.c:1914
+#: src/cli.c:1866 src/cli.c:1921
 msgid ""
 "  list: inspect current-domain entries or identity and legacy masks by "
 "state, with long or JSON detail\n"
 msgstr ""
 
-#: src/cli.c:1860 src/cli.c:1923
+#: src/cli.c:1867 src/cli.c:1930
 msgid ""
 "  attr: show or update one key's visibility, value-access, and bulk_select "
 "attribute\n"
 msgstr ""
 
-#: src/cli.c:1861
+#: src/cli.c:1868
 msgid ""
 "  meta: manage non-secret searchable metadata without reading secret values\n"
 msgstr ""
 
-#: src/cli.c:1862
+#: src/cli.c:1869
 msgid ""
 "  relation: record semantic links between keys and the security meaning of "
 "those links\n"
 msgstr ""
 
-#: src/cli.c:1863
+#: src/cli.c:1870
 msgid ""
 "  meta mark-leaked: mark one key as leaked metadata and suggest high-risk "
 "refresh targets\n"
 msgstr ""
 
-#: src/cli.c:1864
+#: src/cli.c:1871
 msgid ""
 "  relation suggest-refresh: suggest high-risk refresh targets related to one "
 "leaked key\n"
 msgstr ""
 
-#: src/cli.c:1865
+#: src/cli.c:1872
 msgid ""
 "  relation suggest-link: compare same-name keys across registered domains "
 "and show link candidates\n"
 msgstr ""
 
-#: src/cli.c:1866 src/cli.c:1987
+#: src/cli.c:1873 src/cli.c:1994
 msgid ""
 "  fsck: check current-domain store metadata for migration and limited "
 "repair\n"
 msgstr ""
 
-#: src/cli.c:1867
+#: src/cli.c:1874
 msgid "  gc: remove unreachable or dangling v2 graph files after review\n"
 msgstr ""
 
-#: src/cli.c:1868
+#: src/cli.c:1875
 msgid ""
 "  mask: create a rollback-safe identity mask for one inherited key, or "
 "atomically rebind an orphan barrier\n"
 msgstr ""
 
-#: src/cli.c:1869
+#: src/cli.c:1876
 msgid ""
 "  unmask: atomically remove one logical mask chain, with explicit chain "
 "selection when names are ambiguous\n"
 msgstr ""
 
-#: src/cli.c:1870 src/cli.c:2017
+#: src/cli.c:1877 src/cli.c:2024
 msgid ""
 "  exists: check whether one resolved key is visible from the current domain "
 "view\n"
 msgstr ""
 
-#: src/cli.c:1871 src/cli.c:2021
+#: src/cli.c:1878 src/cli.c:2028
 msgid ""
 "  id: print the v2 secret object UUID for one resolved key without reading "
 "its value\n"
 msgstr ""
 
-#: src/cli.c:1872 src/cli.c:2026
+#: src/cli.c:1879 src/cli.c:2033
 msgid ""
 "  get: decrypt one resolved key and write it to standard output; --on-demand-"
 "unlock waits for another terminal to unlock\n"
 msgstr ""
 
-#: src/cli.c:1873
+#: src/cli.c:1880
 msgid ""
 "  set: store or update one key in the resolved current domain; --generate "
 "writes a CSPRNG-generated value without printing it; --unsafe stores "
@@ -347,51 +347,51 @@ msgid ""
 "the active session agent\n"
 msgstr ""
 
-#: src/cli.c:1874
+#: src/cli.c:1881
 msgid ""
 "  rm: remove one key locally or create a tombstone for an inherited key; --"
 "ignore-missing treats absent keys as success; --ephemeral removes only a "
 "session-local ephemeral value\n"
 msgstr ""
 
-#: src/cli.c:1875 src/cli.c:2051
+#: src/cli.c:1882 src/cli.c:2058
 msgid "  mv: rename or relocate one key between resolved locations\n"
 msgstr ""
 
-#: src/cli.c:1876
+#: src/cli.c:1883
 msgid "  cp: copy one key into another resolved location\n"
 msgstr ""
 
-#: src/cli.c:1877 src/cli.c:2060
+#: src/cli.c:1884 src/cli.c:2070
 msgid ""
 "  ln: link another key to the same v2 secret object, including cross-domain "
 "v2 links and authorized @UUID sources\n"
 msgstr ""
 
-#: src/cli.c:1878 src/cli.c:2067
+#: src/cli.c:1885 src/cli.c:2077
 msgid ""
 "  exec: build a child environment through supply, route, and final injection "
 "layers\n"
 msgstr ""
 
-#: src/cli.c:1879 src/cli.c:2076
+#: src/cli.c:1886 src/cli.c:2086
 msgid ""
 "  export: emit shell-ready export lines that defer secret reads to secdat "
 "get\n"
 msgstr ""
 
-#: src/cli.c:1880 src/cli.c:2080
+#: src/cli.c:1887 src/cli.c:2090
 msgid ""
 "  save: write current-view or selected secrets to a passphrase-protected "
 "bundle\n"
 msgstr ""
 
-#: src/cli.c:1881
+#: src/cli.c:1888
 msgid ""
 "  load: import a passphrase-protected bundle into the current domain view\n"
 msgstr ""
 
-#: src/cli.c:1882 src/cli.c:2093
+#: src/cli.c:1889 src/cli.c:2103
 msgid ""
 "  unlock: start or refresh a local unlock for the current domain; --duration "
 "accepts plain minutes, suffix forms like 1h30m, or ISO 8601 durations such "
@@ -399,119 +399,119 @@ msgid ""
 "drops the current domain's local override to fall back to inherited state\n"
 msgstr ""
 
-#: src/cli.c:1883 src/cli.c:2100
+#: src/cli.c:1890 src/cli.c:2110
 msgid ""
 "  inherit: force the current domain back to inherited state by removing a "
 "local lock or clearing a local unlock, without checking whether the result "
 "stays unlocked\n"
 msgstr ""
 
-#: src/cli.c:1884 src/cli.c:2104
+#: src/cli.c:1891 src/cli.c:2114
 msgid "  passwd: change the wrapped-master-key passphrase\n"
 msgstr ""
 
-#: src/cli.c:1885 src/cli.c:2108
+#: src/cli.c:1892 src/cli.c:2118
 msgid ""
 "  lock: return the current domain to a locked local state, or do nothing "
 "when it is already locked\n"
 msgstr ""
 
-#: src/cli.c:1886 src/cli.c:2112
+#: src/cli.c:1893 src/cli.c:2122
 msgid ""
 "  status: report whether secret material is available from the current "
 "domain scope\n"
 msgstr ""
 
-#: src/cli.c:1887 src/cli.c:2116
+#: src/cli.c:1894 src/cli.c:2126
 msgid ""
 "  wait-unlock: wait until the current domain scope becomes unlocked, or fail "
 "on timeout\n"
 msgstr ""
 
-#: src/cli.c:1888 src/cli.c:2168
+#: src/cli.c:1895 src/cli.c:2178
 msgid ""
 "  secret status: print one v2 secret object's non-secret metadata and "
 "reference counts\n"
 msgstr ""
 
-#: src/cli.c:1889
+#: src/cli.c:1896
 msgid ""
 "  store migrate: validate a v1 store and write the side-by-side v2 domain-"
 "entry/object graph after review\n"
 msgstr ""
 
-#: src/cli.c:1890
+#: src/cli.c:1897
 msgid ""
 "  store finalize-migration: inspect or remove legacy v1 fallback files after "
 "a v2 migration\n"
 msgstr ""
 
-#: src/cli.c:1891 src/cli.c:2120
+#: src/cli.c:1898 src/cli.c:2130
 msgid "  version: print the secdat version\n"
 msgstr ""
 
-#: src/cli.c:1896
+#: src/cli.c:1903
 #, c-format
 msgid ""
 "\n"
 "Topics:\n"
 msgstr ""
 
-#: src/cli.c:1897 src/cli.c:2124
+#: src/cli.c:1904 src/cli.c:2134
 msgid ""
 "  usecases: show example workflows and task-oriented command combinations\n"
 msgstr ""
 
-#: src/cli.c:1898
+#: src/cli.c:1905
 msgid ""
 "  concepts: explain domains, stores, inheritance, local unlocks, local "
 "locks, and KEYREF resolution\n"
 msgstr ""
 
-#: src/cli.c:1899 src/cli.c:2132
+#: src/cli.c:1906 src/cli.c:2142
 msgid ""
 "  inject: explain exec --inject layers, rule kinds, selectors, policy files, "
 "and preflight checks\n"
 msgstr ""
 
-#: src/cli.c:1904
+#: src/cli.c:1911
 #, c-format
 msgid ""
 "\n"
 "Meaning:\n"
 msgstr ""
 
-#: src/cli.c:1915
+#: src/cli.c:1922
 msgid ""
 "  --masked, --dormant, and --orphaned select mask states; combine them or "
 "use --all-masks for all three\n"
 msgstr ""
 
-#: src/cli.c:1916
+#: src/cli.c:1923
 msgid ""
 "  --long and --json report record kind, resolution, chain, authorized target "
 "identity, and orphan reason\n"
 msgstr ""
 
-#: src/cli.c:1917
+#: src/cli.c:1924
 msgid ""
 "  locked hidden names are omitted; state=unknown means observation is "
 "incomplete, not a fourth stored state, and lists explicit candidates\n"
 msgstr ""
 
-#: src/cli.c:1918
+#: src/cli.c:1925
 msgid ""
 "  JSON reports visible and redacted unknown-state counts and whether the "
 "selected-state result is complete\n"
 msgstr ""
 
-#: src/cli.c:1919
+#: src/cli.c:1926
 msgid ""
 "  --long and --json cannot be combined with local-entry filters; short state "
 "filters return a union\n"
 msgstr ""
 
-#: src/cli.c:1924
+#: src/cli.c:1931
 msgid ""
 "  key_visibility controls whether the key name is visible while locked; "
 "value_access=always stores a public/plaintext-at-rest value; bulk_select "
@@ -519,577 +519,595 @@ msgid ""
 "--bulk-gate is used for this entry\n"
 msgstr ""
 
-#: src/cli.c:1925
+#: src/cli.c:1932
 msgid ""
 "  v2 effective --bulk-gate selection also requires the secret object's "
 "bulk_select_value policy to allow bulk selection\n"
 msgstr ""
 
-#: src/cli.c:1929
+#: src/cli.c:1936
 msgid ""
 "  meta: manage non-secret searchable metadata attached to keys in the "
 "current store\n"
 msgstr ""
 
-#: src/cli.c:1930
+#: src/cli.c:1937
 msgid ""
 "  metadata values are labels or descriptions for lookup; do not store secret "
 "material in metadata\n"
 msgstr ""
 
-#: src/cli.c:1934
+#: src/cli.c:1941
 msgid "  meta get: print non-secret searchable metadata for one visible key\n"
 msgstr ""
 
-#: src/cli.c:1938
+#: src/cli.c:1945
 msgid ""
 "  meta set: attach or replace one non-secret searchable metadata field on a "
 "local key\n"
 msgstr ""
 
-#: src/cli.c:1942
+#: src/cli.c:1949
 msgid "  meta unset: remove one searchable metadata field from a local key\n"
 msgstr ""
 
-#: src/cli.c:1946
+#: src/cli.c:1953
 msgid ""
 "  meta search: list visible keys whose non-secret metadata contains all "
 "requested fields or glob-matched values\n"
 msgstr ""
 
-#: src/cli.c:1950
+#: src/cli.c:1957
 msgid ""
 "  meta mark-leaked: mark one key as leaked metadata and print high-risk "
 "relation refresh suggestions\n"
 msgstr ""
 
-#: src/cli.c:1954
+#: src/cli.c:1961
 msgid ""
 "  relation: record semantic links between multiple key references and the "
 "non-secret security meaning of the combination\n"
 msgstr ""
 
-#: src/cli.c:1958
+#: src/cli.c:1965
 msgid ""
 "  relation set: create or replace one semantic relation with two or more "
 "role=KEYREF members\n"
 msgstr ""
 
-#: src/cli.c:1962
+#: src/cli.c:1969
 msgid ""
 "  relation ls: list relation identifiers, optionally limited to relations "
 "containing one key\n"
 msgstr ""
 
-#: src/cli.c:1966
+#: src/cli.c:1973
 msgid ""
 "  relation search: list relation identifiers whose non-secret relation "
 "fields match all filters\n"
 msgstr ""
 
-#: src/cli.c:1970
+#: src/cli.c:1977
 msgid ""
 "  relation suggest-refresh: suggest high-risk refresh targets related to one "
 "leaked key without reading secret values\n"
 msgstr ""
 
-#: src/cli.c:1974
+#: src/cli.c:1981
 msgid ""
 "  relation suggest-link: compare same-name keys across registered domains "
 "and print link candidates without printing secret values\n"
 msgstr ""
 
-#: src/cli.c:1975
+#: src/cli.c:1982
 msgid ""
 "  link clusters are optional non-secret key metadata; by default relation "
 "suggest-link reads the link_cluster field\n"
 msgstr ""
 
-#: src/cli.c:1979
+#: src/cli.c:1986
 msgid ""
 "  relation show: print one semantic relation without reading secret values\n"
 msgstr ""
 
-#: src/cli.c:1983
+#: src/cli.c:1990
 msgid "  relation rm: remove one semantic relation record\n"
 msgstr ""
 
-#: src/cli.c:1988
+#: src/cli.c:1995
 msgid ""
 "  with no filters, fsck runs orphaned, dangling, and refcount checks; --"
 "repair only rebuilds cached v2 refcounts\n"
 msgstr ""
 
-#: src/cli.c:1989
+#: src/cli.c:1996
 msgid ""
 "  v2 mask checks report orphaned-mask, ambiguous-mask, dangling-mask, and "
 "incomplete-mask-state; dormant masks are valid\n"
 msgstr ""
 
-#: src/cli.c:1990
+#: src/cli.c:1997
 msgid ""
 "  corrupt mask rows use a non-reversible record-sha256 handle; <redacted> "
 "means the identity is not authorized\n"
 msgstr ""
 
-#: src/cli.c:1991
+#: src/cli.c:1998
 msgid ""
 "  record-sha256 is the first 16 SHA-256 hex digits of the .mask filename "
 "UUID; match it inside the protected masks directory\n"
 msgstr ""
 
-#: src/cli.c:1992
+#: src/cli.c:1999
 msgid ""
 "  no automatic mask-record repair is available; preserve a corrupt record "
 "until its intended mask can be recovered\n"
 msgstr ""
 
-#: src/cli.c:1993
+#: src/cli.c:2000
 msgid ""
 "  unlock affected domains for <redacted> rows and rerun list --all-masks --"
 "long and fsck\n"
 msgstr ""
 
-#: src/cli.c:1997
+#: src/cli.c:2004
 msgid ""
 "  gc: remove unreachable or dangling v2 graph files after dry-run review\n"
 msgstr ""
 
-#: src/cli.c:1998
+#: src/cli.c:2005
 msgid ""
 "  --dry-run previews selected v2 graph files; without --dry-run it "
 "permanently removes the selected graph files\n"
 msgstr ""
 
-#: src/cli.c:2002
+#: src/cli.c:2009
 msgid ""
 "  mask: create a canonical identity mask and, for public names, its v1 "
 "rollback-compatible tombstone in one recoverable transaction\n"
 msgstr ""
 
-#: src/cli.c:2003
+#: src/cli.c:2010
 msgid ""
 "  hidden names remain canonical-only; an unsafe v1 rollback projection is "
 "rejected before mutation\n"
 msgstr ""
 
-#: src/cli.c:2004
+#: src/cli.c:2011
 msgid ""
 "  --rebind repairs a legacy or orphan barrier by attaching the current "
 "unique inherited target without an exposure window\n"
 msgstr ""
 
-#: src/cli.c:2005
+#: src/cli.c:2012
 msgid ""
 "  when rebind has multiple candidates, use domain ls --ancestors and id KEY "
 "in each ancestor to locate duplicates before retrying\n"
 msgstr ""
 
-#: src/cli.c:2006
+#: src/cli.c:2013
 msgid ""
 "  --dry-run reports the immutable plan; --json uses secdat.mask-operation-"
 "plan.v1 for dry-run and committed results\n"
 msgstr ""
 
-#: src/cli.c:2010
+#: src/cli.c:2017
 msgid ""
 "  unmask: atomically remove the unique logical mask chain controlling one "
 "key\n"
 msgstr ""
 
-#: src/cli.c:2011
+#: src/cli.c:2018
 msgid ""
 "  name-only removal refuses competing chains and chains protecting multiple "
 "names; inspect list --all-masks --long and retry with --mask-chain UUID\n"
 msgstr ""
 
-#: src/cli.c:2012
+#: src/cli.c:2019
 msgid ""
 "  --mask-chain must identify a chain that protects the requested key; --dry-"
 "run/--json list every affected authorized key slot\n"
 msgstr ""
 
-#: src/cli.c:2013
+#: src/cli.c:2020
 msgid ""
 "  deferred-exposure warnings default to on; --mask-warnings=default|on|off, "
 "--warn-mask, and --no-warn-mask change warnings only\n"
 msgstr ""
 
-#: src/cli.c:2022
+#: src/cli.c:2029
 msgid ""
 "  the UUID is an address, not authority; follow-up metadata commands still "
 "use the current domain/store object view\n"
 msgstr ""
 
-#: src/cli.c:2030
+#: src/cli.c:2037
 msgid ""
 "  set: store or update one key in the resolved current domain; --generate "
 "writes a CSPRNG-generated value without printing it; --unsafe stores "
 "plaintext visible while locked\n"
 msgstr ""
 
-#: src/cli.c:2031
+#: src/cli.c:2038
 msgid ""
 "  --generate requires --length N and --charset CLASS[,CLASS...]; classes are "
 "lower, upper, digit, symbol, alnum, hex, base64url, and ascii\n"
 msgstr ""
 
-#: src/cli.c:2032
+#: src/cli.c:2039
 msgid ""
 "  --require-each-class requires at least one character from every named "
 "charset class\n"
 msgstr ""
 
-#: src/cli.c:2033
+#: src/cli.c:2040
 msgid ""
 "  --ephemeral stores only in the active session agent, forces unlocked key/"
 "value access, and defaults bulk_select to exclude\n"
 msgstr ""
 
-#: src/cli.c:2034
+#: src/cli.c:2041
 msgid ""
 "  ephemeral values shadow persisted same-name values until rm --ephemeral, "
 "lock, or session expiry; use --bulk-select include to allow bulk-gated "
 "selection\n"
 msgstr ""
 
-#: src/cli.c:2035
+#: src/cli.c:2042
 msgid ""
 "  plain set, SDK/FUSE writes, cp, mv, ln, mask, unmask, attr updates, and "
 "save reject an ephemeral target instead of persisting it accidentally\n"
 msgstr ""
 
-#: src/cli.c:2036
+#: src/cli.c:2043
 msgid ""
 "  mutation planning options such as --dry-run and --json are not supported "
 "with --ephemeral\n"
 msgstr ""
 
-#: src/cli.c:2037
+#: src/cli.c:2044
 msgid ""
 "  v2 writes default to --mask-action=preserve; reject fails before any "
 "direct hit or mask state transition\n"
 msgstr ""
 
-#: src/cli.c:2038
+#: src/cli.c:2045
 msgid ""
 "  mask warnings default to on for preserve and off for reject; warning "
 "controls never change behavior or exit status\n"
 msgstr ""
 
-#: src/cli.c:2039
+#: src/cli.c:2046
 msgid ""
 "  --dry-run and --json expose the same secdat.mutation-plan.v1 used for one "
 "key or the whole assignment batch\n"
 msgstr ""
 
-#: src/cli.c:2043
+#: src/cli.c:2050
 msgid ""
 "  rm: remove one key locally or create a tombstone for an inherited key; --"
 "ignore-missing treats absent keys as success\n"
 msgstr ""
 
-#: src/cli.c:2044
+#: src/cli.c:2051
 msgid ""
 "  --ephemeral removes only the current domain's session-local ephemeral "
 "value and reveals any persisted value it shadowed\n"
 msgstr ""
 
-#: src/cli.c:2045
+#: src/cli.c:2052
 msgid ""
 "  v2 rm preserves canonical masks and reports reactivation or source-mask "
 "creation through the common mutation plan\n"
 msgstr ""
 
-#: src/cli.c:2046
+#: src/cli.c:2053
 msgid ""
 "  --mask-action=reject blocks those interactions; warning controls affect "
 "only successful post-commit warnings\n"
 msgstr ""
 
-#: src/cli.c:2047
+#: src/cli.c:2054
 msgid ""
 "  --dry-run and --json expose secdat.mutation-plan.v1 without changing "
 "persisted state\n"
 msgstr ""
 
-#: src/cli.c:2055
+#: src/cli.c:2059
+msgid ""
+"  a same-domain/store local v2 rename preserves both entry and secret IDs, "
+"existing links, and object refcount\n"
+msgstr ""
+
+#: src/cli.c:2060
+msgid ""
+"  descendant identity masks follow the preserved entry; relation KEYREF "
+"rewrites are reported separately in the common mutation plan\n"
+msgstr ""
+
+#: src/cli.c:2061
+msgid ""
+"  --mask-action=preserve is the default; reject, warning controls, dry-run, "
+"and JSON apply to local same-namespace v2 rename\n"
+msgstr ""
+
+#: src/cli.c:2065
 msgid ""
 "  cp: copy one key to a new independently identified destination while "
 "preserving destination masks in v2 stores\n"
 msgstr ""
 
-#: src/cli.c:2056
+#: src/cli.c:2066
 msgid ""
 "  --mask-action=preserve is the default; reject, warning controls, dry-run, "
 "and JSON use the common mutation plan\n"
 msgstr ""
 
-#: src/cli.c:2061
+#: src/cli.c:2071
 msgid ""
 "  value writes through either linked key affect the shared object; domain-"
 "entry attributes remain per link\n"
 msgstr ""
 
-#: src/cli.c:2062
+#: src/cli.c:2072
 msgid ""
 "  --replace allows replacing an existing same-name destination key; by "
 "default it first confirms both values are equal, and --skip-same-value-check "
 "bypasses that confirmation\n"
 msgstr ""
 
-#: src/cli.c:2063
+#: src/cli.c:2073
 msgid ""
 "  destination masks are preserved; reject, warning controls, dry-run, and "
 "JSON use the common mutation plan\n"
 msgstr ""
 
-#: src/cli.c:2068
+#: src/cli.c:2078
 msgid ""
 "  --inject LAYER:KIND=SELECTOR configures ambient, secret, route, or final "
 "rules; repeated --inject accumulates selectors of the same kind\n"
 msgstr ""
 
-#: src/cli.c:2069
+#: src/cli.c:2079
 msgid ""
 "  --inject-file FILE loads a YAML policy; command profiles can refine file "
 "rules before CLI --inject overrides them\n"
 msgstr ""
 
-#: src/cli.c:2070
+#: src/cli.c:2080
 msgid ""
 "  --bulk-gate applies the store bulk_select pre-filter before secret supply\n"
 msgstr ""
 
-#: src/cli.c:2071
+#: src/cli.c:2081
 msgid ""
 "  --command-resolution MODE selects CMD lookup: caller-path (default), child-"
 "path, or direct\n"
 msgstr ""
 
-#: src/cli.c:2072
+#: src/cli.c:2082
 msgid ""
 "  see help inject for the rule vocabulary, selector syntax, YAML shape, and "
 "preflight examples\n"
 msgstr ""
 
-#: src/cli.c:2081
+#: src/cli.c:2091
 msgid ""
 "  --key KEY may be repeated to save only named keys from the selected domain "
 "and store\n"
 msgstr ""
 
-#: src/cli.c:2085
+#: src/cli.c:2095
 msgid ""
 "  load: import a passphrase-protected bundle through one v2 mutation plan "
 "and one recoverable transaction\n"
 msgstr ""
 
-#: src/cli.c:2086
+#: src/cli.c:2096
 msgid ""
 "  --conflict=reject is the default and rejects any destination name visible "
 "in ls; overwrite replaces, skip leaves it unchanged\n"
 msgstr ""
 
-#: src/cli.c:2087
+#: src/cli.c:2097
 msgid ""
 "  linked v2 objects require a v2 destination; --allow-link-split explicitly "
 "materializes independent v1 values\n"
 msgstr ""
 
-#: src/cli.c:2088
+#: src/cli.c:2098
 msgid ""
 "  --mask-action=reject blocks any batch mask interaction; warning controls "
 "never change the batch result\n"
 msgstr ""
 
-#: src/cli.c:2089
+#: src/cli.c:2099
 msgid ""
 "  --dry-run and --json report the whole batch without committing any entry\n"
 msgstr ""
 
-#: src/cli.c:2094
+#: src/cli.c:2104
 msgid ""
 "  --gui forces passphrase prompts through the askpass helper even when a "
 "terminal is available\n"
 msgstr ""
 
-#: src/cli.c:2095
+#: src/cli.c:2105
 msgid ""
 "  --volatile keeps writes, deletes, tombstones, and read-side resolution "
 "changes in a session overlay; lock --save persists supported overlay changes "
 "before locking\n"
 msgstr ""
 
-#: src/cli.c:2096
+#: src/cli.c:2106
 msgid ""
 "  persisted tombstone removal and v2 local-entry deletions still require a "
 "normal writable session\n"
 msgstr ""
 
-#: src/cli.c:2128
+#: src/cli.c:2138
 msgid ""
 "  concepts: explain domains, stores, inheritance, sessions, and KEYREF "
 "resolution\n"
 msgstr ""
 
-#: src/cli.c:2136
+#: src/cli.c:2146
 msgid ""
 "  store: manage store namespaces and migrate v1 stores to the v2 domain-"
 "entry/object layout\n"
 msgstr ""
 
-#: src/cli.c:2140
+#: src/cli.c:2150
 msgid ""
 "  store create: create one store namespace in the resolved current domain\n"
 msgstr ""
 
-#: src/cli.c:2144
+#: src/cli.c:2154
 msgid ""
 "  store delete: delete one store namespace from the resolved current domain\n"
 msgstr ""
 
-#: src/cli.c:2148
+#: src/cli.c:2158
 msgid "  store ls: list store namespaces in the resolved current domain\n"
 msgstr ""
 
-#: src/cli.c:2152
+#: src/cli.c:2162
 msgid ""
 "  store migrate: validate one v1 store; without --dry-run, write the side-by-"
 "side v2 domain-entry/object graph and leave v1 fallback files in place\n"
 msgstr ""
 
-#: src/cli.c:2153
+#: src/cli.c:2163
 msgid ""
 "  mask plan counts separate existing canonical masks, conversion candidates, "
 "ambiguous legacy masks, and v1 rollback blockers\n"
 msgstr ""
 
-#: src/cli.c:2154
+#: src/cli.c:2164
 msgid ""
 "  dry-run mask-plan rows name each authorized candidate, ambiguity, or "
 "existing canonical mask; ambiguity remains fail closed and does not alone "
 "block migration\n"
 msgstr ""
 
-#: src/cli.c:2155
+#: src/cli.c:2165
 msgid ""
 "  an unverifiable legacy projection blocks migration; unlock affected "
 "domains, inspect masks, and retry the dry-run\n"
 msgstr ""
 
-#: src/cli.c:2159
+#: src/cli.c:2169
 msgid ""
 "  store finalize-migration: inspect legacy v1 fallback files; without --dry-"
 "run, remove only removable files and refuse to remove anything while "
 "blockers remain\n"
 msgstr ""
 
-#: src/cli.c:2160
+#: src/cli.c:2170
 msgid ""
 "  typical order is migrate dry-run, migrate, fsck --format v2, rewrite or "
 "remove fallback-backed values, finalize dry-run, then finalize\n"
 msgstr ""
 
-#: src/cli.c:2169
+#: src/cli.c:2179
 msgid ""
 "  UUID lookup is scoped to the current domain/store object view; use the "
 "object's owning context for cross-domain links\n"
 msgstr ""
 
-#: src/cli.c:2177
+#: src/cli.c:2187
 msgid "  domain create: register the resolved directory as a domain root\n"
 msgstr ""
 
-#: src/cli.c:2181
+#: src/cli.c:2191
 msgid "  domain delete: unregister the resolved directory as a domain root\n"
 msgstr ""
 
-#: src/cli.c:2185
+#: src/cli.c:2195
 msgid ""
 "  domain move: update a registered domain root path without deleting its "
 "stored secrets\n"
 msgstr ""
 
-#: src/cli.c:2189
+#: src/cli.c:2199
 msgid "  domain ls: list domain roots around the scoped directory\n"
 msgstr ""
 
-#: src/cli.c:2193
+#: src/cli.c:2203
 msgid ""
 "  domain status: report the resolved domain root and effective lock/unlock "
 "source\n"
 msgstr ""
 
-#: src/cli.c:2204 src/cli.c:2425
+#: src/cli.c:2214 src/cli.c:2435
 #, c-format
 msgid ""
 "\n"
 "Use cases:\n"
 msgstr ""
 
-#: src/cli.c:2207
+#: src/cli.c:2217
 #, c-format
 msgid "  read one value to stdout: %s get API_TOKEN --stdout\n"
 msgstr ""
 
-#: src/cli.c:2209
+#: src/cli.c:2219
 #, c-format
 msgid ""
 "  wait for another terminal to unlock before reading: %s get --on-demand-"
 "unlock --unlock-timeout 30 API_TOKEN --stdout\n"
 msgstr ""
 
-#: src/cli.c:2215
+#: src/cli.c:2225
 #, c-format
 msgid ""
 "  write one value from an argument: %s set API_TOKEN --value new-token\n"
 msgstr ""
 
-#: src/cli.c:2217
+#: src/cli.c:2227
 #, c-format
 msgid ""
 "  generate a 40-character token without printing it: %s set API_TOKEN --"
 "generate --length 40 --charset lower,upper,digit --require-each-class\n"
 msgstr ""
 
-#: src/cli.c:2219
+#: src/cli.c:2229
 #, c-format
 msgid ""
 "  read a value from standard input without echoing it in shell history: "
 "printf 'token' | %s set API_TOKEN --stdin\n"
 msgstr ""
 
-#: src/cli.c:2225
+#: src/cli.c:2235
 #, c-format
 msgid "  inspect one key's current attributes: %s attr API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2227
+#: src/cli.c:2237
 #, c-format
 msgid ""
 "  make one value public while keeping the key name visible: %s attr "
 "API_TOKEN --value-access always\n"
 msgstr ""
 
-#: src/cli.c:2233
+#: src/cli.c:2243
 #, c-format
 msgid "  tag one key for search: %s meta set API_TOKEN service billing\n"
 msgstr ""
 
-#: src/cli.c:2235
+#: src/cli.c:2245
 #, c-format
 msgid "  find keys by metadata: %s meta search service=bill*\n"
 msgstr ""
 
-#: src/cli.c:2237
+#: src/cli.c:2247
 #, c-format
 msgid ""
 "  mark a leaked key and suggest refresh targets: %s meta mark-leaked "
 "BILLING_PASSWORD\n"
 msgstr ""
 
-#: src/cli.c:2243
+#: src/cli.c:2253
 #, c-format
 msgid ""
 "  record a credential pair: %s relation set billing-login --kind credential "
@@ -1097,612 +1115,612 @@ msgid ""
 "combination-sensitive\n"
 msgstr ""
 
-#: src/cli.c:2245
+#: src/cli.c:2255
 #, c-format
 msgid ""
 "  find credential relations: %s relation search kind=credential "
 "security=combination-*\n"
 msgstr ""
 
-#: src/cli.c:2247
+#: src/cli.c:2257
 #, c-format
 msgid ""
 "  suggest refresh targets after a leak: %s relation suggest-refresh "
 "BILLING_PASSWORD\n"
 msgstr ""
 
-#: src/cli.c:2249
+#: src/cli.c:2259
 #, c-format
 msgid ""
 "  find same-name cross-domain link candidates: %s relation suggest-link "
 "APP_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2251
+#: src/cli.c:2261
 #, c-format
 msgid "  inspect relation metadata: %s relation show billing-login\n"
 msgstr ""
 
-#: src/cli.c:2257
+#: src/cli.c:2267
 #, c-format
 msgid "  run all current-domain metadata checks: %s fsck\n"
 msgstr ""
 
-#: src/cli.c:2259
+#: src/cli.c:2269
 #, c-format
 msgid ""
 "  rebuild cached v2 refcounts after review: %s fsck --format v2 --refcount --"
 "repair\n"
 msgstr ""
 
-#: src/cli.c:2261
+#: src/cli.c:2271
 #, c-format
 msgid ""
 "  validate the global reverse dependency index: %s fsck --format v2 --"
 "dependency-index\n"
 msgstr ""
 
-#: src/cli.c:2263
+#: src/cli.c:2273
 #, c-format
 msgid ""
 "  rebuild and publish the global reverse dependency index: %s fsck --format "
 "v2 --dependency-index --repair\n"
 msgstr ""
 
-#: src/cli.c:2269
+#: src/cli.c:2279
 #, c-format
 msgid ""
 "  preview unreachable v2 graph files before deletion: %s gc --format v2 --"
 "dry-run\n"
 msgstr ""
 
-#: src/cli.c:2271
+#: src/cli.c:2281
 #, c-format
 msgid "  delete the reviewed unreachable v2 graph files: %s gc --format v2\n"
 msgstr ""
 
-#: src/cli.c:2277
+#: src/cli.c:2287
 #, c-format
 msgid ""
 "  preview the canonical identity and any safe rollback projection: %s mask --"
 "dry-run --json API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2279
+#: src/cli.c:2289
 #, c-format
 msgid ""
 "  repair an orphan barrier without exposing the replacement target: %s mask "
 "--rebind API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2285
+#: src/cli.c:2295
 #, c-format
 msgid ""
 "  preview every record removed from the unique chain: %s unmask --dry-run --"
 "json API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2287
+#: src/cli.c:2297
 #, c-format
 msgid ""
 "  inspect and explicitly remove one multi-name chain: %s unmask --dry-run --"
 "mask-chain UUID API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2289
+#: src/cli.c:2299
 #, c-format
 msgid ""
 "  suppress only the post-commit warning: %s unmask --no-warn-mask API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2295
+#: src/cli.c:2305
 #, c-format
 msgid ""
 "  load current shell variables without printing raw secrets: source <(%s "
 "export)\n"
 msgstr ""
 
-#: src/cli.c:2297
+#: src/cli.c:2307
 #, c-format
 msgid ""
 "  export one namespace before running another tool: eval \"$(%s --store app "
 "export --pattern 'APP_*')\"\n"
 msgstr ""
 
-#: src/cli.c:2303
+#: src/cli.c:2313
 #, c-format
 msgid ""
 "  run one command with matching secrets injected: %s exec --inject secret:"
 "only=APP_* env\n"
 msgstr ""
 
-#: src/cli.c:2305
+#: src/cli.c:2315
 #, c-format
 msgid ""
 "  exclude one inherited key while running a child process: %s exec --inject "
 "secret:only=APP_* --inject secret:omit=APP_DEBUG_* CMD\n"
 msgstr ""
 
-#: src/cli.c:2311
+#: src/cli.c:2321
 #, c-format
 msgid ""
 "  share one v2 secret object under another key: %s ln APP_TOKEN "
 "SERVICE_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2313
+#: src/cli.c:2323
 #, c-format
 msgid ""
 "  link across explicit domains/stores: %s ln /src/domain/APP_TOKEN:app /dst/"
 "domain/APP_TOKEN:ops\n"
 msgstr ""
 
-#: src/cli.c:2315
+#: src/cli.c:2325
 #, c-format
 msgid ""
 "  replace an existing same-name destination after value confirmation: %s ln "
 "--replace /src/domain/APP_TOKEN /dst/domain/APP_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2321
+#: src/cli.c:2331
 #, c-format
 msgid ""
 "  resolve one key to its v2 secret object UUID without reading it: %s id "
 "API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2323
+#: src/cli.c:2333
 #, c-format
 msgid ""
 "  inspect that object from its owning domain/store context: %s secret status "
 "01234567-89ab-4def-8123-456789abcdef\n"
 msgstr ""
 
-#: src/cli.c:2329
+#: src/cli.c:2339
 #, c-format
 msgid "  start a session for the current project directory: %s unlock\n"
 msgstr ""
 
-#: src/cli.c:2331
+#: src/cli.c:2341
 #, c-format
 msgid ""
 "  refresh an active session for 15 minutes without re-entering the "
 "passphrase: %s unlock --duration 15\n"
 msgstr ""
 
-#: src/cli.c:2333
+#: src/cli.c:2343
 #, c-format
 msgid ""
 "  unlock one specific domain from elsewhere: %s --dir ~/example/project "
 "unlock\n"
 msgstr ""
 
-#: src/cli.c:2339
+#: src/cli.c:2349
 #, c-format
 msgid ""
 "  block a script until another terminal unlocks the same domain: %s --dir ~/"
 "example/project wait-unlock --timeout 900\n"
 msgstr ""
 
-#: src/cli.c:2341
+#: src/cli.c:2351
 #, c-format
 msgid ""
 "  poll quietly before a later secret read: %s wait-unlock --timeout 30 --"
 "quiet\n"
 msgstr ""
 
-#: src/cli.c:2347
+#: src/cli.c:2357
 #, c-format
 msgid "  check whether the current domain can read secrets now: %s status\n"
 msgstr ""
 
-#: src/cli.c:2349
+#: src/cli.c:2359
 #, c-format
 msgid "  use exit status only in scripts: %s status --quiet\n"
 msgstr ""
 
-#: src/cli.c:2351
+#: src/cli.c:2361
 #, c-format
 msgid "  read machine-readable state in scripts: %s status --json\n"
 msgstr ""
 
-#: src/cli.c:2357
+#: src/cli.c:2367
 #, c-format
 msgid ""
 "  inspect local tombstones and overrides before cleanup: %s list --masked\n"
 msgstr ""
 
-#: src/cli.c:2359
+#: src/cli.c:2369
 #, c-format
 msgid ""
 "  inspect only plaintext-at-rest entries in the current domain: %s list --"
 "unsafe\n"
 msgstr ""
 
-#: src/cli.c:2365
+#: src/cli.c:2375
 #, c-format
 msgid "  create one namespace for app-specific keys: %s store create app\n"
 msgstr ""
 
-#: src/cli.c:2367
+#: src/cli.c:2377
 #, c-format
 msgid ""
 "  inspect available namespaces before selecting one with --store: %s store "
 "ls\n"
 msgstr ""
 
-#: src/cli.c:2369 src/cli.c:2381
+#: src/cli.c:2379 src/cli.c:2391
 #, c-format
 msgid ""
 "  inspect a v1 to v2 migration before writing: %s store migrate app --to-"
 "format v2 --dry-run\n"
 msgstr ""
 
-#: src/cli.c:2371
+#: src/cli.c:2381
 #, c-format
 msgid ""
 "  write the v2 domain-entry/object graph after review: %s store migrate app "
 "--to-format v2\n"
 msgstr ""
 
-#: src/cli.c:2373
+#: src/cli.c:2383
 #, c-format
 msgid ""
 "  inspect legacy fallback files after blockers are rewritten or removed: %s "
 "store finalize-migration app --from-format v1 --dry-run\n"
 msgstr ""
 
-#: src/cli.c:2375
+#: src/cli.c:2385
 #, c-format
 msgid ""
 "  remove removable legacy fallback files after review: %s store finalize-"
 "migration app --from-format v1\n"
 msgstr ""
 
-#: src/cli.c:2383
+#: src/cli.c:2393
 #, c-format
 msgid ""
 "  write the v2 graph after reviewing the dry-run output: %s store migrate "
 "app --to-format v2\n"
 msgstr ""
 
-#: src/cli.c:2389
+#: src/cli.c:2399
 #, c-format
 msgid ""
 "  identify legacy fallback blockers before deleting anything: %s store "
 "finalize-migration app --from-format v1 --dry-run\n"
 msgstr ""
 
-#: src/cli.c:2391
+#: src/cli.c:2401
 #, c-format
 msgid ""
 "  remove removable legacy fallback files only after blockers are gone: %s "
 "store finalize-migration app --from-format v1\n"
 msgstr ""
 
-#: src/cli.c:2397
+#: src/cli.c:2407
 #, c-format
 msgid ""
 "  inspect one v2 secret object by UUID without reading its value: %s secret "
 "status 01234567-89ab-4def-8123-456789abcdef\n"
 msgstr ""
 
-#: src/cli.c:2399
+#: src/cli.c:2409
 #, c-format
 msgid ""
 "  resolve a visible or unlocked key to its UUID first: %s id API_TOKEN\n"
 msgstr ""
 
-#: src/cli.c:2401
+#: src/cli.c:2411
 #, c-format
 msgid ""
 "  for cross-domain links, run status from the object's owning domain/store "
 "context\n"
 msgstr ""
 
-#: src/cli.c:2407
+#: src/cli.c:2417
 #, c-format
 msgid "  register the current directory as a domain root: %s domain create\n"
 msgstr ""
 
-#: src/cli.c:2409
+#: src/cli.c:2419
 #, c-format
 msgid ""
 "  recover a moved domain root: %s --dir /new/path domain move --from /old/"
 "path\n"
 msgstr ""
 
-#: src/cli.c:2411
+#: src/cli.c:2421
 #, c-format
 msgid ""
 "  inspect inherited and blocked descendants: %s domain ls -l --descendants\n"
 msgstr ""
 
-#: src/cli.c:2418
+#: src/cli.c:2428
 #, c-format
 msgid ""
 "  see %s help usecases for workflow-oriented examples across multiple "
 "commands\n"
 msgstr ""
 
-#: src/cli.c:2428
+#: src/cli.c:2438
 #, c-format
 msgid "  bootstrap a new project domain: %s --dir ~/example/project unlock\n"
 msgstr ""
 
-#: src/cli.c:2430
+#: src/cli.c:2440
 #, c-format
 msgid ""
 "  read one secret directly: %s --dir ~/example/project get API_TOKEN --"
 "stdout\n"
 msgstr ""
 
-#: src/cli.c:2432
+#: src/cli.c:2442
 #, c-format
 msgid ""
 "  load shell variables without exposing raw values in exported text: source "
 "<(%s --dir ~/example/project export)\n"
 msgstr ""
 
-#: src/cli.c:2434
+#: src/cli.c:2444
 #, c-format
 msgid ""
 "  inject secrets into one subprocess only: %s --dir ~/example/project exec --"
 "inject secret:rename='s/^MY_APP_\\(.*\\)$/APP_\\1/' CMD\n"
 msgstr ""
 
-#: src/cli.c:2436
+#: src/cli.c:2446
 #, c-format
 msgid ""
 "  block automation until a human unlocks the domain elsewhere: %s --dir ~/"
 "example/project wait-unlock --timeout 900\n"
 msgstr ""
 
-#: src/cli.c:2438
+#: src/cli.c:2448
 #, c-format
 msgid ""
 "  inspect inheritance and local locks under one branch: %s --dir ~/example/"
 "project domain ls -l --descendants\n"
 msgstr ""
 
-#: src/cli.c:2445
+#: src/cli.c:2455
 #, c-format
 msgid ""
 "\n"
 "Concepts:\n"
 msgstr ""
 
-#: src/cli.c:2448
+#: src/cli.c:2458
 #, c-format
 msgid ""
 "  domain: a directory-scoped boundary for inheritance, sessions, and "
 "tombstones; resolve it with --dir or inspect it with %s domain status\n"
 msgstr ""
 
-#: src/cli.c:2450
+#: src/cli.c:2460
 msgid ""
 "  store: a domain-local namespace selected by --store; use it to separate "
 "app, ops, or personal keys inside one domain\n"
 msgstr ""
 
-#: src/cli.c:2451
+#: src/cli.c:2461
 msgid ""
 "  inheritance: reads fall back to parent domains until a local value, "
 "tombstone, or local lock changes the effective view\n"
 msgstr ""
 
-#: src/cli.c:2452
+#: src/cli.c:2462
 msgid ""
 "  local lock: a local override that blocks reuse of an inherited unlock "
 "until the current domain unlocks or inherits again\n"
 msgstr ""
 
-#: src/cli.c:2453
+#: src/cli.c:2463
 #, c-format
 msgid ""
 "  local unlock: an authenticated master-key cache scoped to one domain "
 "branch; inspect availability with %s status and refresh it with %s unlock\n"
 msgstr ""
 
-#: src/cli.c:2455
+#: src/cli.c:2465
 msgid ""
 "  KEYREF: [DOMAIN_PATH/]KEY[:STORE]; DOMAIN_PATH may be absolute or relative "
 "and selects only that exact registered domain\n"
 msgstr ""
 
-#: src/cli.c:2456
+#: src/cli.c:2466
 msgid ""
 "  relative KEYREF domains use --domain, then --dir, then the current working "
 "directory as their base; unqualified keys keep inherited lookup\n"
 msgstr ""
 
-#: src/cli.c:2462
+#: src/cli.c:2472
 #, c-format
 msgid ""
 "\n"
 "Inject rules:\n"
 msgstr ""
 
-#: src/cli.c:2465
+#: src/cli.c:2475
 msgid ""
 "  form: pass repeated --inject LAYER:KIND=SELECTOR rules to exec; use --"
 "inject-file FILE for a YAML policy\n"
 msgstr ""
 
-#: src/cli.c:2466
+#: src/cli.c:2476
 msgid ""
 "  layers: ambient selects caller environment variables; secret selects store "
 "keys; route resolves ambient/secret name collisions; final validates the "
 "child environment\n"
 msgstr ""
 
-#: src/cli.c:2467
+#: src/cli.c:2477
 msgid ""
 "  kinds: only is a whitelist, omit excludes matches, require fails when a "
 "match is missing, reject fails when a match is available, rename maps secret "
 "keys to env names, prefer sets the default collision pick\n"
 msgstr ""
 
-#: src/cli.c:2468
+#: src/cli.c:2478
 msgid ""
 "  selectors: exact names and shell-style globs are allowed; separate "
 "multiple selectors in one value with ':'\n"
 msgstr ""
 
-#: src/cli.c:2469
+#: src/cli.c:2479
 msgid ""
 "  route picks: route:prefer=secret, route:prefer=ambient, route:"
 "prefer=error, or route:GLOB=secret|ambient|error\n"
 msgstr ""
 
-#: src/cli.c:2470
+#: src/cli.c:2480
 msgid ""
 "  rename: secret:rename=EXPR uses one sed-style s/// expression; generated "
 "environment names must be valid identifiers\n"
 msgstr ""
 
-#: src/cli.c:2471
+#: src/cli.c:2481
 msgid ""
 "  files: --inject-file accepts a small YAML subset: bulk_gate, "
 "profile_required, profiles, supply, route, demand, scalar values, inline "
 "arrays, and block lists\n"
 msgstr ""
 
-#: src/cli.c:2472
+#: src/cli.c:2482
 msgid ""
 "  profiles: profiles.NAME.match.command matches CMD path or basename; match."
 "argv_prefix matches CMD arguments from the start\n"
 msgstr ""
 
-#: src/cli.c:2473
+#: src/cli.c:2483
 msgid ""
 "  profile safety: profile_required: true fails when no profile matches, and "
 "multiple matching profiles fail closed\n"
 msgstr ""
 
-#: src/cli.c:2474
+#: src/cli.c:2484
 msgid ""
 "  file limits: unsupported YAML syntax fails closed; use block lists for "
 "large selector sets instead of long inline arrays\n"
 msgstr ""
 
-#: src/cli.c:2475
+#: src/cli.c:2485
 msgid ""
 "  gate: --bulk-gate applies the key bulk_select pre-filter before secret "
 "supply; list and export can also use --bulk-gate but do not inject into a "
 "child process\n"
 msgstr ""
 
-#: src/cli.c:2476
+#: src/cli.c:2486
 msgid ""
 "  ptyterm handoff: secdat can be an optional stdin secret provider for "
 "ptyterm; neither tool requires the other\n"
 msgstr ""
 
-#: src/cli.c:2477
+#: src/cli.c:2487
 #, c-format
 msgid ""
 "  preflight: %s exec --inject secret:only=APP_* --dry-run --json -- CMD\n"
 msgstr ""
 
-#: src/cli.c:2479
+#: src/cli.c:2489
 #, c-format
 msgid ""
 "  example: %s exec --inject ambient:omit=SECDAT_* --inject secret:only=APP_* "
 "--inject route:prefer=secret --inject final:reject=SECDAT_* -- CMD\n"
 msgstr ""
 
-#: src/cli.c:2481
+#: src/cli.c:2491
 #, c-format
 msgid ""
 "  terminal handoff: %s get ROUTER_PASSWORD --stdout | ptyterm --session=1 --"
 "send-stdin --send-eol=cr --redact-sent\n"
 msgstr ""
 
-#: src/cli.c:2488
+#: src/cli.c:2498
 #, c-format
 msgid ""
 "\n"
 "Semantics:\n"
 msgstr ""
 
-#: src/cli.c:2489
+#: src/cli.c:2499
 msgid ""
 "  DIR: base directory used for domain resolution; defaults to the current "
 "working directory\n"
 msgstr ""
 
-#: src/cli.c:2490
+#: src/cli.c:2500
 msgid ""
 "  DOMAIN: directory-scoped configuration boundary used for inheritance and "
 "tombstones\n"
 msgstr ""
 
-#: src/cli.c:2491
+#: src/cli.c:2501
 msgid ""
 "  STORE: domain-local namespace selected by --store; defaults to the default "
 "store\n"
 msgstr ""
 
-#: src/cli.c:2492
+#: src/cli.c:2502
 msgid ""
 "  KEY / KEYREF: logical secret name, optionally qualified as "
 "[DOMAIN_PATH/]KEY[:STORE]; qualified lookup is exact-local\n"
 msgstr ""
 
-#: src/cli.c:2493
+#: src/cli.c:2503
 msgid ""
 "  migration hints: v2-only errors suggest store migrate; set "
 "SECDAT_SUPPRESS_MIGRATION_HINTS=1 to hide those hints\n"
 msgstr ""
 
-#: src/cli.c:2521
+#: src/cli.c:2531
 #, c-format
 msgid "unknown store subcommand: %s\n"
 msgstr ""
 
-#: src/cli.c:2523
+#: src/cli.c:2533
 #, c-format
 msgid "unknown meta subcommand: %s\n"
 msgstr ""
 
-#: src/cli.c:2525
+#: src/cli.c:2535
 #, c-format
 msgid "unknown relation subcommand: %s\n"
 msgstr ""
 
-#: src/cli.c:2527
+#: src/cli.c:2537
 #, c-format
 msgid "unknown secret subcommand: %s\n"
 msgstr ""
 
-#: src/cli.c:2529
+#: src/cli.c:2539
 #, c-format
 msgid "unknown domain subcommand: %s\n"
 msgstr ""
 
-#: src/cli.c:2674 src/cli.c:2690 src/cli.c:2722 src/cli.c:2744
+#: src/cli.c:2684 src/cli.c:2700 src/cli.c:2732 src/cli.c:2754
 #, c-format
 msgid "Usage:\n"
 msgstr ""
 
-#: src/cli.c:2700
+#: src/cli.c:2710
 #, c-format
 msgid "\n"
 msgstr ""
 
-#: src/cli.c:2701
+#: src/cli.c:2711
 msgid ""
 "  KEYREF syntax: [DOMAIN_PATH/]KEY[:STORE] (absolute or relative; qualified "
 "lookup is exact-local)\n"
 msgstr ""
 
-#: src/cli.c:2777
+#: src/cli.c:2787
 #, c-format
 msgid "Try: %s help %s\n"
 msgstr ""
 
-#: src/cli.c:2781
+#: src/cli.c:2791
 #, c-format
 msgid "Try: %s help\n"
 msgstr ""
@@ -1722,38 +1740,38 @@ msgstr ""
 #: src/exec_inject_policy_file.c:60 src/exec_inject_policy_file.c:103
 #: src/exec_inject_policy_file.c:128 src/exec_inject_policy_file.c:202
 #: src/exec_inject_policy_file.c:245 src/exec_inject_policy_file.c:283
-#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1528
-#: src/store.c:1544 src/store.c:1685 src/store.c:1720 src/store.c:1769
-#: src/store.c:1884 src/store.c:1893 src/store.c:1910 src/store.c:1919
-#: src/store.c:1933 src/store.c:1939 src/store.c:4525 src/store.c:4571
-#: src/store.c:4598 src/store.c:4644 src/store.c:4679 src/store.c:5098
-#: src/store.c:5555 src/store.c:5595 src/store.c:9646 src/store.c:10244
-#: src/store.c:10348 src/store.c:10398 src/store.c:10482 src/store.c:10490
-#: src/store.c:11020 src/store.c:11332 src/store.c:11441 src/store.c:11502
-#: src/store.c:11760 src/store.c:11869 src/store.c:11910 src/store.c:11983
-#: src/store.c:13198 src/store.c:13320 src/store.c:13341 src/store.c:13423
-#: src/store.c:13535 src/store.c:13703 src/store.c:13758 src/store.c:15101
-#: src/store.c:15578 src/store.c:15722 src/store.c:16119 src/store.c:16441
-#: src/store.c:16875 src/store.c:17114 src/store.c:17152 src/store.c:17466
-#: src/store.c:17572 src/store.c:17650 src/store.c:17664 src/store.c:17673
-#: src/store.c:17730 src/store.c:17743 src/store.c:17752 src/store.c:17873
-#: src/store.c:18009 src/store.c:18049 src/store.c:18060 src/store.c:18094
-#: src/store.c:18225 src/store.c:19129 src/store.c:19928 src/store.c:21113
-#: src/store.c:21139 src/store.c:21393 src/store.c:21443 src/store.c:21469
-#: src/store.c:21838 src/store.c:22242 src/store.c:22367 src/store.c:22396
-#: src/store.c:22447 src/store.c:22742 src/store.c:23320 src/store.c:23807
-#: src/store.c:24426 src/store.c:24960 src/store.c:25560 src/store.c:25597
-#: src/store.c:25846 src/store.c:25888 src/store.c:25995 src/store.c:26026
-#: src/store.c:29401 src/store.c:29436 src/store.c:29584 src/store.c:29783
-#: src/store.c:30829 src/store.c:30961 src/store.c:31577 src/store.c:36331
-#: src/store.c:36336 src/store.c:36673 src/store.c:36733 src/store.c:36739
-#: src/store.c:36814 src/store.c:36827 src/store.c:37875 src/store.c:37956
-#: src/store.c:38055 src/store.c:38093 src/store.c:39938 src/store.c:40026
-#: src/store.c:40076 src/store.c:41338 src/store.c:41499 src/store.c:43440
-#: src/store.c:44996 src/store.c:45171 src/store.c:45413 src/store.c:45438
-#: src/store.c:45462 src/store.c:45542 src/store.c:45593 src/store.c:45642
-#: src/store.c:45682 src/store.c:45976 src/store.c:46201 src/store.c:47368
-#: src/store.c:47376
+#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1571
+#: src/store.c:1587 src/store.c:1728 src/store.c:1763 src/store.c:1812
+#: src/store.c:1927 src/store.c:1936 src/store.c:1953 src/store.c:1962
+#: src/store.c:1976 src/store.c:1982 src/store.c:4568 src/store.c:4614
+#: src/store.c:4641 src/store.c:4687 src/store.c:4722 src/store.c:5141
+#: src/store.c:5598 src/store.c:5638 src/store.c:9689 src/store.c:10287
+#: src/store.c:10391 src/store.c:10441 src/store.c:10525 src/store.c:10533
+#: src/store.c:11063 src/store.c:11375 src/store.c:11484 src/store.c:11545
+#: src/store.c:11803 src/store.c:11912 src/store.c:11953 src/store.c:12026
+#: src/store.c:13241 src/store.c:13363 src/store.c:13384 src/store.c:13466
+#: src/store.c:13578 src/store.c:13746 src/store.c:13801 src/store.c:15144
+#: src/store.c:15621 src/store.c:15765 src/store.c:16162 src/store.c:16484
+#: src/store.c:16918 src/store.c:17157 src/store.c:17195 src/store.c:17509
+#: src/store.c:17615 src/store.c:17693 src/store.c:17707 src/store.c:17716
+#: src/store.c:17773 src/store.c:17786 src/store.c:17795 src/store.c:17916
+#: src/store.c:18052 src/store.c:18092 src/store.c:18103 src/store.c:18137
+#: src/store.c:18268 src/store.c:19172 src/store.c:19971 src/store.c:21156
+#: src/store.c:21182 src/store.c:21436 src/store.c:21486 src/store.c:21512
+#: src/store.c:21881 src/store.c:22285 src/store.c:22410 src/store.c:22439
+#: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
+#: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
+#: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
+#: src/store.c:29444 src/store.c:29479 src/store.c:29627 src/store.c:29826
+#: src/store.c:30872 src/store.c:31004 src/store.c:31620 src/store.c:36374
+#: src/store.c:36379 src/store.c:36716 src/store.c:36776 src/store.c:36782
+#: src/store.c:36857 src/store.c:36870 src/store.c:37918 src/store.c:37999
+#: src/store.c:38098 src/store.c:38136 src/store.c:39981 src/store.c:40069
+#: src/store.c:40119 src/store.c:41381 src/store.c:41542 src/store.c:41749
+#: src/store.c:43959 src/store.c:45515 src/store.c:45690 src/store.c:45932
+#: src/store.c:45957 src/store.c:45981 src/store.c:46061 src/store.c:46112
+#: src/store.c:46161 src/store.c:46201 src/store.c:46495 src/store.c:46803
+#: src/store.c:48101 src/store.c:48109
 #, c-format
 msgid "out of memory\n"
 msgstr ""
@@ -1764,18 +1782,18 @@ msgstr ""
 #: src/domain.c:955 src/domain.c:990 src/domain.c:1002 src/domain.c:1006
 #: src/domain.c:1101 src/domain.c:1234 src/domain.c:1356 src/domain.c:1364
 #: src/domain.c:1451 src/domain.c:1513 src/domain.c:1590 src/secdat-fuse.c:186
-#: src/store.c:1960 src/store.c:1978 src/store.c:3449 src/store.c:3456
-#: src/store.c:3474 src/store.c:4423 src/store.c:4693 src/store.c:4797
-#: src/store.c:4824 src/store.c:4851 src/store.c:5277 src/store.c:5475
-#: src/store.c:5645 src/store.c:5668 src/store.c:5684 src/store.c:6366
-#: src/store.c:7806 src/store.c:8311 src/store.c:8335 src/store.c:10187
-#: src/store.c:10513 src/store.c:14258 src/store.c:14268 src/store.c:14286
-#: src/store.c:14321 src/store.c:14374 src/store.c:15827 src/store.c:17814
-#: src/store.c:17833 src/store.c:18723 src/store.c:18737 src/store.c:18751
-#: src/store.c:19177 src/store.c:19538 src/store.c:30789 src/store.c:30911
-#: src/store.c:31216 src/store.c:33929 src/store.c:34136 src/store.c:34175
-#: src/store.c:34236 src/store.c:34461 src/store.c:34529 src/store.c:38768
-#: src/store.c:39682 src/store.c:40601
+#: src/store.c:2003 src/store.c:2021 src/store.c:3492 src/store.c:3499
+#: src/store.c:3517 src/store.c:4466 src/store.c:4736 src/store.c:4840
+#: src/store.c:4867 src/store.c:4894 src/store.c:5320 src/store.c:5518
+#: src/store.c:5688 src/store.c:5711 src/store.c:5727 src/store.c:6409
+#: src/store.c:7849 src/store.c:8354 src/store.c:8378 src/store.c:10230
+#: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
+#: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
+#: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
+#: src/store.c:19220 src/store.c:19581 src/store.c:30832 src/store.c:30954
+#: src/store.c:31259 src/store.c:33972 src/store.c:34179 src/store.c:34218
+#: src/store.c:34279 src/store.c:34504 src/store.c:34572 src/store.c:38811
+#: src/store.c:39725 src/store.c:40644
 #, c-format
 msgid "path is too long\n"
 msgstr ""
@@ -1796,17 +1814,17 @@ msgstr ""
 msgid "local-lock"
 msgstr ""
 
-#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12667
+#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12710
 msgid "locked"
 msgstr ""
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12633 src/store.c:12651
-#: src/store.c:12668
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
+#: src/store.c:12711
 msgid "wrapped master key: present"
 msgstr ""
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12633 src/store.c:12651
-#: src/store.c:12668
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
+#: src/store.c:12711
 msgid "wrapped master key: absent"
 msgstr ""
 
@@ -1818,7 +1836,7 @@ msgstr ""
 msgid "session"
 msgstr ""
 
-#: src/domain.c:383 src/store.c:12631 src/store.c:12641
+#: src/domain.c:383 src/store.c:12674 src/store.c:12684
 msgid "unlocked"
 msgstr ""
 
@@ -1854,18 +1872,18 @@ msgstr ""
 msgid "DOMAIN"
 msgstr ""
 
-#: src/domain.c:639 src/store.c:5663
+#: src/domain.c:639 src/store.c:5706
 #, c-format
 msgid "HOME is not set\n"
 msgstr ""
 
-#: src/domain.c:795 src/store.c:5548 src/store.c:5569
+#: src/domain.c:795 src/store.c:5591 src/store.c:5612
 #, c-format
 msgid "failed to open file: %s\n"
 msgstr ""
 
-#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5602
-#: src/store.c:19946
+#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5645
+#: src/store.c:19989
 #, c-format
 msgid "failed to read file: %s\n"
 msgstr ""
@@ -1881,13 +1899,13 @@ msgid "domain root identity mismatch for: %s\n"
 msgstr ""
 
 #: src/domain.c:911 src/domain.c:995 src/domain.c:1447 src/secdat-fuse.c:182
-#: src/store.c:1973
+#: src/store.c:2016
 #, c-format
 msgid "failed to resolve directory: %s\n"
 msgstr ""
 
-#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5254
-#: src/store.c:5301
+#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5297
+#: src/store.c:5344
 #, c-format
 msgid "not a directory: %s\n"
 msgstr ""
@@ -1907,7 +1925,7 @@ msgstr ""
 msgid "failed to generate domain id\n"
 msgstr ""
 
-#: src/domain.c:1268 src/store.c:4731 src/store.c:13806 src/store.c:43388
+#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43907
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr ""
@@ -1958,8 +1976,8 @@ msgstr ""
 msgid "invalid arguments for domain status\n"
 msgstr ""
 
-#: src/domain.c:2288 src/store.c:2223 src/store.c:2229 src/store.c:9994
-#: src/store.c:12752
+#: src/domain.c:2288 src/store.c:2266 src/store.c:2272 src/store.c:10037
+#: src/store.c:12795
 #, c-format
 msgid "resolved domain: %s\n"
 msgstr ""
@@ -2033,7 +2051,7 @@ msgstr ""
 msgid "effective source: locked"
 msgstr ""
 
-#: src/domain.c:2355 src/store.c:45862
+#: src/domain.c:2355 src/store.c:46381
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr ""
@@ -2100,7 +2118,7 @@ msgstr ""
 msgid "invalid secret rename regex: %s\n"
 msgstr ""
 
-#: src/exec_inject.c:834 src/store.c:3498 src/store.c:45109 src/store.c:45179
+#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45628 src/store.c:45698
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr ""
@@ -2441,2066 +2459,2066 @@ msgstr ""
 msgid "failed to create pipe\n"
 msgstr ""
 
-#: src/store.c:1587
+#: src/store.c:1630
 #, c-format
 msgid ""
 "deferred GC remains queued because the owner agent could not be upgraded\n"
 msgstr ""
 
-#: src/store.c:1596
+#: src/store.c:1639
 #, c-format
 msgid "deferred GC remains queued because the owner agent lacks GC_WORKER_V1\n"
 msgstr ""
 
-#: src/store.c:2018
+#: src/store.c:2061
 #, c-format
 msgid "writes to the default domain are not supported\n"
 msgstr ""
 
-#: src/store.c:2095 src/store.c:5446
+#: src/store.c:2138 src/store.c:5489
 #, c-format
 msgid "failed to remove file: %s\n"
 msgstr ""
 
-#: src/store.c:2155
+#: src/store.c:2198
 #, c-format
 msgid "note: %zu descendant domains can now reuse this session\n"
 msgstr ""
 
-#: src/store.c:2158 src/store.c:2195
+#: src/store.c:2201 src/store.c:2238
 #, c-format
 msgid "note: %zu orphaned descendant domains are not affected by unlock\n"
 msgstr ""
 
-#: src/store.c:2160 src/store.c:2197
+#: src/store.c:2203 src/store.c:2240
 #, c-format
 msgid ""
 "recover or delete orphaned descendant: secdat domain move --from %s --to "
 "NEW_ROOT\n"
 msgstr ""
 
-#: src/store.c:2161 src/store.c:2198
+#: src/store.c:2204 src/store.c:2241
 #, c-format
 msgid "discard orphaned descendant: secdat --dir %s domain delete\n"
 msgstr ""
 
-#: src/store.c:2168
+#: src/store.c:2211
 #, c-format
 msgid "note: %zu descendant domains remain locked under this branch\n"
 msgstr ""
 
-#: src/store.c:2169
+#: src/store.c:2212
 msgid "affected descendants:"
-msgstr ""
-
-#: src/store.c:2188
-#, c-format
-msgid "  %s\n"
-msgstr ""
-
-#: src/store.c:2192
-#, c-format
-msgid "  ... and %zu more\n"
-msgstr ""
-
-#: src/store.c:2202
-#, c-format
-msgid "inspect descendants: secdat --dir %s domain ls -l --descendants\n"
-msgstr ""
-
-#: src/store.c:2204
-#, c-format
-msgid "inspect one descendant: secdat --dir %s domain status\n"
-msgstr ""
-
-#: src/store.c:2205
-#, c-format
-msgid "unlock one descendant: secdat --dir %s unlock\n"
-msgstr ""
-
-#: src/store.c:2224
-#, c-format
-msgid "inspect current domain: secdat domain status\n"
-msgstr ""
-
-#: src/store.c:2225
-#, c-format
-msgid "unlock current domain: secdat unlock\n"
-msgstr ""
-
-#: src/store.c:2230
-#, c-format
-msgid "inspect current domain: secdat --dir %s domain status\n"
 msgstr ""
 
 #: src/store.c:2231
 #, c-format
+msgid "  %s\n"
+msgstr ""
+
+#: src/store.c:2235
+#, c-format
+msgid "  ... and %zu more\n"
+msgstr ""
+
+#: src/store.c:2245
+#, c-format
+msgid "inspect descendants: secdat --dir %s domain ls -l --descendants\n"
+msgstr ""
+
+#: src/store.c:2247
+#, c-format
+msgid "inspect one descendant: secdat --dir %s domain status\n"
+msgstr ""
+
+#: src/store.c:2248
+#, c-format
+msgid "unlock one descendant: secdat --dir %s unlock\n"
+msgstr ""
+
+#: src/store.c:2267
+#, c-format
+msgid "inspect current domain: secdat domain status\n"
+msgstr ""
+
+#: src/store.c:2268
+#, c-format
+msgid "unlock current domain: secdat unlock\n"
+msgstr ""
+
+#: src/store.c:2273
+#, c-format
+msgid "inspect current domain: secdat --dir %s domain status\n"
+msgstr ""
+
+#: src/store.c:2274
+#, c-format
 msgid "unlock current domain: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:2327
+#: src/store.c:2370
 #, c-format
 msgid ""
 "Hint: inspect migration first with `%s store migrate %s --to-format v2 --dry-"
 "run`\n"
 msgstr ""
 
-#: src/store.c:2328
+#: src/store.c:2371
 #, c-format
 msgid "Hint: suppress migration hints with %s=1\n"
 msgstr ""
 
-#: src/store.c:2359
+#: src/store.c:2402
 #, c-format
 msgid "invalid value for --unlock-timeout: %s\n"
 msgstr ""
 
-#: src/store.c:2807
+#: src/store.c:2850
 #, c-format
 msgid "missing value for --unlock-timeout\n"
 msgstr ""
 
-#: src/store.c:2812 src/store.c:2821 src/store.c:2833
+#: src/store.c:2855 src/store.c:2864 src/store.c:2876
 #, c-format
 msgid "invalid arguments for get\n"
 msgstr ""
 
-#: src/store.c:2842
+#: src/store.c:2885
 #, c-format
 msgid "missing key for get\n"
 msgstr ""
 
-#: src/store.c:2847
+#: src/store.c:2890
 #, c-format
 msgid "--unlock-timeout requires --on-demand-unlock or %s\n"
 msgstr ""
 
-#: src/store.c:2876
+#: src/store.c:2919
 #, c-format
 msgid "invalid value for --timeout: %s\n"
 msgstr ""
 
-#: src/store.c:2883
+#: src/store.c:2926
 #, c-format
 msgid "missing value for --timeout\n"
 msgstr ""
 
-#: src/store.c:2892 src/store.c:2899 src/store.c:12681
+#: src/store.c:2935 src/store.c:2942 src/store.c:12724
 #, c-format
 msgid "invalid arguments for wait-unlock\n"
 msgstr ""
 
-#: src/store.c:2921
+#: src/store.c:2964
 #, c-format
 msgid ""
 "waiting for another terminal to unlock secrets for resolved domain: %s\n"
 msgstr ""
 
-#: src/store.c:2923 src/store.c:2986
+#: src/store.c:2966 src/store.c:3029
 #, c-format
 msgid "unlock from another terminal: secdat unlock\n"
 msgstr ""
 
-#: src/store.c:2925 src/store.c:2988
+#: src/store.c:2968 src/store.c:3031
 #, c-format
 msgid "unlock from another terminal: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:2928
+#: src/store.c:2971
 #, c-format
 msgid "unlock wait timeout: %lld seconds\n"
 msgstr ""
 
-#: src/store.c:2959
+#: src/store.c:3002
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock secrets after %lld seconds\n"
 msgstr ""
 
-#: src/store.c:2984
+#: src/store.c:3027
 #, c-format
 msgid "waiting for another terminal to unlock resolved domain: %s\n"
 msgstr ""
 
-#: src/store.c:2991
+#: src/store.c:3034
 #, c-format
 msgid "wait-unlock timeout: %lld seconds\n"
 msgstr ""
 
-#: src/store.c:3019
+#: src/store.c:3062
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock resolved domain after %lld "
 "seconds\n"
 msgstr ""
 
-#: src/store.c:3091 src/store.c:3103 src/store.c:3110 src/store.c:3122
-#: src/store.c:3127 src/store.c:3132 src/store.c:12737
+#: src/store.c:3134 src/store.c:3146 src/store.c:3153 src/store.c:3165
+#: src/store.c:3170 src/store.c:3175 src/store.c:12780
 #, c-format
 msgid "invalid arguments for unlock\n"
 msgstr ""
 
-#: src/store.c:3116
+#: src/store.c:3159
 #, c-format
 msgid "--duration and --until cannot be combined\n"
 msgstr ""
 
-#: src/store.c:3138
+#: src/store.c:3181
 #, c-format
 msgid "invalid value for --duration: %s\n"
 msgstr ""
 
-#: src/store.c:3143
+#: src/store.c:3186
 #, c-format
 msgid "invalid value for --until: %s\n"
 msgstr ""
 
-#: src/store.c:3168 src/store.c:3177 src/store.c:3184 src/store.c:13118
+#: src/store.c:3211 src/store.c:3220 src/store.c:3227 src/store.c:13161
 #, c-format
 msgid "invalid arguments for passwd\n"
 msgstr ""
 
-#: src/store.c:3218 src/store.c:3225 src/store.c:3231 src/store.c:13000
+#: src/store.c:3261 src/store.c:3268 src/store.c:3274 src/store.c:13043
 #, c-format
 msgid "invalid arguments for lock\n"
 msgstr ""
 
-#: src/store.c:3250
+#: src/store.c:3293
 #, c-format
 msgid ""
 "cannot unlock descendant domains because an orphaned registered domain is in "
 "this subtree: %s\n"
 msgstr ""
 
-#: src/store.c:3251
+#: src/store.c:3294
 #, c-format
 msgid "recover it with: secdat domain move --from %s --to NEW_ROOT\n"
 msgstr ""
 
-#: src/store.c:3252
+#: src/store.c:3295
 #, c-format
 msgid "or discard it with: secdat --dir %s domain delete\n"
 msgstr ""
 
-#: src/store.c:3312
+#: src/store.c:3355
 #, c-format
 msgid ""
 "unlock --descendants requires confirmation on a terminal or rerun with --"
 "yes\n"
 msgstr ""
 
-#: src/store.c:3319
+#: src/store.c:3362
 #, c-format
 msgid "failed to read confirmation\n"
 msgstr ""
 
-#: src/store.c:3339
+#: src/store.c:3382
 msgid ""
 "unlock descendant domains in this subtree? local locks will remain [y/N]: "
 msgstr ""
 
-#: src/store.c:3349
+#: src/store.c:3392
 #, c-format
 msgid "descendant unlock cancelled\n"
 msgstr ""
 
-#: src/store.c:3382
+#: src/store.c:3425
 #, c-format
 msgid ""
 "note: unlocked %zu descendant domains in this subtree; local locks remain\n"
 msgstr ""
 
-#: src/store.c:3408
+#: src/store.c:3451
 #, c-format
 msgid "invalid key reference\n"
 msgstr ""
 
-#: src/store.c:3417 src/store.c:3443 src/store.c:3488
+#: src/store.c:3460 src/store.c:3486 src/store.c:3531
 #, c-format
 msgid "invalid key reference: %s\n"
 msgstr ""
 
-#: src/store.c:3564
+#: src/store.c:3607
 #, c-format
 msgid "%s is no longer supported; use %s\n"
 msgstr ""
 
-#: src/store.c:3571
+#: src/store.c:3614
 #, c-format
 msgid ""
 "--inject is not valid for %s; use --bulk-select to set bulk_select policy "
 "(exec supply rules use --inject on exec)\n"
 msgstr ""
 
-#: src/store.c:3651
+#: src/store.c:3694
 #, c-format
 msgid "invalid arguments for ls\n"
 msgstr ""
 
-#: src/store.c:3691 src/store.c:3706 src/store.c:3716
+#: src/store.c:3734 src/store.c:3749 src/store.c:3759
 #, c-format
 msgid "invalid arguments for export\n"
 msgstr ""
 
-#: src/store.c:3789 src/store.c:3796 src/store.c:3802 src/store.c:3808
-#: src/store.c:3814
+#: src/store.c:3832 src/store.c:3839 src/store.c:3845 src/store.c:3851
+#: src/store.c:3857
 #, c-format
 msgid "invalid arguments for list\n"
 msgstr ""
 
-#: src/store.c:3821
+#: src/store.c:3864
 #, c-format
 msgid "missing state filter for list\n"
 msgstr ""
 
-#: src/store.c:3878 src/store.c:3892
+#: src/store.c:3921 src/store.c:3935
 #, c-format
 msgid "invalid arguments for attr\n"
 msgstr ""
 
-#: src/store.c:3885
+#: src/store.c:3928
 #, c-format
 msgid "missing key for attr\n"
 msgstr ""
 
-#: src/store.c:3933
+#: src/store.c:3976
 #, c-format
 msgid "invalid fsck format: %s\n"
 msgstr ""
 
-#: src/store.c:3947 src/store.c:3954
+#: src/store.c:3990 src/store.c:3997
 #, c-format
 msgid "invalid arguments for fsck\n"
 msgstr ""
 
-#: src/store.c:3966
+#: src/store.c:4009
 #, c-format
 msgid "fsck --repair is only supported with --format v2\n"
 msgstr ""
 
-#: src/store.c:3970
+#: src/store.c:4013
 #, c-format
 msgid "fsck --repair currently requires --refcount\n"
 msgstr ""
 
-#: src/store.c:3975
+#: src/store.c:4018
 #, c-format
 msgid "fsck --dependency-index requires --format v2\n"
 msgstr ""
 
-#: src/store.c:3980
+#: src/store.c:4023
 #, c-format
 msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgstr ""
 
-#: src/store.c:4005
+#: src/store.c:4048
 #, c-format
 msgid "invalid gc format: %s\n"
 msgstr ""
 
-#: src/store.c:4060
+#: src/store.c:4103
 #, c-format
 msgid "gc --errors requires --status\n"
 msgstr ""
 
-#: src/store.c:4064
+#: src/store.c:4107
 #, c-format
 msgid "gc --json requires --status\n"
 msgstr ""
 
-#: src/store.c:4075
+#: src/store.c:4118
 #, c-format
 msgid "gc --status cannot be combined with mutation selectors\n"
 msgstr ""
 
-#: src/store.c:4087
+#: src/store.c:4130
 #, c-format
 msgid "invalid GC owner domain ID\n"
 msgstr ""
 
-#: src/store.c:4095
+#: src/store.c:4138
 #, c-format
 msgid "gc --owner requires --queued or --status\n"
 msgstr ""
 
-#: src/store.c:4100
+#: src/store.c:4143
 #, c-format
 msgid "gc --owner cannot select a full-store sweep\n"
 msgstr ""
 
-#: src/store.c:4118
+#: src/store.c:4161
 #, c-format
 msgid "gc --repair-epoch cannot be combined with another selector\n"
 msgstr ""
 
-#: src/store.c:4130 src/store.c:4151
+#: src/store.c:4173 src/store.c:4194
 #, c-format
 msgid "invalid GC quarantine selectors\n"
 msgstr ""
 
-#: src/store.c:4141
+#: src/store.c:4184
 #, c-format
 msgid "invalid GC candidate handle\n"
 msgstr ""
 
-#: src/store.c:4207 src/store.c:4214
+#: src/store.c:4250 src/store.c:4257
 #, c-format
 msgid "invalid arguments for gc\n"
 msgstr ""
 
-#: src/store.c:4255
+#: src/store.c:4298
 #, c-format
 msgid "invalid migration target format: %s\n"
 msgstr ""
 
-#: src/store.c:4266 src/store.c:4278
+#: src/store.c:4309 src/store.c:4321
 #, c-format
 msgid "invalid arguments for store migrate\n"
 msgstr ""
 
-#: src/store.c:4273
+#: src/store.c:4316
 #, c-format
 msgid "missing store name for store migrate\n"
 msgstr ""
 
-#: src/store.c:4283
+#: src/store.c:4326
 #, c-format
 msgid "store migrate requires --to-format v2\n"
 msgstr ""
 
-#: src/store.c:4313
+#: src/store.c:4356
 #, c-format
 msgid "invalid migration source format: %s\n"
 msgstr ""
 
-#: src/store.c:4324 src/store.c:4336
+#: src/store.c:4367 src/store.c:4379
 #, c-format
 msgid "invalid arguments for store finalize-migration\n"
 msgstr ""
 
-#: src/store.c:4331
+#: src/store.c:4374
 #, c-format
 msgid "missing store name for store finalize-migration\n"
 msgstr ""
 
-#: src/store.c:4341
+#: src/store.c:4384
 #, c-format
 msgid "store finalize-migration requires --from-format v1\n"
 msgstr ""
 
-#: src/store.c:4367 src/store.c:4378 src/store.c:4388
+#: src/store.c:4410 src/store.c:4421 src/store.c:4431
 #, c-format
 msgid "invalid arguments for store ls\n"
 msgstr ""
 
-#: src/store.c:4566
+#: src/store.c:4609
 #, c-format
 msgid "secret value is too large\n"
 msgstr ""
 
-#: src/store.c:4593 src/store.c:4606
+#: src/store.c:4636 src/store.c:4649
 #, c-format
 msgid "invalid overlay payload\n"
 msgstr ""
 
-#: src/store.c:4906 src/store.c:30809
+#: src/store.c:4949 src/store.c:30852
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr ""
 
-#: src/store.c:4920
+#: src/store.c:4963
 #, c-format
 msgid "invalid value access: %s\n"
 msgstr ""
 
-#: src/store.c:4978
+#: src/store.c:5021
 #, c-format
 msgid "invalid bulk select policy: %s; use %s\n"
 msgstr ""
 
-#: src/store.c:4981 src/store.c:4990
+#: src/store.c:5024 src/store.c:5033
 #, c-format
 msgid "invalid bulk select policy: %s\n"
 msgstr ""
 
-#: src/store.c:5022
+#: src/store.c:5065
 #, c-format
 msgid ""
 "key_visibility=unlocked requires store format v2; run store migrate STORE --"
 "to-format v2 --dry-run first\n"
 msgstr ""
 
-#: src/store.c:5053 src/store.c:5092
+#: src/store.c:5096 src/store.c:5135
 #, c-format
 msgid "invalid secret metadata\n"
 msgstr ""
 
-#: src/store.c:5070
+#: src/store.c:5113
 #, c-format
 msgid "unsupported secret metadata field: %s\n"
 msgstr ""
 
-#: src/store.c:5106
+#: src/store.c:5149
 #, c-format
 msgid "unsupported secret metadata format\n"
 msgstr ""
 
-#: src/store.c:5200 src/store.c:31167 src/store.c:37724
+#: src/store.c:5243 src/store.c:31210 src/store.c:37767
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr ""
 
-#: src/store.c:5217 src/store.c:30866 src/store.c:30943 src/store.c:30955
-#: src/store.c:31312
+#: src/store.c:5260 src/store.c:30909 src/store.c:30986 src/store.c:30998
+#: src/store.c:31355
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr ""
 
-#: src/store.c:5289 src/store.c:5296
+#: src/store.c:5332 src/store.c:5339
 #, c-format
 msgid "failed to create directory: %s\n"
 msgstr ""
 
-#: src/store.c:5470 src/store.c:19487
+#: src/store.c:5513 src/store.c:19530
 #, c-format
 msgid "invalid path: %s\n"
 msgstr ""
 
-#: src/store.c:5485
+#: src/store.c:5528
 #, c-format
 msgid "failed to create temporary file for: %s\n"
 msgstr ""
 
-#: src/store.c:5490
+#: src/store.c:5533
 #, c-format
 msgid "failed to set permissions on: %s\n"
 msgstr ""
 
-#: src/store.c:5500
+#: src/store.c:5543
 #, c-format
 msgid "failed to write file: %s\n"
 msgstr ""
 
-#: src/store.c:5509
+#: src/store.c:5552
 #, c-format
 msgid "failed to fsync file: %s\n"
 msgstr ""
 
-#: src/store.c:5516 src/store.c:19954
+#: src/store.c:5559 src/store.c:19997
 #, c-format
 msgid "failed to close file: %s\n"
 msgstr ""
 
-#: src/store.c:5522
+#: src/store.c:5565
 #, c-format
 msgid "failed to rename file into place: %s\n"
 msgstr ""
 
-#: src/store.c:5575 src/store.c:5588
+#: src/store.c:5618 src/store.c:5631
 #, c-format
 msgid "failed to seek file: %s\n"
 msgstr ""
 
-#: src/store.c:5582
+#: src/store.c:5625
 #, c-format
 msgid "failed to determine file size: %s\n"
 msgstr ""
 
-#: src/store.c:5701 src/store.c:12103
+#: src/store.c:5744 src/store.c:12146
 #, c-format
 msgid "failed to derive encryption key\n"
 msgstr ""
 
-#: src/store.c:5784
+#: src/store.c:5827
 #, c-format
 msgid "%s must be an integer between %u and %u\n"
 msgstr ""
 
-#: src/store.c:6381 src/store.c:6394 src/store.c:7905 src/store.c:7911
-#: src/store.c:7921 src/store.c:7969
+#: src/store.c:6424 src/store.c:6437 src/store.c:7948 src/store.c:7954
+#: src/store.c:7964 src/store.c:8012
 #, c-format
 msgid "failed to start session agent\n"
 msgstr ""
 
-#: src/store.c:6399 src/store.c:7976
+#: src/store.c:6442 src/store.c:8019
 #, c-format
 msgid "timed out waiting for session agent readiness\n"
 msgstr ""
 
-#: src/store.c:6826
+#: src/store.c:6869
 #, c-format
 msgid "failed to open file descriptor\n"
 msgstr ""
 
-#: src/store.c:7815
+#: src/store.c:7858
 #, c-format
 msgid "failed to bind session agent socket\n"
 msgstr ""
 
-#: src/store.c:7838
+#: src/store.c:7881
 #, c-format
 msgid "failed to listen on session agent socket\n"
 msgstr ""
 
-#: src/store.c:7984
+#: src/store.c:8027
 #, c-format
 msgid "session agent failed before readiness\n"
 msgstr ""
 
-#: src/store.c:8022
+#: src/store.c:8065
 #, c-format
 msgid "empty passphrase is not allowed\n"
 msgstr ""
 
-#: src/store.c:8039
+#: src/store.c:8082
 #, c-format
 msgid "missing askpass provider\n"
 msgstr ""
 
-#: src/store.c:8044
+#: src/store.c:8087
 #, c-format
 msgid "missing askpass provider: %s\n"
 msgstr ""
 
-#: src/store.c:8046
+#: src/store.c:8089
 #, c-format
 msgid "unsupported askpass provider: %s\n"
 msgstr ""
 
-#: src/store.c:8052 src/store.c:8060
+#: src/store.c:8095 src/store.c:8103
 #, c-format
 msgid "failed to start askpass command\n"
 msgstr ""
 
-#: src/store.c:8110
+#: src/store.c:8153
 #, c-format
 msgid "failed to read askpass output\n"
 msgstr ""
 
-#: src/store.c:8117
+#: src/store.c:8160
 #, c-format
 msgid "askpass prompt cancelled\n"
 msgstr ""
 
-#: src/store.c:8122
+#: src/store.c:8165
 #, c-format
 msgid "askpass output is too long\n"
 msgstr ""
 
-#: src/store.c:8149
+#: src/store.c:8192
 #, c-format
 msgid ""
 "missing askpass provider; --gui requires --askpass, SECDAT_ASKPASS, or "
 "SSH_ASKPASS\n"
 msgstr ""
 
-#: src/store.c:8152
+#: src/store.c:8195
 #, c-format
 msgid ""
 "missing askpass provider; this command requires a terminal for passphrase "
 "input\n"
 msgstr ""
 
-#: src/store.c:8160
+#: src/store.c:8203
 #, c-format
 msgid "failed to read terminal settings\n"
 msgstr ""
 
-#: src/store.c:8167 src/store.c:8183
+#: src/store.c:8210 src/store.c:8226
 #, c-format
 msgid "failed to update terminal settings\n"
 msgstr ""
 
-#: src/store.c:8173
+#: src/store.c:8216
 #, c-format
 msgid "failed to read passphrase\n"
 msgstr ""
 
-#: src/store.c:8204
+#: src/store.c:8247
 msgid "Create secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8207
+#: src/store.c:8250
 msgid "Confirm secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8214 src/store.c:8242
+#: src/store.c:8257 src/store.c:8285
 #, c-format
 msgid "passphrase confirmation did not match\n"
 msgstr ""
 
-#: src/store.c:8270
+#: src/store.c:8313
 msgid "Enter secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8303 src/store.c:8330
+#: src/store.c:8346 src/store.c:8373
 #, c-format
 msgid "failed to create session agent socket\n"
 msgstr ""
 
-#: src/store.c:8340
+#: src/store.c:8383
 #, c-format
 msgid "failed to connect to session agent\n"
 msgstr ""
 
-#: src/store.c:8722
+#: src/store.c:8765
 #, c-format
 msgid "failed to hand over the active session agent safely\n"
 msgstr ""
 
-#: src/store.c:8841 src/store.c:8854 src/store.c:8878
+#: src/store.c:8884 src/store.c:8897 src/store.c:8921
 #, c-format
 msgid "invalid response from the active session agent\n"
 msgstr ""
 
-#: src/store.c:8887 src/store.c:9231 src/store.c:9545
+#: src/store.c:8930 src/store.c:9274 src/store.c:9588
 #, c-format
 msgid "failed to negotiate capabilities with the active session agent\n"
 msgstr ""
 
-#: src/store.c:9015 src/store.c:9019
+#: src/store.c:9058 src/store.c:9062
 #, c-format
 msgid ""
 "failed to purge session-local ephemeral values from an active session agent\n"
 msgstr ""
 
-#: src/store.c:9237 src/store.c:9551
+#: src/store.c:9280 src/store.c:9594
 #, c-format
 msgid "the active session agent cannot expose its volatile overlay safely\n"
 msgstr ""
 
-#: src/store.c:9260 src/store.c:9275 src/store.c:9574 src/store.c:9589
+#: src/store.c:9303 src/store.c:9318 src/store.c:9617 src/store.c:9632
 #, c-format
 msgid "legacy volatile session cannot be read safely by this secdat version\n"
 msgstr ""
 
-#: src/store.c:9263 src/store.c:9577
+#: src/store.c:9306 src/store.c:9620
 #, c-format
 msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 
-#: src/store.c:9379 src/store.c:11427 src/store.c:11494 src/store.c:37816
+#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37859
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
 "%s\n"
 msgstr ""
 
-#: src/store.c:9429 src/store.c:37781
+#: src/store.c:9472 src/store.c:37824
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
 "secret: %s\n"
 msgstr ""
 
-#: src/store.c:9471 src/store.c:9510 src/store.c:38757
+#: src/store.c:9514 src/store.c:9553 src/store.c:38800
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
 "%s\n"
 msgstr ""
 
-#: src/store.c:9860
+#: src/store.c:9903
 #, c-format
 msgid ""
 "per-key ephemeral secrets require an active secdat session agent; run secdat "
 "unlock first\n"
 msgstr ""
 
-#: src/store.c:9866
+#: src/store.c:9909
 #, c-format
 msgid "current session is readonly and cannot store an ephemeral secret\n"
 msgstr ""
 
-#: src/store.c:9996
+#: src/store.c:10039
 #, c-format
 msgid "unlock writable session: secdat unlock\n"
 msgstr ""
 
-#: src/store.c:9998
+#: src/store.c:10041
 #, c-format
 msgid "unlock writable session: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:10007
+#: src/store.c:10050
 #, c-format
 msgid "current session is readonly and cannot run %s\n"
 msgstr ""
 
-#: src/store.c:10069 src/store.c:38723 src/store.c:38869 src/store.c:40926
+#: src/store.c:10112 src/store.c:38766 src/store.c:38912 src/store.c:40969
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr ""
 
-#: src/store.c:10085 src/store.c:10090
+#: src/store.c:10128 src/store.c:10133
 #, c-format
 msgid "lock --save requires a local volatile session\n"
 msgstr ""
 
-#: src/store.c:10170
+#: src/store.c:10213
 #, c-format
 msgid "invalid wrap key iteration count\n"
 msgstr ""
 
-#: src/store.c:10174
+#: src/store.c:10217
 #, c-format
 msgid "failed to derive wrap key\n"
 msgstr ""
 
-#: src/store.c:10191 src/store.c:10234 src/store.c:11750 src/store.c:13190
-#: src/store.c:13415 src/store.c:30652
+#: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
+#: src/store.c:13458 src/store.c:30695
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr ""
 
-#: src/store.c:10260 src/store.c:11776 src/store.c:13212 src/store.c:13437
+#: src/store.c:10303 src/store.c:11819 src/store.c:13255 src/store.c:13480
 #, c-format
 msgid "failed to create encryption context\n"
 msgstr ""
 
-#: src/store.c:10266 src/store.c:11782 src/store.c:13219 src/store.c:13443
+#: src/store.c:10309 src/store.c:11825 src/store.c:13262 src/store.c:13486
 #, c-format
 msgid "failed to initialize encryption\n"
 msgstr ""
 
-#: src/store.c:10276 src/store.c:11796 src/store.c:13230 src/store.c:13447
-#: src/store.c:13457
+#: src/store.c:10319 src/store.c:11839 src/store.c:13273 src/store.c:13490
+#: src/store.c:13500
 #, c-format
 msgid "failed to encrypt value\n"
 msgstr ""
 
-#: src/store.c:10284 src/store.c:11804 src/store.c:13235 src/store.c:13461
+#: src/store.c:10327 src/store.c:11847 src/store.c:13278 src/store.c:13504
 #, c-format
 msgid "failed to finalize encryption\n"
 msgstr ""
 
-#: src/store.c:10289 src/store.c:11809 src/store.c:13241 src/store.c:13466
+#: src/store.c:10332 src/store.c:11852 src/store.c:13284 src/store.c:13509
 #, c-format
 msgid "failed to obtain authentication tag\n"
 msgstr ""
 
-#: src/store.c:10331 src/store.c:10339 src/store.c:12023
+#: src/store.c:10374 src/store.c:10382 src/store.c:12066
 #, c-format
 msgid "invalid wrapped master key\n"
 msgstr ""
 
-#: src/store.c:10423 src/store.c:11848 src/store.c:11859 src/store.c:45422
-#: src/store.c:45453 src/store.c:45473 src/store.c:45496 src/store.c:45664
-#: src/store.c:45672 src/store.c:45694 src/store.c:45710
+#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45941
+#: src/store.c:45972 src/store.c:45992 src/store.c:46015 src/store.c:46183
+#: src/store.c:46191 src/store.c:46213 src/store.c:46229
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr ""
 
-#: src/store.c:10475
+#: src/store.c:10518
 #, c-format
 msgid "secret bundle has too many objects\n"
 msgstr ""
 
-#: src/store.c:10585 src/store.c:10736 src/store.c:14533 src/store.c:14729
-#: src/store.c:18133 src/store.c:18182 src/store.c:35294 src/store.c:35476
-#: src/store.c:37350 src/store.c:38812 src/store.c:38835 src/store.c:38889
-#: src/store.c:39160 src/store.c:39714 src/store.c:39746 src/store.c:41046
-#: src/store.c:42332
+#: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
+#: src/store.c:18176 src/store.c:18225 src/store.c:35337 src/store.c:35519
+#: src/store.c:37393 src/store.c:38855 src/store.c:38878 src/store.c:38932
+#: src/store.c:39203 src/store.c:39757 src/store.c:39789 src/store.c:41089
+#: src/store.c:42776
 #, c-format
 msgid "key not found: %s\n"
 msgstr ""
 
-#: src/store.c:10643
+#: src/store.c:10686
 #, c-format
 msgid "secret bundle entry is too large\n"
 msgstr ""
 
-#: src/store.c:10653
+#: src/store.c:10696
 #, c-format
 msgid "secret bundle value is unavailable for a selected v2 object\n"
 msgstr ""
 
-#: src/store.c:10743
+#: src/store.c:10786
 #, c-format
 msgid "save is not supported while an ephemeral secret is visible: %s\n"
 msgstr ""
 
-#: src/store.c:11742
+#: src/store.c:11785
 #, c-format
 msgid "bundle file already exists: %s\n"
 msgstr ""
 
-#: src/store.c:11746
+#: src/store.c:11789
 #, c-format
 msgid "secret bundle is too large\n"
 msgstr ""
 
-#: src/store.c:11786
+#: src/store.c:11829
 #, c-format
 msgid "failed to encrypt bundle metadata\n"
 msgstr ""
 
-#: src/store.c:11915 src/store.c:11989 src/store.c:13351 src/store.c:13545
+#: src/store.c:11958 src/store.c:12032 src/store.c:13394 src/store.c:13588
 #, c-format
 msgid "failed to create decryption context\n"
 msgstr ""
 
-#: src/store.c:11921 src/store.c:11995 src/store.c:13358 src/store.c:13551
+#: src/store.c:11964 src/store.c:12038 src/store.c:13401 src/store.c:13594
 #, c-format
 msgid "failed to initialize decryption\n"
 msgstr ""
 
-#: src/store.c:11925
+#: src/store.c:11968
 #, c-format
 msgid "failed to decrypt bundle metadata\n"
 msgstr ""
 
-#: src/store.c:11929 src/store.c:12005 src/store.c:13363 src/store.c:13555
-#: src/store.c:13559
+#: src/store.c:11972 src/store.c:12048 src/store.c:13406 src/store.c:13598
+#: src/store.c:13602
 #, c-format
 msgid "failed to decrypt value\n"
 msgstr ""
 
-#: src/store.c:11933 src/store.c:12014 src/store.c:13368 src/store.c:13563
+#: src/store.c:11976 src/store.c:12057 src/store.c:13411 src/store.c:13606
 #, c-format
 msgid "failed to set authentication tag\n"
 msgstr ""
 
-#: src/store.c:11937
+#: src/store.c:11980
 #, c-format
 msgid "failed to unlock secret bundle\n"
 msgstr ""
 
-#: src/store.c:12018
+#: src/store.c:12061
 #, c-format
 msgid "failed to unlock persistent master key\n"
 msgstr ""
 
-#: src/store.c:12094 src/store.c:19043 src/store.c:41035
+#: src/store.c:12137 src/store.c:19086 src/store.c:41078
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
 "export SECDAT_MASTER_KEY\n"
 msgstr ""
 
-#: src/store.c:12266 src/store.c:12270 src/store.c:12293
+#: src/store.c:12309 src/store.c:12313 src/store.c:12336
 #, c-format
 msgid "no local lock for: %s\n"
 msgstr ""
 
-#: src/store.c:12280
+#: src/store.c:12323
 #, c-format
 msgid "refusing to remove local lock for: %s\n"
 msgstr ""
 
-#: src/store.c:12281 src/store.c:12329
+#: src/store.c:12324 src/store.c:12372
 #, c-format
 msgid "expected resulting state: %s\n"
 msgstr ""
 
-#: src/store.c:12283
+#: src/store.c:12326
 #, c-format
 msgid "actual resulting state after removing local lock: %s\n"
 msgstr ""
 
-#: src/store.c:12298
+#: src/store.c:12341
 msgid "local lock removed; resulting state: unlocked"
 msgstr ""
 
-#: src/store.c:12300
+#: src/store.c:12343
 msgid "local lock removed; resulting state: locked"
 msgstr ""
 
-#: src/store.c:12302
+#: src/store.c:12345
 msgid "local lock removed"
 msgstr ""
 
-#: src/store.c:12318 src/store.c:12364
+#: src/store.c:12361 src/store.c:12407
 #, c-format
 msgid "no local lock or local unlock for: %s\n"
 msgstr ""
 
-#: src/store.c:12328
+#: src/store.c:12371
 #, c-format
 msgid "refusing to clear local unlock for: %s\n"
 msgstr ""
 
-#: src/store.c:12331
+#: src/store.c:12374
 #, c-format
 msgid "actual resulting state after clearing local unlock: %s\n"
 msgstr ""
 
-#: src/store.c:12342
+#: src/store.c:12385
 msgid "local unlock cleared; resulting state: unlocked"
 msgstr ""
 
-#: src/store.c:12344
+#: src/store.c:12387
 msgid "local unlock cleared; resulting state: locked"
 msgstr ""
 
-#: src/store.c:12346
+#: src/store.c:12389
 msgid "local unlock cleared"
 msgstr ""
 
-#: src/store.c:12601 src/store.c:12608 src/store.c:12614 src/store.c:12620
+#: src/store.c:12644 src/store.c:12651 src/store.c:12657 src/store.c:12663
 #, c-format
 msgid "invalid arguments for status\n"
 msgstr ""
 
-#: src/store.c:12632
+#: src/store.c:12675
 msgid "source: environment"
 msgstr ""
 
-#: src/store.c:12642
+#: src/store.c:12685
 msgid "source: session agent"
 msgstr ""
 
-#: src/store.c:12644
+#: src/store.c:12687
 msgid "overlay: volatile"
 msgstr ""
 
-#: src/store.c:12647
+#: src/store.c:12690
 msgid "access: readonly"
 msgstr ""
 
-#: src/store.c:12650
+#: src/store.c:12693
 #, c-format
 msgid "expires in: %s\n"
 msgstr ""
 
-#: src/store.c:12770
+#: src/store.c:12813
 #, c-format
 msgid "this will unlock %zu descendant domains in the current subtree\n"
 msgstr ""
 
-#: src/store.c:12771
+#: src/store.c:12814
 #, c-format
 msgid "local locks will remain after local unlock expiry or a later lock\n"
 msgstr ""
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "volatile session refreshed"
 msgstr ""
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "readonly session refreshed"
 msgstr ""
 
-#: src/store.c:12805
+#: src/store.c:12848
 msgid "session refreshed"
 msgstr ""
 
-#: src/store.c:12886
+#: src/store.c:12929
 msgid "readonly session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12887 src/store.c:12979
+#: src/store.c:12930 src/store.c:13022
 msgid "readonly session unlocked"
 msgstr ""
 
-#: src/store.c:12889 src/store.c:12925
+#: src/store.c:12932 src/store.c:12968
 msgid "volatile session unlocked with an ephemeral master key"
 msgstr ""
 
-#: src/store.c:12892
+#: src/store.c:12935
 msgid "volatile session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12893 src/store.c:12979
+#: src/store.c:12936 src/store.c:13022
 msgid "volatile session unlocked"
 msgstr ""
 
-#: src/store.c:12896
+#: src/store.c:12939
 msgid "persistent master key initialized; session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12897
+#: src/store.c:12940
 msgid "persistent master key initialized; session unlocked"
 msgstr ""
 
-#: src/store.c:12899
+#: src/store.c:12942
 msgid "session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12932
+#: src/store.c:12975
 #, c-format
 msgid ""
 "no persistent master key is initialized; readonly unlock requires an "
 "existing master key\n"
 msgstr ""
 
-#: src/store.c:12937 src/store.c:13127
+#: src/store.c:12980 src/store.c:13170
 #, c-format
 msgid ""
 "no persistent master key is initialized; run secdat unlock once to create "
 "one\n"
 msgstr ""
 
-#: src/store.c:12979
+#: src/store.c:13022
 msgid "session unlocked"
 msgstr ""
 
-#: src/store.c:13032
+#: src/store.c:13075
 msgid "already locked"
 msgstr ""
 
-#: src/store.c:13059
+#: src/store.c:13102
 msgid "volatile session saved and locked"
 msgstr ""
 
-#: src/store.c:13059
+#: src/store.c:13102
 msgid "session locked"
 msgstr ""
 
-#: src/store.c:13092
+#: src/store.c:13135
 #, c-format
 msgid "invalid arguments for inherit\n"
 msgstr ""
 
-#: src/store.c:13139
+#: src/store.c:13182
 msgid "Create new secdat passphrase: "
 msgstr ""
 
-#: src/store.c:13140
+#: src/store.c:13183
 msgid "Confirm new secdat passphrase: "
 msgstr ""
 
-#: src/store.c:13156
+#: src/store.c:13199
 msgid "persistent master key passphrase updated"
 msgstr ""
 
-#: src/store.c:13286 src/store.c:13304 src/store.c:13309 src/store.c:13315
-#: src/store.c:13330 src/store.c:13516 src/store.c:13523 src/store.c:13528
-#: src/store.c:14585 src/store.c:14669
+#: src/store.c:13329 src/store.c:13347 src/store.c:13352 src/store.c:13358
+#: src/store.c:13373 src/store.c:13559 src/store.c:13566 src/store.c:13571
+#: src/store.c:14628 src/store.c:14712
 #, c-format
 msgid "invalid encrypted entry\n"
 msgstr ""
 
-#: src/store.c:13291 src/store.c:14592 src/store.c:14673
+#: src/store.c:13334 src/store.c:14635 src/store.c:14716
 #, c-format
 msgid "unsupported encrypted entry format\n"
 msgstr ""
 
-#: src/store.c:13297 src/store.c:14596 src/store.c:14677
+#: src/store.c:13340 src/store.c:14639 src/store.c:14720
 #, c-format
 msgid "unsupported encryption algorithm\n"
 msgstr ""
 
-#: src/store.c:13374 src/store.c:13567
+#: src/store.c:13417 src/store.c:13610
 #, c-format
 msgid "failed to authenticate encrypted value\n"
 msgstr ""
 
-#: src/store.c:13733 src/store.c:14610 src/store.c:14616 src/store.c:18945
-#: src/store.c:18962 src/store.c:19016 src/store.c:19027 src/store.c:29356
-#: src/store.c:29975 src/store.c:30137 src/store.c:30719 src/store.c:30729
-#: src/store.c:31039 src/store.c:31075 src/store.c:31201 src/store.c:40743
-#: src/store.c:40766 src/store.c:42443
+#: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
+#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29399
+#: src/store.c:30018 src/store.c:30180 src/store.c:30762 src/store.c:30772
+#: src/store.c:31082 src/store.c:31118 src/store.c:31244 src/store.c:40786
+#: src/store.c:40809 src/store.c:42907
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr ""
 
-#: src/store.c:13771
+#: src/store.c:13814
 #, c-format
 msgid "failed to read standard input\n"
 msgstr ""
 
-#: src/store.c:13998 src/store.c:14221 src/store.c:14391 src/store.c:30029
-#: src/store.c:30276 src/store.c:33992 src/store.c:34097 src/store.c:34427
-#: src/store.c:37415 src/store.c:37703 src/store.c:38512 src/store.c:38611
-#: src/store.c:38855 src/store.c:41026 src/store.c:43028 src/store.c:43174
-#: src/store.c:43586 src/store.c:44206 src/store.c:44930 src/store.c:45506
+#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30072
+#: src/store.c:30319 src/store.c:34035 src/store.c:34140 src/store.c:34470
+#: src/store.c:37458 src/store.c:37746 src/store.c:38555 src/store.c:38654
+#: src/store.c:38898 src/store.c:41069 src/store.c:43547 src/store.c:43693
+#: src/store.c:44105 src/store.c:44725 src/store.c:45449 src/store.c:46025
 #, c-format
 msgid "invalid store format marker\n"
 msgstr ""
 
-#: src/store.c:14121
+#: src/store.c:14164
 #, c-format
 msgid "Key candidates:\n"
 msgstr ""
 
-#: src/store.c:14144
+#: src/store.c:14187
 #, c-format
 msgid ""
 "Hint: use %s get KEY for an explicit key lookup, or %s help COMMAND for "
 "command help\n"
 msgstr ""
 
-#: src/store.c:14156
+#: src/store.c:14199
 #, c-format
 msgid ""
 "Hint: check secdat status, --dir, and --store to confirm the lookup context\n"
 msgstr ""
 
-#: src/store.c:14565 src/store.c:30617 src/store.c:31045 src/store.c:31049
-#: src/store.c:31189 src/store.c:38659 src/store.c:38666 src/store.c:40749
+#: src/store.c:14608 src/store.c:30660 src/store.c:31088 src/store.c:31092
+#: src/store.c:31232 src/store.c:38702 src/store.c:38709 src/store.c:40792
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr ""
 
-#: src/store.c:14573
+#: src/store.c:14616
 #, c-format
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr ""
 
-#: src/store.c:15831 src/store.c:37986
+#: src/store.c:15874 src/store.c:38029
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr ""
 
-#: src/store.c:15923
+#: src/store.c:15966
 #, c-format
 msgid "failed to calculate GC candidate handle\n"
 msgstr ""
 
-#: src/store.c:16605
+#: src/store.c:16648
 #, c-format
 msgid "failed to read the GC scheduling clock\n"
 msgstr ""
 
-#: src/store.c:16859
+#: src/store.c:16902
 #, c-format
 msgid "invalid deferred GC topology effect\n"
 msgstr ""
 
-#: src/store.c:17005
+#: src/store.c:17048
 #, c-format
 msgid "secret reference count is too large\n"
 msgstr ""
 
-#: src/store.c:17552 src/store.c:17565
+#: src/store.c:17595 src/store.c:17608
 #, c-format
 msgid "metadata is too large\n"
 msgstr ""
 
-#: src/store.c:17644 src/store.c:17687 src/store.c:17736 src/store.c:35500
-#: src/store.c:35620 src/store.c:36876
+#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35543
+#: src/store.c:35663 src/store.c:36919
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr ""
 
-#: src/store.c:17725
+#: src/store.c:17768
 #, c-format
 msgid "invalid metadata filter: %s\n"
 msgstr ""
 
-#: src/store.c:17867 src/store.c:17896 src/store.c:17907
+#: src/store.c:17910 src/store.c:17939 src/store.c:17950
 #, c-format
 msgid "invalid key metadata\n"
 msgstr ""
 
-#: src/store.c:17882
+#: src/store.c:17925
 #, c-format
 msgid "unsupported key metadata format\n"
 msgstr ""
 
-#: src/store.c:18027 src/store.c:18100
+#: src/store.c:18070 src/store.c:18143
 #, c-format
 msgid "invalid relation member role: %s\n"
 msgstr ""
 
-#: src/store.c:18033
+#: src/store.c:18076
 #, c-format
 msgid "invalid relation member key reference\n"
 msgstr ""
 
-#: src/store.c:18040
+#: src/store.c:18083
 #, c-format
 msgid "duplicate relation member role: %s\n"
 msgstr ""
 
-#: src/store.c:18085
+#: src/store.c:18128
 #, c-format
 msgid "invalid relation member: %s\n"
 msgstr ""
 
-#: src/store.c:18210 src/store.c:35779
+#: src/store.c:18253 src/store.c:35822
 #, c-format
 msgid "relation not found: %s\n"
 msgstr ""
 
-#: src/store.c:18219 src/store.c:18247 src/store.c:18404
+#: src/store.c:18262 src/store.c:18290 src/store.c:18447
 #, c-format
 msgid "invalid relation metadata\n"
 msgstr ""
 
-#: src/store.c:18233
+#: src/store.c:18276
 #, c-format
 msgid "unsupported relation metadata format\n"
 msgstr ""
 
-#: src/store.c:18460
+#: src/store.c:18503
 #, c-format
 msgid "key_visibility=unlocked cannot be used while key metadata exists: %s\n"
 msgstr ""
 
-#: src/store.c:18482
+#: src/store.c:18525
 #, c-format
 msgid ""
 "key_visibility=unlocked cannot be used while relation references key: %s "
 "(%s)\n"
 msgstr ""
 
-#: src/store.c:19440
+#: src/store.c:19483
 #, c-format
 msgid "failed to calculate transaction digest\n"
 msgstr ""
 
-#: src/store.c:19462
+#: src/store.c:19505
 #, c-format
 msgid "failed to open directory for fsync: %s\n"
 msgstr ""
 
-#: src/store.c:19466
+#: src/store.c:19509
 #, c-format
 msgid "failed to fsync directory: %s\n"
 msgstr ""
 
-#: src/store.c:19471
+#: src/store.c:19514
 #, c-format
 msgid "failed to close directory: %s\n"
 msgstr ""
 
-#: src/store.c:19511
+#: src/store.c:19554
 #, c-format
 msgid "invalid transaction directory: %s\n"
 msgstr ""
 
-#: src/store.c:19549
+#: src/store.c:19592
 #, c-format
 msgid "invalid transaction lock\n"
 msgstr ""
 
-#: src/store.c:19566 src/store.c:19583
+#: src/store.c:19609 src/store.c:19626
 #, c-format
 msgid "failed to lock transactions\n"
 msgstr ""
 
-#: src/store.c:19912
+#: src/store.c:19955
 #, c-format
 msgid "failed to inspect transaction target: %s\n"
 msgstr ""
 
-#: src/store.c:19921
+#: src/store.c:19964
 #, c-format
 msgid "invalid transaction target: %s\n"
 msgstr ""
 
-#: src/store.c:20691
+#: src/store.c:20734
 #, c-format
 msgid "container tree does not match schema: %s\n"
 msgstr ""
 
-#: src/store.c:21237 src/store.c:21243 src/store.c:21364
+#: src/store.c:21280 src/store.c:21286 src/store.c:21407
 #, c-format
 msgid "failed to inspect typed directory: %s\n"
 msgstr ""
 
-#: src/store.c:21264
+#: src/store.c:21307
 #, c-format
 msgid "invalid typed directory: %s\n"
 msgstr ""
 
-#: src/store.c:21660 src/store.c:21751
+#: src/store.c:21703 src/store.c:21794
 #, c-format
 msgid "invalid transaction target directory\n"
 msgstr ""
 
-#: src/store.c:21780 src/store.c:21790 src/store.c:21868
+#: src/store.c:21823 src/store.c:21833 src/store.c:21911
 #, c-format
 msgid "failed to read transaction target\n"
 msgstr ""
 
-#: src/store.c:22236 src/store.c:22427 src/store.c:22438
+#: src/store.c:22279 src/store.c:22470 src/store.c:22481
 #, c-format
 msgid "transaction data is too large\n"
 msgstr ""
 
-#: src/store.c:22300
+#: src/store.c:22343
 #, c-format
 msgid "transaction has too many targets\n"
 msgstr ""
 
-#: src/store.c:22312
+#: src/store.c:22355
 #, c-format
 msgid "invalid transaction validation target\n"
 msgstr ""
 
-#: src/store.c:22358 src/store.c:22794
+#: src/store.c:22401 src/store.c:22837
 #, c-format
 msgid "transaction changed since plan\n"
 msgstr ""
 
-#: src/store.c:22381 src/store.c:22839
+#: src/store.c:22424 src/store.c:22882
 #, c-format
 msgid "duplicate transaction target\n"
 msgstr ""
 
-#: src/store.c:22825
+#: src/store.c:22868
 #, c-format
 msgid "typed directory guards require transaction manifest v2\n"
 msgstr ""
 
-#: src/store.c:22890
+#: src/store.c:22933
 #, c-format
 msgid "prepared guard is outside the state directory\n"
 msgstr ""
 
-#: src/store.c:22912
+#: src/store.c:22955
 #, c-format
 msgid "prepared write is outside the state directory\n"
 msgstr ""
 
-#: src/store.c:23015
+#: src/store.c:23058
 #, c-format
 msgid "invalid move source removal target\n"
 msgstr ""
 
-#: src/store.c:23187
+#: src/store.c:23230
 #, c-format
 msgid "invalid transaction blob: %s\n"
 msgstr ""
 
-#: src/store.c:23989
+#: src/store.c:24032
 #, c-format
 msgid "invalid transaction journal: %s\n"
 msgstr ""
 
-#: src/store.c:24056 src/store.c:24097
+#: src/store.c:24099 src/store.c:24140
 #, c-format
 msgid "failed to open transaction directory: %s\n"
 msgstr ""
 
-#: src/store.c:24072
+#: src/store.c:24115
 #, c-format
 msgid "unexpected transaction file: %s\n"
 msgstr ""
 
-#: src/store.c:24080
+#: src/store.c:24123
 #, c-format
 msgid "failed to close transaction directory\n"
 msgstr ""
 
-#: src/store.c:24123
+#: src/store.c:24166
 #, c-format
 msgid "invalid transaction temporary file: %s\n"
 msgstr ""
 
-#: src/store.c:24232
+#: src/store.c:24275
 #, c-format
 msgid "failed to remove completed transaction: %s\n"
 msgstr ""
 
-#: src/store.c:24286 src/store.c:24298 src/store.c:24303 src/store.c:24309
-#: src/store.c:24405
+#: src/store.c:24329 src/store.c:24341 src/store.c:24346 src/store.c:24352
+#: src/store.c:24448
 #, c-format
 msgid "failed to apply transaction target\n"
 msgstr ""
 
-#: src/store.c:24461
+#: src/store.c:24504
 #, c-format
 msgid "transaction target changed during recovery: %s\n"
 msgstr ""
 
-#: src/store.c:24497
+#: src/store.c:24540
 #, c-format
 msgid "committed transaction target is inconsistent: %s\n"
 msgstr ""
 
-#: src/store.c:24552
+#: src/store.c:24595
 #, c-format
 msgid "invalid unpublished transaction: %s\n"
 msgstr ""
 
-#: src/store.c:24576
+#: src/store.c:24619
 #, c-format
 msgid "failed to open transactions directory\n"
 msgstr ""
 
-#: src/store.c:24588
+#: src/store.c:24631
 #, c-format
 msgid "invalid transaction entry: %s\n"
 msgstr ""
 
-#: src/store.c:24672
+#: src/store.c:24715
 #, c-format
 msgid "failed to inspect transactions directory\n"
 msgstr ""
 
-#: src/store.c:24781
+#: src/store.c:24824
 #, c-format
 msgid "failed to stage transaction\n"
 msgstr ""
 
-#: src/store.c:24860
+#: src/store.c:24903
 #, c-format
 msgid "transaction changed since plan: %s\n"
 msgstr ""
 
-#: src/store.c:25122
+#: src/store.c:25165
 #, c-format
 msgid "invalid abandoned mutation stage\n"
 msgstr ""
 
-#: src/store.c:25382 src/store.c:25386
+#: src/store.c:25425 src/store.c:25429
 #, c-format
 msgid "invalid dependency index directory\n"
 msgstr ""
 
-#: src/store.c:25990
+#: src/store.c:26033
 #, c-format
 msgid "dependency index node is too large\n"
 msgstr ""
 
-#: src/store.c:26394
+#: src/store.c:26437
 #, c-format
 msgid "cannot index a relation dependency that references a hidden v2 key\n"
 msgstr ""
 
-#: src/store.c:26538
+#: src/store.c:26581
 #, c-format
 msgid "cannot build dependency index from invalid mask record\n"
 msgstr ""
 
-#: src/store.c:26564
+#: src/store.c:26607
 #, c-format
 msgid "cannot build dependency index from invalid relation record\n"
 msgstr ""
 
-#: src/store.c:26584
+#: src/store.c:26627
 #, c-format
 msgid "cannot index relation dependency: %s\n"
 msgstr ""
 
-#: src/store.c:27662 src/store.c:28057 src/store.c:28159 src/store.c:28686
-#: src/store.c:28796 src/store.c:29154 src/store.c:29169
+#: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
+#: src/store.c:28839 src/store.c:29197 src/store.c:29212
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
 "repair\n"
 msgstr ""
 
-#: src/store.c:28018 src/store.c:28223 src/store.c:29144 src/store.c:42367
+#: src/store.c:28061 src/store.c:28266 src/store.c:29187 src/store.c:42824
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
 "repair\n"
 msgstr ""
 
-#: src/store.c:28348
+#: src/store.c:28391
 #, c-format
 msgid "ambiguous legacy mask blocks key visibility transition: %s\n"
 msgstr ""
 
-#: src/store.c:28359
+#: src/store.c:28402
 #, c-format
 msgid "hidden-name transition cannot preserve v1 rollback mask state: %s\n"
 msgstr ""
 
-#: src/store.c:28947
+#: src/store.c:28990
 #, c-format
 msgid "invalid dependency index node: %s\n"
 msgstr ""
 
-#: src/store.c:29282
+#: src/store.c:29325
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
 msgstr ""
 
-#: src/store.c:29330
+#: src/store.c:29373
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr ""
 
-#: src/store.c:29892
+#: src/store.c:29935
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr ""
 
-#: src/store.c:29922 src/store.c:29931 src/store.c:29935
+#: src/store.c:29965 src/store.c:29974 src/store.c:29978
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr ""
 
-#: src/store.c:30013
+#: src/store.c:30056
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr ""
 
-#: src/store.c:30052
+#: src/store.c:30095 src/store.c:41864
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr ""
 
-#: src/store.c:30090
+#: src/store.c:30133
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr ""
 
-#: src/store.c:30111 src/store.c:30232
+#: src/store.c:30154 src/store.c:30275
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr ""
 
-#: src/store.c:30151 src/store.c:30157
+#: src/store.c:30194 src/store.c:30200
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr ""
 
-#: src/store.c:30196
+#: src/store.c:30239
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30200 src/store.c:31399
+#: src/store.c:30243 src/store.c:31442
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30220
+#: src/store.c:30263
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
 "handle\n"
 msgstr ""
 
-#: src/store.c:30476 src/store.c:39415
+#: src/store.c:30519 src/store.c:39458
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr ""
 
-#: src/store.c:30594
+#: src/store.c:30637
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 
-#: src/store.c:31053 src/store.c:31195
+#: src/store.c:31096 src/store.c:31238
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr ""
 
-#: src/store.c:31361
+#: src/store.c:31404
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr ""
 
-#: src/store.c:31948
+#: src/store.c:31991
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32673
+#: src/store.c:32716
 #, c-format
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr ""
 
-#: src/store.c:33300
+#: src/store.c:33343
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33715
+#: src/store.c:33758
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:33984 src/store.c:34089
+#: src/store.c:34027 src/store.c:34132
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:33996
+#: src/store.c:34039
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr ""
 
-#: src/store.c:34101
+#: src/store.c:34144
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr ""
 
-#: src/store.c:34412 src/store.c:34802
+#: src/store.c:34455 src/store.c:34845
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:34431
+#: src/store.c:34474
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr ""
 
-#: src/store.c:34635
+#: src/store.c:34678
 #, c-format
 msgid "GC owner domain must be registered before mutation\n"
 msgstr ""
 
-#: src/store.c:34813
+#: src/store.c:34856
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr ""
 
-#: src/store.c:35219
+#: src/store.c:35262
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
 "counts\n"
 msgstr ""
 
-#: src/store.c:35230
+#: src/store.c:35273
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
 "the affected domains or use --json for counts\n"
 msgstr ""
 
-#: src/store.c:35315 src/store.c:35385
+#: src/store.c:35358 src/store.c:35428
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr ""
 
-#: src/store.c:35377
+#: src/store.c:35420
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
 "with set --ephemeral\n"
 msgstr ""
 
-#: src/store.c:35378
+#: src/store.c:35421
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35507 src/store.c:35627
+#: src/store.c:35550 src/store.c:35670
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr ""
 
-#: src/store.c:35514 src/store.c:35634
+#: src/store.c:35557 src/store.c:35677
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr ""
 
-#: src/store.c:35515 src/store.c:35635
+#: src/store.c:35558 src/store.c:35678
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35520
+#: src/store.c:35563
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:35552
+#: src/store.c:35595
 #, c-format
 msgid "missing key for meta get\n"
 msgstr ""
 
-#: src/store.c:35552
+#: src/store.c:35595
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr ""
 
-#: src/store.c:35580
+#: src/store.c:35623
 #, c-format
 msgid "missing key for meta set\n"
 msgstr ""
 
-#: src/store.c:35580
+#: src/store.c:35623
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr ""
 
-#: src/store.c:35592
+#: src/store.c:35635
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35592
+#: src/store.c:35635
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35615
+#: src/store.c:35658
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr ""
 
-#: src/store.c:35615
+#: src/store.c:35658
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr ""
 
-#: src/store.c:35914
+#: src/store.c:35957
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr ""
 
-#: src/store.c:35958
+#: src/store.c:36001
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:35964
+#: src/store.c:36007
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:36001 src/store.c:36008
+#: src/store.c:36044 src/store.c:36051
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr ""
 
-#: src/store.c:36008
+#: src/store.c:36051
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr ""
 
-#: src/store.c:36014 src/store.c:37208 src/store.c:37257
+#: src/store.c:36057 src/store.c:37251 src/store.c:37300
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr ""
 
-#: src/store.c:36019
+#: src/store.c:36062
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 
-#: src/store.c:36031 src/store.c:37267
+#: src/store.c:36074 src/store.c:37310
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:36884 src/store.c:36890
+#: src/store.c:36927 src/store.c:36933
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr ""
 
-#: src/store.c:37083
+#: src/store.c:37126
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr ""
 
-#: src/store.c:37102
+#: src/store.c:37145
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37155
+#: src/store.c:37198
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37188
+#: src/store.c:37231
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37188
+#: src/store.c:37231
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37203
+#: src/store.c:37246
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr ""
 
-#: src/store.c:37203
+#: src/store.c:37246
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr ""
 
-#: src/store.c:37215
+#: src/store.c:37258
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37252
+#: src/store.c:37295
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr ""
 
-#: src/store.c:37252
+#: src/store.c:37295
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr ""
 
-#: src/store.c:37297
+#: src/store.c:37340
 #, c-format
 msgid "missing key for exists\n"
 msgstr ""
 
-#: src/store.c:37302
+#: src/store.c:37345
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr ""
 
-#: src/store.c:37331
+#: src/store.c:37374
 #, c-format
 msgid "missing key for id\n"
 msgstr ""
 
-#: src/store.c:37336
+#: src/store.c:37379
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr ""
 
-#: src/store.c:37356
+#: src/store.c:37399
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37384
+#: src/store.c:37427
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr ""
 
-#: src/store.c:37394
+#: src/store.c:37437
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr ""
 
-#: src/store.c:37399
+#: src/store.c:37442
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr ""
 
-#: src/store.c:37407
+#: src/store.c:37450
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37419
+#: src/store.c:37462
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37429
+#: src/store.c:37472
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr ""
 
-#: src/store.c:37433
+#: src/store.c:37476
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr ""
 
-#: src/store.c:37563
+#: src/store.c:37606
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr ""
 
-#: src/store.c:37577 src/store.c:37645
+#: src/store.c:37620 src/store.c:37688
 #, c-format
 msgid "failed to write standard output\n"
 msgstr ""
 
-#: src/store.c:37626
+#: src/store.c:37669
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr ""
 
-#: src/store.c:37773 src/store.c:38314
+#: src/store.c:37816 src/store.c:38357
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
 msgstr ""
 
-#: src/store.c:37828 src/store.c:38789 src/store.c:47160
+#: src/store.c:37871 src/store.c:38832 src/store.c:47891
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:37843
+#: src/store.c:37886
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:37948 src/store.c:38196 src/store.c:38206 src/store.c:38228
-#: src/store.c:38253 src/store.c:38262 src/store.c:38272 src/store.c:38301
-#: src/store.c:38377 src/store.c:38410 src/store.c:38419
+#: src/store.c:37991 src/store.c:38239 src/store.c:38249 src/store.c:38271
+#: src/store.c:38296 src/store.c:38305 src/store.c:38315 src/store.c:38344
+#: src/store.c:38420 src/store.c:38453 src/store.c:38462
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr ""
 
-#: src/store.c:37980
+#: src/store.c:38023
 #, c-format
 msgid "invalid generated secret charset\n"
 msgstr ""
 
-#: src/store.c:38001
+#: src/store.c:38044
 #, c-format
 msgid "generated secret charset is too large\n"
 msgstr ""
 
-#: src/store.c:38049
+#: src/store.c:38092
 #, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr ""
 
-#: src/store.c:38063 src/store.c:38072
+#: src/store.c:38106 src/store.c:38115
 #, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr ""
 
-#: src/store.c:38077
+#: src/store.c:38120
 #, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr ""
 
-#: src/store.c:38088
+#: src/store.c:38131
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38279
+#: src/store.c:38322
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr ""
 
-#: src/store.c:38323
+#: src/store.c:38366
 #, c-format
 msgid "missing key for set\n"
 msgstr ""
 
-#: src/store.c:38333
+#: src/store.c:38376
 #, c-format
 msgid "invalid arguments for generated set\n"
 msgstr ""
 
-#: src/store.c:38359
+#: src/store.c:38402
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38383
+#: src/store.c:38426
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr ""
 
-#: src/store.c:38432
+#: src/store.c:38475
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr ""
 
-#: src/store.c:38972
+#: src/store.c:39015
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39081
+#: src/store.c:39124
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 
-#: src/store.c:39090
+#: src/store.c:39133
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
 msgstr ""
 
-#: src/store.c:39119
+#: src/store.c:39162
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39146
+#: src/store.c:39189
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -4508,522 +4526,534 @@ msgid ""
 "inaccessible candidates without unmasking: %s\n"
 msgstr ""
 
-#: src/store.c:39167
+#: src/store.c:39210
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr ""
 
-#: src/store.c:39225
+#: src/store.c:39268
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39249
+#: src/store.c:39292
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39255 src/store.c:39265
+#: src/store.c:39298 src/store.c:39308
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr ""
 
-#: src/store.c:39276
+#: src/store.c:39319
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
 "and choose a chain with unmask --dry-run --mask-chain: %s\n"
 msgstr ""
 
-#: src/store.c:39363
+#: src/store.c:39406
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
 "its name: %s\n"
 msgstr ""
 
-#: src/store.c:39391
+#: src/store.c:39434
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
 "use mask --rebind after exactly one inherited v2 target remains: %s\n"
 msgstr ""
 
-#: src/store.c:39498 src/store.c:40306 src/store.c:40341 src/store.c:40348
-#: src/store.c:40445 src/store.c:40451
+#: src/store.c:39541 src/store.c:40349 src/store.c:40384 src/store.c:40391
+#: src/store.c:40488 src/store.c:40494
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr ""
 
-#: src/store.c:39654
+#: src/store.c:39697
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:39704 src/store.c:39736
+#: src/store.c:39747 src/store.c:39779
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr ""
 
-#: src/store.c:39856
+#: src/store.c:39899
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr ""
 
-#: src/store.c:39872
+#: src/store.c:39915
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr ""
 
-#: src/store.c:39905
+#: src/store.c:39948
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr ""
 
-#: src/store.c:39913
+#: src/store.c:39956
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:39979
+#: src/store.c:40022
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr ""
 
-#: src/store.c:39986 src/store.c:40624 src/store.c:40636
+#: src/store.c:40029 src/store.c:40667 src/store.c:40679
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr ""
 
-#: src/store.c:40019
+#: src/store.c:40062
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:40621
+#: src/store.c:40664
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
 "active: %s\n"
 msgstr ""
 
-#: src/store.c:40670
+#: src/store.c:40713
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr ""
 
-#: src/store.c:40704
+#: src/store.c:40747
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr ""
 
-#: src/store.c:40846 src/store.c:40852
+#: src/store.c:40889 src/store.c:40895
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr ""
 
-#: src/store.c:40857
+#: src/store.c:40900
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr ""
 
-#: src/store.c:40911 src/store.c:41219 src/store.c:42328 src/store.c:42773
-#: src/store.c:45318
+#: src/store.c:40954 src/store.c:41262 src/store.c:42772 src/store.c:43282
+#: src/store.c:45837
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr ""
 
-#: src/store.c:40963
+#: src/store.c:41006
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr ""
 
-#: src/store.c:40968 src/store.c:41003 src/store.c:41082 src/store.c:41166
-#: src/store.c:41190 src/store.c:42719 src/store.c:42743
+#: src/store.c:41011 src/store.c:41046 src/store.c:41125 src/store.c:41209
+#: src/store.c:41233 src/store.c:43228 src/store.c:43252
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr ""
 
-#: src/store.c:41019
+#: src/store.c:41062
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:41030 src/store.c:41055
+#: src/store.c:41073 src/store.c:41098
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr ""
 
-#: src/store.c:41051 src/store.c:41063
+#: src/store.c:41094 src/store.c:41106
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41069
+#: src/store.c:41112
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
 "after value confirmation)\n"
 msgstr ""
 
-#: src/store.c:41075
+#: src/store.c:41118
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr ""
 
-#: src/store.c:41102
+#: src/store.c:41145
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
 "replace to replace anyway)\n"
 msgstr ""
 
-#: src/store.c:41161
+#: src/store.c:41204
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr ""
 
-#: src/store.c:41232
+#: src/store.c:41275
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41256 src/store.c:42471 src/store.c:42847
+#: src/store.c:41299 src/store.c:42935 src/store.c:43366
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:41331
+#: src/store.c:41374
 #, c-format
 msgid "too many move relation dependencies\n"
 msgstr ""
 
-#: src/store.c:42334 src/store.c:42799
+#: src/store.c:41875
+#, c-format
+msgid "affected descendant mask is inaccessible: %s\n"
+msgstr ""
+
+#: src/store.c:42778 src/store.c:43308
 #, c-format
 msgid "mv requires v2 source and destination stores\n"
 msgstr ""
 
-#: src/store.c:42430
+#: src/store.c:42798
+#, c-format
+msgid ""
+"mv mutation planning requires a local source in the same v2 domain and "
+"store\n"
+msgstr ""
+
+#: src/store.c:42894
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
 
-#: src/store.c:42714
+#: src/store.c:43223
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr ""
 
-#: src/store.c:42787
+#: src/store.c:43296
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:42813
+#: src/store.c:43325 src/store.c:47921
+#, c-format
+msgid "mask mutation planning requires store format v2\n"
+msgstr ""
+
+#: src/store.c:43332
 #, c-format
 msgid "mv requires matching source and destination store formats\n"
 msgstr ""
 
-#: src/store.c:42977
+#: src/store.c:43496
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr ""
 
-#: src/store.c:43044
+#: src/store.c:43563
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43073
+#: src/store.c:43592
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr ""
 
-#: src/store.c:43193
+#: src/store.c:43712
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43244
+#: src/store.c:43763
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
 "barrier\n"
 msgstr ""
 
-#: src/store.c:43251
+#: src/store.c:43770
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
 "inherited value\n"
 msgstr ""
 
-#: src/store.c:43285
+#: src/store.c:43804
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr ""
 
-#: src/store.c:43291
+#: src/store.c:43810
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 
-#: src/store.c:43333 src/store.c:43340
+#: src/store.c:43852 src/store.c:43859
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr ""
 
-#: src/store.c:43468 src/store.c:43979 src/store.c:44337 src/store.c:44800
-#: src/store.c:44886
+#: src/store.c:43987 src/store.c:44498 src/store.c:44856 src/store.c:45319
+#: src/store.c:45405
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr ""
 
-#: src/store.c:43568
+#: src/store.c:44087
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:43579 src/store.c:44199 src/store.c:44921
+#: src/store.c:44098 src/store.c:44718 src/store.c:45440
 #, c-format
 msgid "store not found: %s\n"
 msgstr ""
 
-#: src/store.c:43590
+#: src/store.c:44109
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr ""
 
-#: src/store.c:43868
+#: src/store.c:44387
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr ""
 
-#: src/store.c:43937
+#: src/store.c:44456
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr ""
 
-#: src/store.c:44189
+#: src/store.c:44708
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:44210
+#: src/store.c:44729
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 
-#: src/store.c:44748
+#: src/store.c:45267
 #, c-format
 msgid "domain is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:44805
+#: src/store.c:45324
 #, c-format
 msgid "missing store name for store create\n"
 msgstr ""
 
-#: src/store.c:44810
+#: src/store.c:45329
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr ""
 
-#: src/store.c:44835
+#: src/store.c:45354
 #, c-format
 msgid "store already exists: %s\n"
 msgstr ""
 
-#: src/store.c:44891
+#: src/store.c:45410
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr ""
 
-#: src/store.c:44896
+#: src/store.c:45415
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr ""
 
-#: src/store.c:44937
+#: src/store.c:45456
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:44946
+#: src/store.c:45465
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:44990
+#: src/store.c:45509
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr ""
 
-#: src/store.c:45190 src/store.c:45198
+#: src/store.c:45709 src/store.c:45717
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr ""
 
-#: src/store.c:45210
+#: src/store.c:45729
 msgid "Create secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45211
+#: src/store.c:45730
 msgid "Confirm secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45267
+#: src/store.c:45786
 #, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr ""
 
-#: src/store.c:45272
+#: src/store.c:45791
 #, c-format
 msgid "conflicting load conflict policies\n"
 msgstr ""
 
-#: src/store.c:45285 src/store.c:45291
+#: src/store.c:45804 src/store.c:45810
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr ""
 
-#: src/store.c:45350
+#: src/store.c:45869
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45351
+#: src/store.c:45870
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45385
+#: src/store.c:45904
 msgid "Enter secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45864
+#: src/store.c:46383
 #, c-format
 msgid "  dir=%s\n"
 msgstr ""
 
-#: src/store.c:45867
+#: src/store.c:46386
 #, c-format
 msgid "  domain=%s\n"
 msgstr ""
 
-#: src/store.c:45870
+#: src/store.c:46389
 #, c-format
 msgid "  store=%s\n"
 msgstr ""
 
-#: src/store.c:45909
+#: src/store.c:46428
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr ""
 
-#: src/store.c:45913
+#: src/store.c:46432
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr ""
 
-#: src/store.c:45927
+#: src/store.c:46446
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr ""
 
-#: src/store.c:46008
+#: src/store.c:46527
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr ""
 
-#: src/store.c:46038 src/store.c:46070
+#: src/store.c:46557 src/store.c:46589
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr ""
 
-#: src/store.c:46049
+#: src/store.c:46568
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr ""
 
-#: src/store.c:46523
+#: src/store.c:47105
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr ""
 
-#: src/store.c:46619 src/store.c:46769
+#: src/store.c:47204 src/store.c:47466
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr ""
 
-#: src/store.c:46832
+#: src/store.c:47563
 #, c-format
 msgid "warning: %s: "
 msgstr ""
 
-#: src/store.c:46846
+#: src/store.c:47577
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr ""
 
-#: src/store.c:46850
+#: src/store.c:47581
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr ""
 
-#: src/store.c:46854
+#: src/store.c:47585
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr ""
 
-#: src/store.c:46858
+#: src/store.c:47589
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr ""
 
-#: src/store.c:46862
+#: src/store.c:47593
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr ""
 
-#: src/store.c:46866
+#: src/store.c:47597
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr ""
 
-#: src/store.c:46988
+#: src/store.c:47719
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr ""
 
-#: src/store.c:46989
+#: src/store.c:47720
 msgid "mask interaction rejected before mutation\n"
 msgstr ""
 
-#: src/store.c:47172
+#: src/store.c:47903
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:47190
-#, c-format
-msgid "mask mutation planning requires store format v2\n"
-msgstr ""
-
-#: src/store.c:47290
+#: src/store.c:48021
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr ""
 
-#: src/store.c:47308
+#: src/store.c:48039
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr ""
 
-#: src/store.c:47322 src/store.c:47331
+#: src/store.c:48053 src/store.c:48062
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr ""

--- a/po/secdat.pot
+++ b/po/secdat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: secdat 0.10.0\n"
 "Report-Msgid-Bugs-To: noreply@example.invalid\n"
-"POT-Creation-Date: 2026-08-28 19:23+0900\n"
+"POT-Creation-Date: 2026-08-31 12:28+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1740,38 +1740,38 @@ msgstr ""
 #: src/exec_inject_policy_file.c:60 src/exec_inject_policy_file.c:103
 #: src/exec_inject_policy_file.c:128 src/exec_inject_policy_file.c:202
 #: src/exec_inject_policy_file.c:245 src/exec_inject_policy_file.c:283
-#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1571
-#: src/store.c:1587 src/store.c:1728 src/store.c:1763 src/store.c:1812
-#: src/store.c:1927 src/store.c:1936 src/store.c:1953 src/store.c:1962
-#: src/store.c:1976 src/store.c:1982 src/store.c:4568 src/store.c:4614
-#: src/store.c:4641 src/store.c:4687 src/store.c:4722 src/store.c:5141
-#: src/store.c:5598 src/store.c:5638 src/store.c:9689 src/store.c:10287
-#: src/store.c:10391 src/store.c:10441 src/store.c:10525 src/store.c:10533
-#: src/store.c:11063 src/store.c:11375 src/store.c:11484 src/store.c:11545
-#: src/store.c:11803 src/store.c:11912 src/store.c:11953 src/store.c:12026
-#: src/store.c:13241 src/store.c:13363 src/store.c:13384 src/store.c:13466
-#: src/store.c:13578 src/store.c:13746 src/store.c:13801 src/store.c:15144
-#: src/store.c:15621 src/store.c:15765 src/store.c:16162 src/store.c:16484
-#: src/store.c:16918 src/store.c:17157 src/store.c:17195 src/store.c:17509
-#: src/store.c:17615 src/store.c:17693 src/store.c:17707 src/store.c:17716
-#: src/store.c:17773 src/store.c:17786 src/store.c:17795 src/store.c:17916
-#: src/store.c:18052 src/store.c:18092 src/store.c:18103 src/store.c:18137
-#: src/store.c:18268 src/store.c:19172 src/store.c:19971 src/store.c:21156
-#: src/store.c:21182 src/store.c:21436 src/store.c:21486 src/store.c:21512
-#: src/store.c:21881 src/store.c:22285 src/store.c:22410 src/store.c:22439
-#: src/store.c:22490 src/store.c:22785 src/store.c:23363 src/store.c:23850
-#: src/store.c:24469 src/store.c:25003 src/store.c:25603 src/store.c:25640
-#: src/store.c:25889 src/store.c:25931 src/store.c:26038 src/store.c:26069
-#: src/store.c:29465 src/store.c:29500 src/store.c:29648 src/store.c:29847
-#: src/store.c:30893 src/store.c:31025 src/store.c:31641 src/store.c:36395
-#: src/store.c:36400 src/store.c:36737 src/store.c:36797 src/store.c:36803
-#: src/store.c:36878 src/store.c:36891 src/store.c:37939 src/store.c:38020
-#: src/store.c:38119 src/store.c:38157 src/store.c:40002 src/store.c:40090
-#: src/store.c:40140 src/store.c:41402 src/store.c:41563 src/store.c:41770
-#: src/store.c:43980 src/store.c:45536 src/store.c:45711 src/store.c:45953
-#: src/store.c:45978 src/store.c:46002 src/store.c:46082 src/store.c:46133
-#: src/store.c:46182 src/store.c:46222 src/store.c:46516 src/store.c:46824
-#: src/store.c:48122 src/store.c:48130
+#: src/exec_inject_policy_file.c:475 src/secdat-fuse.c:145 src/store.c:1577
+#: src/store.c:1593 src/store.c:1734 src/store.c:1769 src/store.c:1818
+#: src/store.c:1933 src/store.c:1942 src/store.c:1959 src/store.c:1968
+#: src/store.c:1982 src/store.c:1988 src/store.c:4574 src/store.c:4620
+#: src/store.c:4647 src/store.c:4693 src/store.c:4728 src/store.c:5147
+#: src/store.c:5604 src/store.c:5644 src/store.c:9695 src/store.c:10293
+#: src/store.c:10397 src/store.c:10447 src/store.c:10531 src/store.c:10539
+#: src/store.c:11069 src/store.c:11381 src/store.c:11490 src/store.c:11551
+#: src/store.c:11809 src/store.c:11918 src/store.c:11959 src/store.c:12032
+#: src/store.c:13247 src/store.c:13369 src/store.c:13390 src/store.c:13472
+#: src/store.c:13584 src/store.c:13752 src/store.c:13807 src/store.c:15150
+#: src/store.c:15627 src/store.c:15771 src/store.c:16168 src/store.c:16490
+#: src/store.c:16924 src/store.c:17163 src/store.c:17201 src/store.c:17515
+#: src/store.c:17621 src/store.c:17699 src/store.c:17713 src/store.c:17722
+#: src/store.c:17779 src/store.c:17792 src/store.c:17801 src/store.c:17922
+#: src/store.c:18058 src/store.c:18098 src/store.c:18109 src/store.c:18143
+#: src/store.c:18274 src/store.c:19178 src/store.c:19977 src/store.c:21162
+#: src/store.c:21188 src/store.c:21442 src/store.c:21492 src/store.c:21518
+#: src/store.c:21887 src/store.c:22291 src/store.c:22416 src/store.c:22445
+#: src/store.c:22496 src/store.c:22791 src/store.c:23394 src/store.c:23881
+#: src/store.c:24500 src/store.c:25034 src/store.c:25638 src/store.c:25675
+#: src/store.c:25924 src/store.c:25966 src/store.c:26073 src/store.c:26104
+#: src/store.c:29500 src/store.c:29535 src/store.c:29683 src/store.c:29882
+#: src/store.c:30928 src/store.c:31060 src/store.c:31676 src/store.c:36430
+#: src/store.c:36435 src/store.c:36772 src/store.c:36832 src/store.c:36838
+#: src/store.c:36913 src/store.c:36926 src/store.c:37974 src/store.c:38055
+#: src/store.c:38154 src/store.c:38192 src/store.c:40037 src/store.c:40125
+#: src/store.c:40175 src/store.c:41437 src/store.c:41598 src/store.c:41805
+#: src/store.c:44067 src/store.c:45623 src/store.c:45798 src/store.c:46040
+#: src/store.c:46065 src/store.c:46089 src/store.c:46169 src/store.c:46220
+#: src/store.c:46269 src/store.c:46309 src/store.c:46603 src/store.c:46913
+#: src/store.c:48216 src/store.c:48224
 #, c-format
 msgid "out of memory\n"
 msgstr ""
@@ -1782,18 +1782,18 @@ msgstr ""
 #: src/domain.c:955 src/domain.c:990 src/domain.c:1002 src/domain.c:1006
 #: src/domain.c:1101 src/domain.c:1234 src/domain.c:1356 src/domain.c:1364
 #: src/domain.c:1451 src/domain.c:1513 src/domain.c:1590 src/secdat-fuse.c:186
-#: src/store.c:2003 src/store.c:2021 src/store.c:3492 src/store.c:3499
-#: src/store.c:3517 src/store.c:4466 src/store.c:4736 src/store.c:4840
-#: src/store.c:4867 src/store.c:4894 src/store.c:5320 src/store.c:5518
-#: src/store.c:5688 src/store.c:5711 src/store.c:5727 src/store.c:6409
-#: src/store.c:7849 src/store.c:8354 src/store.c:8378 src/store.c:10230
-#: src/store.c:10556 src/store.c:14301 src/store.c:14311 src/store.c:14329
-#: src/store.c:14364 src/store.c:14417 src/store.c:15870 src/store.c:17857
-#: src/store.c:17876 src/store.c:18766 src/store.c:18780 src/store.c:18794
-#: src/store.c:19220 src/store.c:19581 src/store.c:30853 src/store.c:30975
-#: src/store.c:31280 src/store.c:33993 src/store.c:34200 src/store.c:34239
-#: src/store.c:34300 src/store.c:34525 src/store.c:34593 src/store.c:38832
-#: src/store.c:39746 src/store.c:40665
+#: src/store.c:2009 src/store.c:2027 src/store.c:3498 src/store.c:3505
+#: src/store.c:3523 src/store.c:4472 src/store.c:4742 src/store.c:4846
+#: src/store.c:4873 src/store.c:4900 src/store.c:5326 src/store.c:5524
+#: src/store.c:5694 src/store.c:5717 src/store.c:5733 src/store.c:6415
+#: src/store.c:7855 src/store.c:8360 src/store.c:8384 src/store.c:10236
+#: src/store.c:10562 src/store.c:14307 src/store.c:14317 src/store.c:14335
+#: src/store.c:14370 src/store.c:14423 src/store.c:15876 src/store.c:17863
+#: src/store.c:17882 src/store.c:18772 src/store.c:18786 src/store.c:18800
+#: src/store.c:19226 src/store.c:19587 src/store.c:30888 src/store.c:31010
+#: src/store.c:31315 src/store.c:34028 src/store.c:34235 src/store.c:34274
+#: src/store.c:34335 src/store.c:34560 src/store.c:34628 src/store.c:38867
+#: src/store.c:39781 src/store.c:40700
 #, c-format
 msgid "path is too long\n"
 msgstr ""
@@ -1814,17 +1814,17 @@ msgstr ""
 msgid "local-lock"
 msgstr ""
 
-#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12710
+#: src/domain.c:337 src/domain.c:375 src/domain.c:382 src/store.c:12716
 msgid "locked"
 msgstr ""
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
-#: src/store.c:12711
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12682 src/store.c:12700
+#: src/store.c:12717
 msgid "wrapped master key: present"
 msgstr ""
 
-#: src/domain.c:356 src/domain.c:2337 src/store.c:12676 src/store.c:12694
-#: src/store.c:12711
+#: src/domain.c:356 src/domain.c:2337 src/store.c:12682 src/store.c:12700
+#: src/store.c:12717
 msgid "wrapped master key: absent"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "session"
 msgstr ""
 
-#: src/domain.c:383 src/store.c:12674 src/store.c:12684
+#: src/domain.c:383 src/store.c:12680 src/store.c:12690
 msgid "unlocked"
 msgstr ""
 
@@ -1872,18 +1872,18 @@ msgstr ""
 msgid "DOMAIN"
 msgstr ""
 
-#: src/domain.c:639 src/store.c:5706
+#: src/domain.c:639 src/store.c:5712
 #, c-format
 msgid "HOME is not set\n"
 msgstr ""
 
-#: src/domain.c:795 src/store.c:5591 src/store.c:5612
+#: src/domain.c:795 src/store.c:5597 src/store.c:5618
 #, c-format
 msgid "failed to open file: %s\n"
 msgstr ""
 
-#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5645
-#: src/store.c:19989
+#: src/domain.c:801 src/domain.c:835 src/domain.c:1502 src/store.c:5651
+#: src/store.c:19995
 #, c-format
 msgid "failed to read file: %s\n"
 msgstr ""
@@ -1899,13 +1899,13 @@ msgid "domain root identity mismatch for: %s\n"
 msgstr ""
 
 #: src/domain.c:911 src/domain.c:995 src/domain.c:1447 src/secdat-fuse.c:182
-#: src/store.c:2016
+#: src/store.c:2022
 #, c-format
 msgid "failed to resolve directory: %s\n"
 msgstr ""
 
-#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5297
-#: src/store.c:5344
+#: src/domain.c:921 src/domain.c:1622 src/domain.c:1782 src/store.c:5303
+#: src/store.c:5350
 #, c-format
 msgid "not a directory: %s\n"
 msgstr ""
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "failed to generate domain id\n"
 msgstr ""
 
-#: src/domain.c:1268 src/store.c:4774 src/store.c:13849 src/store.c:43928
+#: src/domain.c:1268 src/store.c:4780 src/store.c:13855 src/store.c:44015
 #, c-format
 msgid "failed to open directory: %s\n"
 msgstr ""
@@ -1976,8 +1976,8 @@ msgstr ""
 msgid "invalid arguments for domain status\n"
 msgstr ""
 
-#: src/domain.c:2288 src/store.c:2266 src/store.c:2272 src/store.c:10037
-#: src/store.c:12795
+#: src/domain.c:2288 src/store.c:2272 src/store.c:2278 src/store.c:10043
+#: src/store.c:12801
 #, c-format
 msgid "resolved domain: %s\n"
 msgstr ""
@@ -2051,7 +2051,7 @@ msgstr ""
 msgid "effective source: locked"
 msgstr ""
 
-#: src/domain.c:2355 src/store.c:46402
+#: src/domain.c:2355 src/store.c:46489
 #, c-format
 msgid "command not implemented yet: %s\n"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "invalid secret rename regex: %s\n"
 msgstr ""
 
-#: src/exec_inject.c:834 src/store.c:3541 src/store.c:45649 src/store.c:45719
+#: src/exec_inject.c:834 src/store.c:3547 src/store.c:45736 src/store.c:45806
 #, c-format
 msgid "key is not a valid environment variable name: %s\n"
 msgstr ""
@@ -2459,2066 +2459,2066 @@ msgstr ""
 msgid "failed to create pipe\n"
 msgstr ""
 
-#: src/store.c:1630
+#: src/store.c:1636
 #, c-format
 msgid ""
 "deferred GC remains queued because the owner agent could not be upgraded\n"
 msgstr ""
 
-#: src/store.c:1639
+#: src/store.c:1645
 #, c-format
 msgid "deferred GC remains queued because the owner agent lacks GC_WORKER_V1\n"
 msgstr ""
 
-#: src/store.c:2061
+#: src/store.c:2067
 #, c-format
 msgid "writes to the default domain are not supported\n"
 msgstr ""
 
-#: src/store.c:2138 src/store.c:5489
+#: src/store.c:2144 src/store.c:5495
 #, c-format
 msgid "failed to remove file: %s\n"
 msgstr ""
 
-#: src/store.c:2198
+#: src/store.c:2204
 #, c-format
 msgid "note: %zu descendant domains can now reuse this session\n"
 msgstr ""
 
-#: src/store.c:2201 src/store.c:2238
+#: src/store.c:2207 src/store.c:2244
 #, c-format
 msgid "note: %zu orphaned descendant domains are not affected by unlock\n"
 msgstr ""
 
-#: src/store.c:2203 src/store.c:2240
+#: src/store.c:2209 src/store.c:2246
 #, c-format
 msgid ""
 "recover or delete orphaned descendant: secdat domain move --from %s --to "
 "NEW_ROOT\n"
 msgstr ""
 
-#: src/store.c:2204 src/store.c:2241
+#: src/store.c:2210 src/store.c:2247
 #, c-format
 msgid "discard orphaned descendant: secdat --dir %s domain delete\n"
 msgstr ""
 
-#: src/store.c:2211
+#: src/store.c:2217
 #, c-format
 msgid "note: %zu descendant domains remain locked under this branch\n"
 msgstr ""
 
-#: src/store.c:2212
+#: src/store.c:2218
 msgid "affected descendants:"
 msgstr ""
 
-#: src/store.c:2231
+#: src/store.c:2237
 #, c-format
 msgid "  %s\n"
 msgstr ""
 
-#: src/store.c:2235
+#: src/store.c:2241
 #, c-format
 msgid "  ... and %zu more\n"
 msgstr ""
 
-#: src/store.c:2245
+#: src/store.c:2251
 #, c-format
 msgid "inspect descendants: secdat --dir %s domain ls -l --descendants\n"
 msgstr ""
 
-#: src/store.c:2247
+#: src/store.c:2253
 #, c-format
 msgid "inspect one descendant: secdat --dir %s domain status\n"
 msgstr ""
 
-#: src/store.c:2248
+#: src/store.c:2254
 #, c-format
 msgid "unlock one descendant: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:2267
+#: src/store.c:2273
 #, c-format
 msgid "inspect current domain: secdat domain status\n"
 msgstr ""
 
-#: src/store.c:2268
+#: src/store.c:2274
 #, c-format
 msgid "unlock current domain: secdat unlock\n"
 msgstr ""
 
-#: src/store.c:2273
+#: src/store.c:2279
 #, c-format
 msgid "inspect current domain: secdat --dir %s domain status\n"
 msgstr ""
 
-#: src/store.c:2274
+#: src/store.c:2280
 #, c-format
 msgid "unlock current domain: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:2370
+#: src/store.c:2376
 #, c-format
 msgid ""
 "Hint: inspect migration first with `%s store migrate %s --to-format v2 --dry-"
 "run`\n"
 msgstr ""
 
-#: src/store.c:2371
+#: src/store.c:2377
 #, c-format
 msgid "Hint: suppress migration hints with %s=1\n"
 msgstr ""
 
-#: src/store.c:2402
+#: src/store.c:2408
 #, c-format
 msgid "invalid value for --unlock-timeout: %s\n"
 msgstr ""
 
-#: src/store.c:2850
+#: src/store.c:2856
 #, c-format
 msgid "missing value for --unlock-timeout\n"
 msgstr ""
 
-#: src/store.c:2855 src/store.c:2864 src/store.c:2876
+#: src/store.c:2861 src/store.c:2870 src/store.c:2882
 #, c-format
 msgid "invalid arguments for get\n"
 msgstr ""
 
-#: src/store.c:2885
+#: src/store.c:2891
 #, c-format
 msgid "missing key for get\n"
 msgstr ""
 
-#: src/store.c:2890
+#: src/store.c:2896
 #, c-format
 msgid "--unlock-timeout requires --on-demand-unlock or %s\n"
 msgstr ""
 
-#: src/store.c:2919
+#: src/store.c:2925
 #, c-format
 msgid "invalid value for --timeout: %s\n"
 msgstr ""
 
-#: src/store.c:2926
+#: src/store.c:2932
 #, c-format
 msgid "missing value for --timeout\n"
 msgstr ""
 
-#: src/store.c:2935 src/store.c:2942 src/store.c:12724
+#: src/store.c:2941 src/store.c:2948 src/store.c:12730
 #, c-format
 msgid "invalid arguments for wait-unlock\n"
 msgstr ""
 
-#: src/store.c:2964
+#: src/store.c:2970
 #, c-format
 msgid ""
 "waiting for another terminal to unlock secrets for resolved domain: %s\n"
 msgstr ""
 
-#: src/store.c:2966 src/store.c:3029
+#: src/store.c:2972 src/store.c:3035
 #, c-format
 msgid "unlock from another terminal: secdat unlock\n"
 msgstr ""
 
-#: src/store.c:2968 src/store.c:3031
+#: src/store.c:2974 src/store.c:3037
 #, c-format
 msgid "unlock from another terminal: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:2971
+#: src/store.c:2977
 #, c-format
 msgid "unlock wait timeout: %lld seconds\n"
 msgstr ""
 
-#: src/store.c:3002
+#: src/store.c:3008
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock secrets after %lld seconds\n"
 msgstr ""
 
-#: src/store.c:3027
+#: src/store.c:3033
 #, c-format
 msgid "waiting for another terminal to unlock resolved domain: %s\n"
 msgstr ""
 
-#: src/store.c:3034
+#: src/store.c:3040
 #, c-format
 msgid "wait-unlock timeout: %lld seconds\n"
 msgstr ""
 
-#: src/store.c:3062
+#: src/store.c:3068
 #, c-format
 msgid ""
 "timed out waiting for another terminal to unlock resolved domain after %lld "
 "seconds\n"
 msgstr ""
 
-#: src/store.c:3134 src/store.c:3146 src/store.c:3153 src/store.c:3165
-#: src/store.c:3170 src/store.c:3175 src/store.c:12780
+#: src/store.c:3140 src/store.c:3152 src/store.c:3159 src/store.c:3171
+#: src/store.c:3176 src/store.c:3181 src/store.c:12786
 #, c-format
 msgid "invalid arguments for unlock\n"
 msgstr ""
 
-#: src/store.c:3159
+#: src/store.c:3165
 #, c-format
 msgid "--duration and --until cannot be combined\n"
 msgstr ""
 
-#: src/store.c:3181
+#: src/store.c:3187
 #, c-format
 msgid "invalid value for --duration: %s\n"
 msgstr ""
 
-#: src/store.c:3186
+#: src/store.c:3192
 #, c-format
 msgid "invalid value for --until: %s\n"
 msgstr ""
 
-#: src/store.c:3211 src/store.c:3220 src/store.c:3227 src/store.c:13161
+#: src/store.c:3217 src/store.c:3226 src/store.c:3233 src/store.c:13167
 #, c-format
 msgid "invalid arguments for passwd\n"
 msgstr ""
 
-#: src/store.c:3261 src/store.c:3268 src/store.c:3274 src/store.c:13043
+#: src/store.c:3267 src/store.c:3274 src/store.c:3280 src/store.c:13049
 #, c-format
 msgid "invalid arguments for lock\n"
 msgstr ""
 
-#: src/store.c:3293
+#: src/store.c:3299
 #, c-format
 msgid ""
 "cannot unlock descendant domains because an orphaned registered domain is in "
 "this subtree: %s\n"
 msgstr ""
 
-#: src/store.c:3294
+#: src/store.c:3300
 #, c-format
 msgid "recover it with: secdat domain move --from %s --to NEW_ROOT\n"
 msgstr ""
 
-#: src/store.c:3295
+#: src/store.c:3301
 #, c-format
 msgid "or discard it with: secdat --dir %s domain delete\n"
 msgstr ""
 
-#: src/store.c:3355
+#: src/store.c:3361
 #, c-format
 msgid ""
 "unlock --descendants requires confirmation on a terminal or rerun with --"
 "yes\n"
 msgstr ""
 
-#: src/store.c:3362
+#: src/store.c:3368
 #, c-format
 msgid "failed to read confirmation\n"
 msgstr ""
 
-#: src/store.c:3382
+#: src/store.c:3388
 msgid ""
 "unlock descendant domains in this subtree? local locks will remain [y/N]: "
 msgstr ""
 
-#: src/store.c:3392
+#: src/store.c:3398
 #, c-format
 msgid "descendant unlock cancelled\n"
 msgstr ""
 
-#: src/store.c:3425
+#: src/store.c:3431
 #, c-format
 msgid ""
 "note: unlocked %zu descendant domains in this subtree; local locks remain\n"
 msgstr ""
 
-#: src/store.c:3451
+#: src/store.c:3457
 #, c-format
 msgid "invalid key reference\n"
 msgstr ""
 
-#: src/store.c:3460 src/store.c:3486 src/store.c:3531
+#: src/store.c:3466 src/store.c:3492 src/store.c:3537
 #, c-format
 msgid "invalid key reference: %s\n"
 msgstr ""
 
-#: src/store.c:3607
+#: src/store.c:3613
 #, c-format
 msgid "%s is no longer supported; use %s\n"
 msgstr ""
 
-#: src/store.c:3614
+#: src/store.c:3620
 #, c-format
 msgid ""
 "--inject is not valid for %s; use --bulk-select to set bulk_select policy "
 "(exec supply rules use --inject on exec)\n"
 msgstr ""
 
-#: src/store.c:3694
+#: src/store.c:3700
 #, c-format
 msgid "invalid arguments for ls\n"
 msgstr ""
 
-#: src/store.c:3734 src/store.c:3749 src/store.c:3759
+#: src/store.c:3740 src/store.c:3755 src/store.c:3765
 #, c-format
 msgid "invalid arguments for export\n"
 msgstr ""
 
-#: src/store.c:3832 src/store.c:3839 src/store.c:3845 src/store.c:3851
-#: src/store.c:3857
+#: src/store.c:3838 src/store.c:3845 src/store.c:3851 src/store.c:3857
+#: src/store.c:3863
 #, c-format
 msgid "invalid arguments for list\n"
 msgstr ""
 
-#: src/store.c:3864
+#: src/store.c:3870
 #, c-format
 msgid "missing state filter for list\n"
 msgstr ""
 
-#: src/store.c:3921 src/store.c:3935
+#: src/store.c:3927 src/store.c:3941
 #, c-format
 msgid "invalid arguments for attr\n"
 msgstr ""
 
-#: src/store.c:3928
+#: src/store.c:3934
 #, c-format
 msgid "missing key for attr\n"
 msgstr ""
 
-#: src/store.c:3976
+#: src/store.c:3982
 #, c-format
 msgid "invalid fsck format: %s\n"
 msgstr ""
 
-#: src/store.c:3990 src/store.c:3997
+#: src/store.c:3996 src/store.c:4003
 #, c-format
 msgid "invalid arguments for fsck\n"
 msgstr ""
 
-#: src/store.c:4009
+#: src/store.c:4015
 #, c-format
 msgid "fsck --repair is only supported with --format v2\n"
 msgstr ""
 
-#: src/store.c:4013
+#: src/store.c:4019
 #, c-format
 msgid "fsck --repair currently requires --refcount\n"
 msgstr ""
 
-#: src/store.c:4018
+#: src/store.c:4024
 #, c-format
 msgid "fsck --dependency-index requires --format v2\n"
 msgstr ""
 
-#: src/store.c:4023
+#: src/store.c:4029
 #, c-format
 msgid "fsck --dependency-index cannot be combined with store checks\n"
 msgstr ""
 
-#: src/store.c:4048
+#: src/store.c:4054
 #, c-format
 msgid "invalid gc format: %s\n"
 msgstr ""
 
-#: src/store.c:4103
+#: src/store.c:4109
 #, c-format
 msgid "gc --errors requires --status\n"
 msgstr ""
 
-#: src/store.c:4107
+#: src/store.c:4113
 #, c-format
 msgid "gc --json requires --status\n"
 msgstr ""
 
-#: src/store.c:4118
+#: src/store.c:4124
 #, c-format
 msgid "gc --status cannot be combined with mutation selectors\n"
 msgstr ""
 
-#: src/store.c:4130
+#: src/store.c:4136
 #, c-format
 msgid "invalid GC owner domain ID\n"
 msgstr ""
 
-#: src/store.c:4138
+#: src/store.c:4144
 #, c-format
 msgid "gc --owner requires --queued or --status\n"
 msgstr ""
 
-#: src/store.c:4143
+#: src/store.c:4149
 #, c-format
 msgid "gc --owner cannot select a full-store sweep\n"
 msgstr ""
 
-#: src/store.c:4161
+#: src/store.c:4167
 #, c-format
 msgid "gc --repair-epoch cannot be combined with another selector\n"
 msgstr ""
 
-#: src/store.c:4173 src/store.c:4194
+#: src/store.c:4179 src/store.c:4200
 #, c-format
 msgid "invalid GC quarantine selectors\n"
 msgstr ""
 
-#: src/store.c:4184
+#: src/store.c:4190
 #, c-format
 msgid "invalid GC candidate handle\n"
 msgstr ""
 
-#: src/store.c:4250 src/store.c:4257
+#: src/store.c:4256 src/store.c:4263
 #, c-format
 msgid "invalid arguments for gc\n"
 msgstr ""
 
-#: src/store.c:4298
+#: src/store.c:4304
 #, c-format
 msgid "invalid migration target format: %s\n"
 msgstr ""
 
-#: src/store.c:4309 src/store.c:4321
+#: src/store.c:4315 src/store.c:4327
 #, c-format
 msgid "invalid arguments for store migrate\n"
 msgstr ""
 
-#: src/store.c:4316
+#: src/store.c:4322
 #, c-format
 msgid "missing store name for store migrate\n"
 msgstr ""
 
-#: src/store.c:4326
+#: src/store.c:4332
 #, c-format
 msgid "store migrate requires --to-format v2\n"
 msgstr ""
 
-#: src/store.c:4356
+#: src/store.c:4362
 #, c-format
 msgid "invalid migration source format: %s\n"
 msgstr ""
 
-#: src/store.c:4367 src/store.c:4379
+#: src/store.c:4373 src/store.c:4385
 #, c-format
 msgid "invalid arguments for store finalize-migration\n"
 msgstr ""
 
-#: src/store.c:4374
+#: src/store.c:4380
 #, c-format
 msgid "missing store name for store finalize-migration\n"
 msgstr ""
 
-#: src/store.c:4384
+#: src/store.c:4390
 #, c-format
 msgid "store finalize-migration requires --from-format v1\n"
 msgstr ""
 
-#: src/store.c:4410 src/store.c:4421 src/store.c:4431
+#: src/store.c:4416 src/store.c:4427 src/store.c:4437
 #, c-format
 msgid "invalid arguments for store ls\n"
 msgstr ""
 
-#: src/store.c:4609
+#: src/store.c:4615
 #, c-format
 msgid "secret value is too large\n"
 msgstr ""
 
-#: src/store.c:4636 src/store.c:4649
+#: src/store.c:4642 src/store.c:4655
 #, c-format
 msgid "invalid overlay payload\n"
 msgstr ""
 
-#: src/store.c:4949 src/store.c:30873
+#: src/store.c:4955 src/store.c:30908
 #, c-format
 msgid "invalid key visibility: %s\n"
 msgstr ""
 
-#: src/store.c:4963
+#: src/store.c:4969
 #, c-format
 msgid "invalid value access: %s\n"
 msgstr ""
 
-#: src/store.c:5021
+#: src/store.c:5027
 #, c-format
 msgid "invalid bulk select policy: %s; use %s\n"
 msgstr ""
 
-#: src/store.c:5024 src/store.c:5033
+#: src/store.c:5030 src/store.c:5039
 #, c-format
 msgid "invalid bulk select policy: %s\n"
 msgstr ""
 
-#: src/store.c:5065
+#: src/store.c:5071
 #, c-format
 msgid ""
 "key_visibility=unlocked requires store format v2; run store migrate STORE --"
 "to-format v2 --dry-run first\n"
 msgstr ""
 
-#: src/store.c:5096 src/store.c:5135
+#: src/store.c:5102 src/store.c:5141
 #, c-format
 msgid "invalid secret metadata\n"
 msgstr ""
 
-#: src/store.c:5113
+#: src/store.c:5119
 #, c-format
 msgid "unsupported secret metadata field: %s\n"
 msgstr ""
 
-#: src/store.c:5149
+#: src/store.c:5155
 #, c-format
 msgid "unsupported secret metadata format\n"
 msgstr ""
 
-#: src/store.c:5243 src/store.c:31231 src/store.c:37788
+#: src/store.c:5249 src/store.c:31266 src/store.c:37823
 #, c-format
 msgid "secret value_access does not match storage mode\n"
 msgstr ""
 
-#: src/store.c:5260 src/store.c:30930 src/store.c:31007 src/store.c:31019
-#: src/store.c:31376
+#: src/store.c:5266 src/store.c:30965 src/store.c:31042 src/store.c:31054
+#: src/store.c:31411
 #, c-format
 msgid "secret metadata is too large\n"
 msgstr ""
 
-#: src/store.c:5332 src/store.c:5339
+#: src/store.c:5338 src/store.c:5345
 #, c-format
 msgid "failed to create directory: %s\n"
 msgstr ""
 
-#: src/store.c:5513 src/store.c:19530
+#: src/store.c:5519 src/store.c:19536
 #, c-format
 msgid "invalid path: %s\n"
 msgstr ""
 
-#: src/store.c:5528
+#: src/store.c:5534
 #, c-format
 msgid "failed to create temporary file for: %s\n"
 msgstr ""
 
-#: src/store.c:5533
+#: src/store.c:5539
 #, c-format
 msgid "failed to set permissions on: %s\n"
 msgstr ""
 
-#: src/store.c:5543
+#: src/store.c:5549
 #, c-format
 msgid "failed to write file: %s\n"
 msgstr ""
 
-#: src/store.c:5552
+#: src/store.c:5558
 #, c-format
 msgid "failed to fsync file: %s\n"
 msgstr ""
 
-#: src/store.c:5559 src/store.c:19997
+#: src/store.c:5565 src/store.c:20003
 #, c-format
 msgid "failed to close file: %s\n"
 msgstr ""
 
-#: src/store.c:5565
+#: src/store.c:5571
 #, c-format
 msgid "failed to rename file into place: %s\n"
 msgstr ""
 
-#: src/store.c:5618 src/store.c:5631
+#: src/store.c:5624 src/store.c:5637
 #, c-format
 msgid "failed to seek file: %s\n"
 msgstr ""
 
-#: src/store.c:5625
+#: src/store.c:5631
 #, c-format
 msgid "failed to determine file size: %s\n"
 msgstr ""
 
-#: src/store.c:5744 src/store.c:12146
+#: src/store.c:5750 src/store.c:12152
 #, c-format
 msgid "failed to derive encryption key\n"
 msgstr ""
 
-#: src/store.c:5827
+#: src/store.c:5833
 #, c-format
 msgid "%s must be an integer between %u and %u\n"
 msgstr ""
 
-#: src/store.c:6424 src/store.c:6437 src/store.c:7948 src/store.c:7954
-#: src/store.c:7964 src/store.c:8012
+#: src/store.c:6430 src/store.c:6443 src/store.c:7954 src/store.c:7960
+#: src/store.c:7970 src/store.c:8018
 #, c-format
 msgid "failed to start session agent\n"
 msgstr ""
 
-#: src/store.c:6442 src/store.c:8019
+#: src/store.c:6448 src/store.c:8025
 #, c-format
 msgid "timed out waiting for session agent readiness\n"
 msgstr ""
 
-#: src/store.c:6869
+#: src/store.c:6875
 #, c-format
 msgid "failed to open file descriptor\n"
 msgstr ""
 
-#: src/store.c:7858
+#: src/store.c:7864
 #, c-format
 msgid "failed to bind session agent socket\n"
 msgstr ""
 
-#: src/store.c:7881
+#: src/store.c:7887
 #, c-format
 msgid "failed to listen on session agent socket\n"
 msgstr ""
 
-#: src/store.c:8027
+#: src/store.c:8033
 #, c-format
 msgid "session agent failed before readiness\n"
 msgstr ""
 
-#: src/store.c:8065
+#: src/store.c:8071
 #, c-format
 msgid "empty passphrase is not allowed\n"
 msgstr ""
 
-#: src/store.c:8082
+#: src/store.c:8088
 #, c-format
 msgid "missing askpass provider\n"
 msgstr ""
 
-#: src/store.c:8087
+#: src/store.c:8093
 #, c-format
 msgid "missing askpass provider: %s\n"
 msgstr ""
 
-#: src/store.c:8089
+#: src/store.c:8095
 #, c-format
 msgid "unsupported askpass provider: %s\n"
 msgstr ""
 
-#: src/store.c:8095 src/store.c:8103
+#: src/store.c:8101 src/store.c:8109
 #, c-format
 msgid "failed to start askpass command\n"
 msgstr ""
 
-#: src/store.c:8153
+#: src/store.c:8159
 #, c-format
 msgid "failed to read askpass output\n"
 msgstr ""
 
-#: src/store.c:8160
+#: src/store.c:8166
 #, c-format
 msgid "askpass prompt cancelled\n"
 msgstr ""
 
-#: src/store.c:8165
+#: src/store.c:8171
 #, c-format
 msgid "askpass output is too long\n"
 msgstr ""
 
-#: src/store.c:8192
+#: src/store.c:8198
 #, c-format
 msgid ""
 "missing askpass provider; --gui requires --askpass, SECDAT_ASKPASS, or "
 "SSH_ASKPASS\n"
 msgstr ""
 
-#: src/store.c:8195
+#: src/store.c:8201
 #, c-format
 msgid ""
 "missing askpass provider; this command requires a terminal for passphrase "
 "input\n"
 msgstr ""
 
-#: src/store.c:8203
+#: src/store.c:8209
 #, c-format
 msgid "failed to read terminal settings\n"
 msgstr ""
 
-#: src/store.c:8210 src/store.c:8226
+#: src/store.c:8216 src/store.c:8232
 #, c-format
 msgid "failed to update terminal settings\n"
 msgstr ""
 
-#: src/store.c:8216
+#: src/store.c:8222
 #, c-format
 msgid "failed to read passphrase\n"
 msgstr ""
 
-#: src/store.c:8247
+#: src/store.c:8253
 msgid "Create secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8250
+#: src/store.c:8256
 msgid "Confirm secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8257 src/store.c:8285
+#: src/store.c:8263 src/store.c:8291
 #, c-format
 msgid "passphrase confirmation did not match\n"
 msgstr ""
 
-#: src/store.c:8313
+#: src/store.c:8319
 msgid "Enter secdat passphrase: "
 msgstr ""
 
-#: src/store.c:8346 src/store.c:8373
+#: src/store.c:8352 src/store.c:8379
 #, c-format
 msgid "failed to create session agent socket\n"
 msgstr ""
 
-#: src/store.c:8383
+#: src/store.c:8389
 #, c-format
 msgid "failed to connect to session agent\n"
 msgstr ""
 
-#: src/store.c:8765
+#: src/store.c:8771
 #, c-format
 msgid "failed to hand over the active session agent safely\n"
 msgstr ""
 
-#: src/store.c:8884 src/store.c:8897 src/store.c:8921
+#: src/store.c:8890 src/store.c:8903 src/store.c:8927
 #, c-format
 msgid "invalid response from the active session agent\n"
 msgstr ""
 
-#: src/store.c:8930 src/store.c:9274 src/store.c:9588
+#: src/store.c:8936 src/store.c:9280 src/store.c:9594
 #, c-format
 msgid "failed to negotiate capabilities with the active session agent\n"
 msgstr ""
 
-#: src/store.c:9058 src/store.c:9062
+#: src/store.c:9064 src/store.c:9068
 #, c-format
 msgid ""
 "failed to purge session-local ephemeral values from an active session agent\n"
 msgstr ""
 
-#: src/store.c:9280 src/store.c:9594
+#: src/store.c:9286 src/store.c:9600
 #, c-format
 msgid "the active session agent cannot expose its volatile overlay safely\n"
 msgstr ""
 
-#: src/store.c:9303 src/store.c:9318 src/store.c:9617 src/store.c:9632
+#: src/store.c:9309 src/store.c:9324 src/store.c:9623 src/store.c:9638
 #, c-format
 msgid "legacy volatile session cannot be read safely by this secdat version\n"
 msgstr ""
 
-#: src/store.c:9306 src/store.c:9620
+#: src/store.c:9312 src/store.c:9626
 #, c-format
 msgid "the active session agent did not complete the overlay protocol\n"
 msgstr ""
 
-#: src/store.c:9422 src/store.c:11470 src/store.c:11537 src/store.c:37880
+#: src/store.c:9428 src/store.c:11476 src/store.c:11543 src/store.c:37915
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use set --ephemeral to update it: "
 "%s\n"
 msgstr ""
 
-#: src/store.c:9472 src/store.c:37845
+#: src/store.c:9478 src/store.c:37880
 #, c-format
 msgid ""
 "key has a volatile session change and cannot be replaced by an ephemeral "
 "secret: %s\n"
 msgstr ""
 
-#: src/store.c:9514 src/store.c:9553 src/store.c:38821
+#: src/store.c:9520 src/store.c:9559 src/store.c:38856
 #, c-format
 msgid ""
 "key is ephemeral in the current session; use rm --ephemeral to remove it: "
 "%s\n"
 msgstr ""
 
-#: src/store.c:9903
+#: src/store.c:9909
 #, c-format
 msgid ""
 "per-key ephemeral secrets require an active secdat session agent; run secdat "
 "unlock first\n"
 msgstr ""
 
-#: src/store.c:9909
+#: src/store.c:9915
 #, c-format
 msgid "current session is readonly and cannot store an ephemeral secret\n"
 msgstr ""
 
-#: src/store.c:10039
+#: src/store.c:10045
 #, c-format
 msgid "unlock writable session: secdat unlock\n"
 msgstr ""
 
-#: src/store.c:10041
+#: src/store.c:10047
 #, c-format
 msgid "unlock writable session: secdat --dir %s unlock\n"
 msgstr ""
 
-#: src/store.c:10050
+#: src/store.c:10056
 #, c-format
 msgid "current session is readonly and cannot run %s\n"
 msgstr ""
 
-#: src/store.c:10112 src/store.c:38787 src/store.c:38933 src/store.c:40990
+#: src/store.c:10118 src/store.c:38822 src/store.c:38968 src/store.c:41025
 #, c-format
 msgid "failed to remove key: %s\n"
 msgstr ""
 
-#: src/store.c:10128 src/store.c:10133
+#: src/store.c:10134 src/store.c:10139
 #, c-format
 msgid "lock --save requires a local volatile session\n"
 msgstr ""
 
-#: src/store.c:10213
+#: src/store.c:10219
 #, c-format
 msgid "invalid wrap key iteration count\n"
 msgstr ""
 
-#: src/store.c:10217
+#: src/store.c:10223
 #, c-format
 msgid "failed to derive wrap key\n"
 msgstr ""
 
-#: src/store.c:10234 src/store.c:10277 src/store.c:11793 src/store.c:13233
-#: src/store.c:13458 src/store.c:30716
+#: src/store.c:10240 src/store.c:10283 src/store.c:11799 src/store.c:13239
+#: src/store.c:13464 src/store.c:30751
 #, c-format
 msgid "failed to generate nonce\n"
 msgstr ""
 
-#: src/store.c:10303 src/store.c:11819 src/store.c:13255 src/store.c:13480
+#: src/store.c:10309 src/store.c:11825 src/store.c:13261 src/store.c:13486
 #, c-format
 msgid "failed to create encryption context\n"
 msgstr ""
 
-#: src/store.c:10309 src/store.c:11825 src/store.c:13262 src/store.c:13486
+#: src/store.c:10315 src/store.c:11831 src/store.c:13268 src/store.c:13492
 #, c-format
 msgid "failed to initialize encryption\n"
 msgstr ""
 
-#: src/store.c:10319 src/store.c:11839 src/store.c:13273 src/store.c:13490
-#: src/store.c:13500
+#: src/store.c:10325 src/store.c:11845 src/store.c:13279 src/store.c:13496
+#: src/store.c:13506
 #, c-format
 msgid "failed to encrypt value\n"
 msgstr ""
 
-#: src/store.c:10327 src/store.c:11847 src/store.c:13278 src/store.c:13504
+#: src/store.c:10333 src/store.c:11853 src/store.c:13284 src/store.c:13510
 #, c-format
 msgid "failed to finalize encryption\n"
 msgstr ""
 
-#: src/store.c:10332 src/store.c:11852 src/store.c:13284 src/store.c:13509
+#: src/store.c:10338 src/store.c:11858 src/store.c:13290 src/store.c:13515
 #, c-format
 msgid "failed to obtain authentication tag\n"
 msgstr ""
 
-#: src/store.c:10374 src/store.c:10382 src/store.c:12066
+#: src/store.c:10380 src/store.c:10388 src/store.c:12072
 #, c-format
 msgid "invalid wrapped master key\n"
 msgstr ""
 
-#: src/store.c:10466 src/store.c:11891 src/store.c:11902 src/store.c:45962
-#: src/store.c:45993 src/store.c:46013 src/store.c:46036 src/store.c:46204
-#: src/store.c:46212 src/store.c:46234 src/store.c:46250
+#: src/store.c:10472 src/store.c:11897 src/store.c:11908 src/store.c:46049
+#: src/store.c:46080 src/store.c:46100 src/store.c:46123 src/store.c:46291
+#: src/store.c:46299 src/store.c:46321 src/store.c:46337
 #, c-format
 msgid "invalid secret bundle\n"
 msgstr ""
 
-#: src/store.c:10518
+#: src/store.c:10524
 #, c-format
 msgid "secret bundle has too many objects\n"
 msgstr ""
 
-#: src/store.c:10628 src/store.c:10779 src/store.c:14576 src/store.c:14772
-#: src/store.c:18176 src/store.c:18225 src/store.c:35358 src/store.c:35540
-#: src/store.c:37414 src/store.c:38876 src/store.c:38899 src/store.c:38953
-#: src/store.c:39224 src/store.c:39778 src/store.c:39810 src/store.c:41110
-#: src/store.c:42797
+#: src/store.c:10634 src/store.c:10785 src/store.c:14582 src/store.c:14778
+#: src/store.c:18182 src/store.c:18231 src/store.c:35393 src/store.c:35575
+#: src/store.c:37449 src/store.c:38911 src/store.c:38934 src/store.c:38988
+#: src/store.c:39259 src/store.c:39813 src/store.c:39845 src/store.c:41145
+#: src/store.c:42875
 #, c-format
 msgid "key not found: %s\n"
 msgstr ""
 
-#: src/store.c:10686
+#: src/store.c:10692
 #, c-format
 msgid "secret bundle entry is too large\n"
 msgstr ""
 
-#: src/store.c:10696
+#: src/store.c:10702
 #, c-format
 msgid "secret bundle value is unavailable for a selected v2 object\n"
 msgstr ""
 
-#: src/store.c:10786
+#: src/store.c:10792
 #, c-format
 msgid "save is not supported while an ephemeral secret is visible: %s\n"
 msgstr ""
 
-#: src/store.c:11785
+#: src/store.c:11791
 #, c-format
 msgid "bundle file already exists: %s\n"
 msgstr ""
 
-#: src/store.c:11789
+#: src/store.c:11795
 #, c-format
 msgid "secret bundle is too large\n"
 msgstr ""
 
-#: src/store.c:11829
+#: src/store.c:11835
 #, c-format
 msgid "failed to encrypt bundle metadata\n"
 msgstr ""
 
-#: src/store.c:11958 src/store.c:12032 src/store.c:13394 src/store.c:13588
+#: src/store.c:11964 src/store.c:12038 src/store.c:13400 src/store.c:13594
 #, c-format
 msgid "failed to create decryption context\n"
 msgstr ""
 
-#: src/store.c:11964 src/store.c:12038 src/store.c:13401 src/store.c:13594
+#: src/store.c:11970 src/store.c:12044 src/store.c:13407 src/store.c:13600
 #, c-format
 msgid "failed to initialize decryption\n"
 msgstr ""
 
-#: src/store.c:11968
+#: src/store.c:11974
 #, c-format
 msgid "failed to decrypt bundle metadata\n"
 msgstr ""
 
-#: src/store.c:11972 src/store.c:12048 src/store.c:13406 src/store.c:13598
-#: src/store.c:13602
+#: src/store.c:11978 src/store.c:12054 src/store.c:13412 src/store.c:13604
+#: src/store.c:13608
 #, c-format
 msgid "failed to decrypt value\n"
 msgstr ""
 
-#: src/store.c:11976 src/store.c:12057 src/store.c:13411 src/store.c:13606
+#: src/store.c:11982 src/store.c:12063 src/store.c:13417 src/store.c:13612
 #, c-format
 msgid "failed to set authentication tag\n"
 msgstr ""
 
-#: src/store.c:11980
+#: src/store.c:11986
 #, c-format
 msgid "failed to unlock secret bundle\n"
 msgstr ""
 
-#: src/store.c:12061
+#: src/store.c:12067
 #, c-format
 msgid "failed to unlock persistent master key\n"
 msgstr ""
 
-#: src/store.c:12137 src/store.c:19086 src/store.c:41099
+#: src/store.c:12143 src/store.c:19092 src/store.c:41134
 #, c-format
 msgid ""
 "missing SECDAT_MASTER_KEY and no active secdat session; run secdat unlock or "
 "export SECDAT_MASTER_KEY\n"
 msgstr ""
 
-#: src/store.c:12309 src/store.c:12313 src/store.c:12336
+#: src/store.c:12315 src/store.c:12319 src/store.c:12342
 #, c-format
 msgid "no local lock for: %s\n"
 msgstr ""
 
-#: src/store.c:12323
+#: src/store.c:12329
 #, c-format
 msgid "refusing to remove local lock for: %s\n"
 msgstr ""
 
-#: src/store.c:12324 src/store.c:12372
+#: src/store.c:12330 src/store.c:12378
 #, c-format
 msgid "expected resulting state: %s\n"
 msgstr ""
 
-#: src/store.c:12326
+#: src/store.c:12332
 #, c-format
 msgid "actual resulting state after removing local lock: %s\n"
 msgstr ""
 
-#: src/store.c:12341
+#: src/store.c:12347
 msgid "local lock removed; resulting state: unlocked"
 msgstr ""
 
-#: src/store.c:12343
+#: src/store.c:12349
 msgid "local lock removed; resulting state: locked"
 msgstr ""
 
-#: src/store.c:12345
+#: src/store.c:12351
 msgid "local lock removed"
 msgstr ""
 
-#: src/store.c:12361 src/store.c:12407
+#: src/store.c:12367 src/store.c:12413
 #, c-format
 msgid "no local lock or local unlock for: %s\n"
 msgstr ""
 
-#: src/store.c:12371
+#: src/store.c:12377
 #, c-format
 msgid "refusing to clear local unlock for: %s\n"
 msgstr ""
 
-#: src/store.c:12374
+#: src/store.c:12380
 #, c-format
 msgid "actual resulting state after clearing local unlock: %s\n"
 msgstr ""
 
-#: src/store.c:12385
+#: src/store.c:12391
 msgid "local unlock cleared; resulting state: unlocked"
 msgstr ""
 
-#: src/store.c:12387
+#: src/store.c:12393
 msgid "local unlock cleared; resulting state: locked"
 msgstr ""
 
-#: src/store.c:12389
+#: src/store.c:12395
 msgid "local unlock cleared"
 msgstr ""
 
-#: src/store.c:12644 src/store.c:12651 src/store.c:12657 src/store.c:12663
+#: src/store.c:12650 src/store.c:12657 src/store.c:12663 src/store.c:12669
 #, c-format
 msgid "invalid arguments for status\n"
 msgstr ""
 
-#: src/store.c:12675
+#: src/store.c:12681
 msgid "source: environment"
 msgstr ""
 
-#: src/store.c:12685
+#: src/store.c:12691
 msgid "source: session agent"
 msgstr ""
 
-#: src/store.c:12687
+#: src/store.c:12693
 msgid "overlay: volatile"
 msgstr ""
 
-#: src/store.c:12690
+#: src/store.c:12696
 msgid "access: readonly"
 msgstr ""
 
-#: src/store.c:12693
+#: src/store.c:12699
 #, c-format
 msgid "expires in: %s\n"
 msgstr ""
 
-#: src/store.c:12813
+#: src/store.c:12819
 #, c-format
 msgid "this will unlock %zu descendant domains in the current subtree\n"
 msgstr ""
 
-#: src/store.c:12814
+#: src/store.c:12820
 #, c-format
 msgid "local locks will remain after local unlock expiry or a later lock\n"
 msgstr ""
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "volatile session refreshed"
 msgstr ""
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "readonly session refreshed"
 msgstr ""
 
-#: src/store.c:12848
+#: src/store.c:12854
 msgid "session refreshed"
 msgstr ""
 
-#: src/store.c:12929
+#: src/store.c:12935
 msgid "readonly session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12930 src/store.c:13022
+#: src/store.c:12936 src/store.c:13028
 msgid "readonly session unlocked"
 msgstr ""
 
-#: src/store.c:12932 src/store.c:12968
+#: src/store.c:12938 src/store.c:12974
 msgid "volatile session unlocked with an ephemeral master key"
 msgstr ""
 
-#: src/store.c:12935
+#: src/store.c:12941
 msgid "volatile session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12936 src/store.c:13022
+#: src/store.c:12942 src/store.c:13028
 msgid "volatile session unlocked"
 msgstr ""
 
-#: src/store.c:12939
+#: src/store.c:12945
 msgid "persistent master key initialized; session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12940
+#: src/store.c:12946
 msgid "persistent master key initialized; session unlocked"
 msgstr ""
 
-#: src/store.c:12942
+#: src/store.c:12948
 msgid "session unlocked from environment"
 msgstr ""
 
-#: src/store.c:12975
+#: src/store.c:12981
 #, c-format
 msgid ""
 "no persistent master key is initialized; readonly unlock requires an "
 "existing master key\n"
 msgstr ""
 
-#: src/store.c:12980 src/store.c:13170
+#: src/store.c:12986 src/store.c:13176
 #, c-format
 msgid ""
 "no persistent master key is initialized; run secdat unlock once to create "
 "one\n"
 msgstr ""
 
-#: src/store.c:13022
+#: src/store.c:13028
 msgid "session unlocked"
 msgstr ""
 
-#: src/store.c:13075
+#: src/store.c:13081
 msgid "already locked"
 msgstr ""
 
-#: src/store.c:13102
+#: src/store.c:13108
 msgid "volatile session saved and locked"
 msgstr ""
 
-#: src/store.c:13102
+#: src/store.c:13108
 msgid "session locked"
 msgstr ""
 
-#: src/store.c:13135
+#: src/store.c:13141
 #, c-format
 msgid "invalid arguments for inherit\n"
 msgstr ""
 
-#: src/store.c:13182
+#: src/store.c:13188
 msgid "Create new secdat passphrase: "
 msgstr ""
 
-#: src/store.c:13183
+#: src/store.c:13189
 msgid "Confirm new secdat passphrase: "
 msgstr ""
 
-#: src/store.c:13199
+#: src/store.c:13205
 msgid "persistent master key passphrase updated"
 msgstr ""
 
-#: src/store.c:13329 src/store.c:13347 src/store.c:13352 src/store.c:13358
-#: src/store.c:13373 src/store.c:13559 src/store.c:13566 src/store.c:13571
-#: src/store.c:14628 src/store.c:14712
+#: src/store.c:13335 src/store.c:13353 src/store.c:13358 src/store.c:13364
+#: src/store.c:13379 src/store.c:13565 src/store.c:13572 src/store.c:13577
+#: src/store.c:14634 src/store.c:14718
 #, c-format
 msgid "invalid encrypted entry\n"
 msgstr ""
 
-#: src/store.c:13334 src/store.c:14635 src/store.c:14716
+#: src/store.c:13340 src/store.c:14641 src/store.c:14722
 #, c-format
 msgid "unsupported encrypted entry format\n"
 msgstr ""
 
-#: src/store.c:13340 src/store.c:14639 src/store.c:14720
+#: src/store.c:13346 src/store.c:14645 src/store.c:14726
 #, c-format
 msgid "unsupported encryption algorithm\n"
 msgstr ""
 
-#: src/store.c:13417 src/store.c:13610
+#: src/store.c:13423 src/store.c:13616
 #, c-format
 msgid "failed to authenticate encrypted value\n"
 msgstr ""
 
-#: src/store.c:13776 src/store.c:14653 src/store.c:14659 src/store.c:18988
-#: src/store.c:19005 src/store.c:19059 src/store.c:19070 src/store.c:29420
-#: src/store.c:30039 src/store.c:30201 src/store.c:30783 src/store.c:30793
-#: src/store.c:31103 src/store.c:31139 src/store.c:31265 src/store.c:40807
-#: src/store.c:40830 src/store.c:42928
+#: src/store.c:13782 src/store.c:14659 src/store.c:14665 src/store.c:18994
+#: src/store.c:19011 src/store.c:19065 src/store.c:19076 src/store.c:29455
+#: src/store.c:30074 src/store.c:30236 src/store.c:30818 src/store.c:30828
+#: src/store.c:31138 src/store.c:31174 src/store.c:31300 src/store.c:40842
+#: src/store.c:40865 src/store.c:43006
 #, c-format
 msgid "invalid v2 domain entry: %s\n"
 msgstr ""
 
-#: src/store.c:13814
+#: src/store.c:13820
 #, c-format
 msgid "failed to read standard input\n"
 msgstr ""
 
-#: src/store.c:14041 src/store.c:14264 src/store.c:14434 src/store.c:30093
-#: src/store.c:30340 src/store.c:34056 src/store.c:34161 src/store.c:34491
-#: src/store.c:37479 src/store.c:37767 src/store.c:38576 src/store.c:38675
-#: src/store.c:38919 src/store.c:41090 src/store.c:43568 src/store.c:43714
-#: src/store.c:44126 src/store.c:44746 src/store.c:45470 src/store.c:46046
+#: src/store.c:14047 src/store.c:14270 src/store.c:14440 src/store.c:30128
+#: src/store.c:30375 src/store.c:34091 src/store.c:34196 src/store.c:34526
+#: src/store.c:37514 src/store.c:37802 src/store.c:38611 src/store.c:38710
+#: src/store.c:38954 src/store.c:41125 src/store.c:43655 src/store.c:43801
+#: src/store.c:44213 src/store.c:44833 src/store.c:45557 src/store.c:46133
 #, c-format
 msgid "invalid store format marker\n"
 msgstr ""
 
-#: src/store.c:14164
+#: src/store.c:14170
 #, c-format
 msgid "Key candidates:\n"
 msgstr ""
 
-#: src/store.c:14187
+#: src/store.c:14193
 #, c-format
 msgid ""
 "Hint: use %s get KEY for an explicit key lookup, or %s help COMMAND for "
 "command help\n"
 msgstr ""
 
-#: src/store.c:14199
+#: src/store.c:14205
 #, c-format
 msgid ""
 "Hint: check secdat status, --dir, and --store to confirm the lookup context\n"
 msgstr ""
 
-#: src/store.c:14608 src/store.c:30681 src/store.c:31109 src/store.c:31113
-#: src/store.c:31253 src/store.c:38723 src/store.c:38730 src/store.c:40813
+#: src/store.c:14614 src/store.c:30716 src/store.c:31144 src/store.c:31148
+#: src/store.c:31288 src/store.c:38758 src/store.c:38765 src/store.c:40848
 #, c-format
 msgid "invalid v2 secret object: %s\n"
 msgstr ""
 
-#: src/store.c:14616
+#: src/store.c:14622
 #, c-format
 msgid "v2 secret value storage is not implemented yet\n"
 msgstr ""
 
-#: src/store.c:15874 src/store.c:38050
+#: src/store.c:15880 src/store.c:38085
 #, c-format
 msgid "failed to generate random bytes\n"
 msgstr ""
 
-#: src/store.c:15966
+#: src/store.c:15972
 #, c-format
 msgid "failed to calculate GC candidate handle\n"
 msgstr ""
 
-#: src/store.c:16648
+#: src/store.c:16654
 #, c-format
 msgid "failed to read the GC scheduling clock\n"
 msgstr ""
 
-#: src/store.c:16902
+#: src/store.c:16908
 #, c-format
 msgid "invalid deferred GC topology effect\n"
 msgstr ""
 
-#: src/store.c:17048
+#: src/store.c:17054
 #, c-format
 msgid "secret reference count is too large\n"
 msgstr ""
 
-#: src/store.c:17595 src/store.c:17608
+#: src/store.c:17601 src/store.c:17614
 #, c-format
 msgid "metadata is too large\n"
 msgstr ""
 
-#: src/store.c:17687 src/store.c:17730 src/store.c:17779 src/store.c:35564
-#: src/store.c:35684 src/store.c:36940
+#: src/store.c:17693 src/store.c:17736 src/store.c:17785 src/store.c:35599
+#: src/store.c:35719 src/store.c:36975
 #, c-format
 msgid "invalid metadata field: %s\n"
 msgstr ""
 
-#: src/store.c:17768
+#: src/store.c:17774
 #, c-format
 msgid "invalid metadata filter: %s\n"
 msgstr ""
 
-#: src/store.c:17910 src/store.c:17939 src/store.c:17950
+#: src/store.c:17916 src/store.c:17945 src/store.c:17956
 #, c-format
 msgid "invalid key metadata\n"
 msgstr ""
 
-#: src/store.c:17925
+#: src/store.c:17931
 #, c-format
 msgid "unsupported key metadata format\n"
 msgstr ""
 
-#: src/store.c:18070 src/store.c:18143
+#: src/store.c:18076 src/store.c:18149
 #, c-format
 msgid "invalid relation member role: %s\n"
 msgstr ""
 
-#: src/store.c:18076
+#: src/store.c:18082
 #, c-format
 msgid "invalid relation member key reference\n"
 msgstr ""
 
-#: src/store.c:18083
+#: src/store.c:18089
 #, c-format
 msgid "duplicate relation member role: %s\n"
 msgstr ""
 
-#: src/store.c:18128
+#: src/store.c:18134
 #, c-format
 msgid "invalid relation member: %s\n"
 msgstr ""
 
-#: src/store.c:18253 src/store.c:35843
+#: src/store.c:18259 src/store.c:35878
 #, c-format
 msgid "relation not found: %s\n"
 msgstr ""
 
-#: src/store.c:18262 src/store.c:18290 src/store.c:18447
+#: src/store.c:18268 src/store.c:18296 src/store.c:18453
 #, c-format
 msgid "invalid relation metadata\n"
 msgstr ""
 
-#: src/store.c:18276
+#: src/store.c:18282
 #, c-format
 msgid "unsupported relation metadata format\n"
 msgstr ""
 
-#: src/store.c:18503
+#: src/store.c:18509
 #, c-format
 msgid "key_visibility=unlocked cannot be used while key metadata exists: %s\n"
 msgstr ""
 
-#: src/store.c:18525
+#: src/store.c:18531
 #, c-format
 msgid ""
 "key_visibility=unlocked cannot be used while relation references key: %s "
 "(%s)\n"
 msgstr ""
 
-#: src/store.c:19483
+#: src/store.c:19489
 #, c-format
 msgid "failed to calculate transaction digest\n"
 msgstr ""
 
-#: src/store.c:19505
+#: src/store.c:19511
 #, c-format
 msgid "failed to open directory for fsync: %s\n"
 msgstr ""
 
-#: src/store.c:19509
+#: src/store.c:19515
 #, c-format
 msgid "failed to fsync directory: %s\n"
 msgstr ""
 
-#: src/store.c:19514
+#: src/store.c:19520
 #, c-format
 msgid "failed to close directory: %s\n"
 msgstr ""
 
-#: src/store.c:19554
+#: src/store.c:19560
 #, c-format
 msgid "invalid transaction directory: %s\n"
 msgstr ""
 
-#: src/store.c:19592
+#: src/store.c:19598
 #, c-format
 msgid "invalid transaction lock\n"
 msgstr ""
 
-#: src/store.c:19609 src/store.c:19626
+#: src/store.c:19615 src/store.c:19632
 #, c-format
 msgid "failed to lock transactions\n"
 msgstr ""
 
-#: src/store.c:19955
+#: src/store.c:19961
 #, c-format
 msgid "failed to inspect transaction target: %s\n"
 msgstr ""
 
-#: src/store.c:19964
+#: src/store.c:19970
 #, c-format
 msgid "invalid transaction target: %s\n"
 msgstr ""
 
-#: src/store.c:20734
+#: src/store.c:20740
 #, c-format
 msgid "container tree does not match schema: %s\n"
 msgstr ""
 
-#: src/store.c:21280 src/store.c:21286 src/store.c:21407
+#: src/store.c:21286 src/store.c:21292 src/store.c:21413
 #, c-format
 msgid "failed to inspect typed directory: %s\n"
 msgstr ""
 
-#: src/store.c:21307
+#: src/store.c:21313
 #, c-format
 msgid "invalid typed directory: %s\n"
 msgstr ""
 
-#: src/store.c:21703 src/store.c:21794
+#: src/store.c:21709 src/store.c:21800
 #, c-format
 msgid "invalid transaction target directory\n"
 msgstr ""
 
-#: src/store.c:21823 src/store.c:21833 src/store.c:21911
+#: src/store.c:21829 src/store.c:21839 src/store.c:21917
 #, c-format
 msgid "failed to read transaction target\n"
 msgstr ""
 
-#: src/store.c:22279 src/store.c:22470 src/store.c:22481
+#: src/store.c:22285 src/store.c:22476 src/store.c:22487
 #, c-format
 msgid "transaction data is too large\n"
 msgstr ""
 
-#: src/store.c:22343
+#: src/store.c:22349
 #, c-format
 msgid "transaction has too many targets\n"
 msgstr ""
 
-#: src/store.c:22355
+#: src/store.c:22361
 #, c-format
 msgid "invalid transaction validation target\n"
 msgstr ""
 
-#: src/store.c:22401 src/store.c:22837
+#: src/store.c:22407 src/store.c:22843
 #, c-format
 msgid "transaction changed since plan\n"
 msgstr ""
 
-#: src/store.c:22424 src/store.c:22882
+#: src/store.c:22430 src/store.c:22888
 #, c-format
 msgid "duplicate transaction target\n"
 msgstr ""
 
-#: src/store.c:22868
+#: src/store.c:22874
 #, c-format
 msgid "typed directory guards require transaction manifest v2\n"
 msgstr ""
 
-#: src/store.c:22933
+#: src/store.c:22939
 #, c-format
 msgid "prepared guard is outside the state directory\n"
 msgstr ""
 
-#: src/store.c:22955
+#: src/store.c:22961
 #, c-format
 msgid "prepared write is outside the state directory\n"
 msgstr ""
 
-#: src/store.c:23058
+#: src/store.c:23089
 #, c-format
 msgid "invalid move source removal target\n"
 msgstr ""
 
-#: src/store.c:23230
+#: src/store.c:23261
 #, c-format
 msgid "invalid transaction blob: %s\n"
 msgstr ""
 
-#: src/store.c:24032
+#: src/store.c:24063
 #, c-format
 msgid "invalid transaction journal: %s\n"
 msgstr ""
 
-#: src/store.c:24099 src/store.c:24140
+#: src/store.c:24130 src/store.c:24171
 #, c-format
 msgid "failed to open transaction directory: %s\n"
 msgstr ""
 
-#: src/store.c:24115
+#: src/store.c:24146
 #, c-format
 msgid "unexpected transaction file: %s\n"
 msgstr ""
 
-#: src/store.c:24123
+#: src/store.c:24154
 #, c-format
 msgid "failed to close transaction directory\n"
 msgstr ""
 
-#: src/store.c:24166
+#: src/store.c:24197
 #, c-format
 msgid "invalid transaction temporary file: %s\n"
 msgstr ""
 
-#: src/store.c:24275
+#: src/store.c:24306
 #, c-format
 msgid "failed to remove completed transaction: %s\n"
 msgstr ""
 
-#: src/store.c:24329 src/store.c:24341 src/store.c:24346 src/store.c:24352
-#: src/store.c:24448
+#: src/store.c:24360 src/store.c:24372 src/store.c:24377 src/store.c:24383
+#: src/store.c:24479
 #, c-format
 msgid "failed to apply transaction target\n"
 msgstr ""
 
-#: src/store.c:24504
+#: src/store.c:24535
 #, c-format
 msgid "transaction target changed during recovery: %s\n"
 msgstr ""
 
-#: src/store.c:24540
+#: src/store.c:24571
 #, c-format
 msgid "committed transaction target is inconsistent: %s\n"
 msgstr ""
 
-#: src/store.c:24595
+#: src/store.c:24626
 #, c-format
 msgid "invalid unpublished transaction: %s\n"
 msgstr ""
 
-#: src/store.c:24619
+#: src/store.c:24650
 #, c-format
 msgid "failed to open transactions directory\n"
 msgstr ""
 
-#: src/store.c:24631
+#: src/store.c:24662
 #, c-format
 msgid "invalid transaction entry: %s\n"
 msgstr ""
 
-#: src/store.c:24715
+#: src/store.c:24746
 #, c-format
 msgid "failed to inspect transactions directory\n"
 msgstr ""
 
-#: src/store.c:24824
+#: src/store.c:24855
 #, c-format
 msgid "failed to stage transaction\n"
 msgstr ""
 
-#: src/store.c:24903
+#: src/store.c:24934
 #, c-format
 msgid "transaction changed since plan: %s\n"
 msgstr ""
 
-#: src/store.c:25165
+#: src/store.c:25196
 #, c-format
 msgid "invalid abandoned mutation stage\n"
 msgstr ""
 
-#: src/store.c:25425 src/store.c:25429
+#: src/store.c:25460 src/store.c:25464
 #, c-format
 msgid "invalid dependency index directory\n"
 msgstr ""
 
-#: src/store.c:26033
+#: src/store.c:26068
 #, c-format
 msgid "dependency index node is too large\n"
 msgstr ""
 
-#: src/store.c:26437
+#: src/store.c:26472
 #, c-format
 msgid "cannot index a relation dependency that references a hidden v2 key\n"
 msgstr ""
 
-#: src/store.c:26581
+#: src/store.c:26616
 #, c-format
 msgid "cannot build dependency index from invalid mask record\n"
 msgstr ""
 
-#: src/store.c:26607
+#: src/store.c:26642
 #, c-format
 msgid "cannot build dependency index from invalid relation record\n"
 msgstr ""
 
-#: src/store.c:26627
+#: src/store.c:26662
 #, c-format
 msgid "cannot index relation dependency: %s\n"
 msgstr ""
 
-#: src/store.c:27705 src/store.c:28100 src/store.c:28202 src/store.c:28729
-#: src/store.c:28839 src/store.c:29218 src/store.c:29233
+#: src/store.c:27740 src/store.c:28135 src/store.c:28237 src/store.c:28764
+#: src/store.c:28874 src/store.c:29253 src/store.c:29268
 #, c-format
 msgid ""
 "dependency index is corrupt; run fsck --format v2 --dependency-index --"
 "repair\n"
 msgstr ""
 
-#: src/store.c:28061 src/store.c:28266 src/store.c:29208 src/store.c:42845
+#: src/store.c:28096 src/store.c:28301 src/store.c:29243 src/store.c:42923
 #, c-format
 msgid ""
 "dependency index is incomplete; run fsck --format v2 --dependency-index --"
 "repair\n"
 msgstr ""
 
-#: src/store.c:28391
+#: src/store.c:28426
 #, c-format
 msgid "ambiguous legacy mask blocks key visibility transition: %s\n"
 msgstr ""
 
-#: src/store.c:28402
+#: src/store.c:28437
 #, c-format
 msgid "hidden-name transition cannot preserve v1 rollback mask state: %s\n"
 msgstr ""
 
-#: src/store.c:28990
+#: src/store.c:29025
 #, c-format
 msgid "invalid dependency index node: %s\n"
 msgstr ""
 
-#: src/store.c:29346
+#: src/store.c:29381
 #, c-format
 msgid ""
 "dependency index generation changed: first=%s/%zu/%zu second=%s/%zu/%zu\n"
 msgstr ""
 
-#: src/store.c:29394
+#: src/store.c:29429
 #, c-format
 msgid "dependency index rebuild failed at %s\n"
 msgstr ""
 
-#: src/store.c:29956
+#: src/store.c:29991
 #, c-format
 msgid "invalid tombstone file: %s\n"
 msgstr ""
 
-#: src/store.c:29986 src/store.c:29995 src/store.c:29999
+#: src/store.c:30021 src/store.c:30030 src/store.c:30034
 #, c-format
 msgid "invalid v2 compatibility tombstone\n"
 msgstr ""
 
-#: src/store.c:30077
+#: src/store.c:30112
 #, c-format
 msgid "invalid v2 mask target store: %s\n"
 msgstr ""
 
-#: src/store.c:30116 src/store.c:41885
+#: src/store.c:30151 src/store.c:41920
 #, c-format
 msgid "duplicate v2 mask target entry: %s\n"
 msgstr ""
 
-#: src/store.c:30154
+#: src/store.c:30189
 #, c-format
 msgid "invalid encrypted v2 mask name: %s\n"
 msgstr ""
 
-#: src/store.c:30175 src/store.c:30296
+#: src/store.c:30210 src/store.c:30331
 #, c-format
 msgid "invalid v2 mask target: %s\n"
 msgstr ""
 
-#: src/store.c:30215 src/store.c:30221
+#: src/store.c:30250 src/store.c:30256
 #, c-format
 msgid "invalid v2 mask target name: %s\n"
 msgstr ""
 
-#: src/store.c:30260
+#: src/store.c:30295
 #, c-format
 msgid "invalid v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30264 src/store.c:31463
+#: src/store.c:30299 src/store.c:31498
 #, c-format
 msgid "failed to inspect v2 masks directory\n"
 msgstr ""
 
-#: src/store.c:30284
+#: src/store.c:30319
 #, c-format
 msgid ""
 "invalid v2 mask record: %s; run fsck --format v2 --dangling for a diagnostic "
 "handle\n"
 msgstr ""
 
-#: src/store.c:30540 src/store.c:39479
+#: src/store.c:30575 src/store.c:39514
 #, c-format
 msgid "compatibility tombstone does not match its canonical mask: %s\n"
 msgstr ""
 
-#: src/store.c:30658
+#: src/store.c:30693
 #, c-format
 msgid "cannot analyze mask impact while hidden mask names are locked\n"
 msgstr ""
 
-#: src/store.c:31117 src/store.c:31259
+#: src/store.c:31152 src/store.c:31294
 #, c-format
 msgid "secret object excludes bulk select: %s\n"
 msgstr ""
 
-#: src/store.c:31425
+#: src/store.c:31460
 #, c-format
 msgid "failed to encode mask diagnostic handle\n"
 msgstr ""
 
-#: src/store.c:32012
+#: src/store.c:32047
 #, c-format
 msgid "deferred GC requires a valid reference epoch\n"
 msgstr ""
 
-#: src/store.c:32737
+#: src/store.c:32772
 #, c-format
 msgid "%s requires an exact-local persistent writable session\n"
 msgstr ""
 
-#: src/store.c:33364
+#: src/store.c:33399
 #, c-format
 msgid "GC mutation fence is busy; retry later\n"
 msgstr ""
 
-#: src/store.c:33779
+#: src/store.c:33814
 #, c-format
 msgid "GC candidate is structurally valid and cannot be quarantined\n"
 msgstr ""
 
-#: src/store.c:34048 src/store.c:34153
+#: src/store.c:34083 src/store.c:34188
 #, c-format
 msgid "fsck requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:34060
+#: src/store.c:34095
 #, c-format
 msgid "store format is v2; use --format v2\n"
 msgstr ""
 
-#: src/store.c:34165
+#: src/store.c:34200
 #, c-format
 msgid "store format is v1; use --format v1\n"
 msgstr ""
 
-#: src/store.c:34476 src/store.c:34866
+#: src/store.c:34511 src/store.c:34901
 #, c-format
 msgid "gc requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:34495
+#: src/store.c:34530
 #, c-format
 msgid "store format is v1; gc requires --format v2\n"
 msgstr ""
 
-#: src/store.c:34699
+#: src/store.c:34734
 #, c-format
 msgid "GC owner domain must be registered before mutation\n"
 msgstr ""
 
-#: src/store.c:34877
+#: src/store.c:34912
 #, c-format
 msgid "gc is only supported with --format v2\n"
 msgstr ""
 
-#: src/store.c:35283
+#: src/store.c:35318
 #, c-format
 msgid ""
 "%zu hidden mask(s) omitted; unlock the affected domains or use --json for "
 "counts\n"
 msgstr ""
 
-#: src/store.c:35294
+#: src/store.c:35329
 #, c-format
 msgid ""
 "%zu mask state(s) are incomplete while ancestor key names are locked; unlock "
 "the affected domains or use --json for counts\n"
 msgstr ""
 
-#: src/store.c:35379 src/store.c:35449
+#: src/store.c:35414 src/store.c:35484
 #, c-format
 msgid "cannot update inherited key attributes: %s\n"
 msgstr ""
 
-#: src/store.c:35441
+#: src/store.c:35476
 #, c-format
 msgid ""
 "secret attributes cannot be changed for an ephemeral secret; recreate it "
 "with set --ephemeral\n"
 msgstr ""
 
-#: src/store.c:35442
+#: src/store.c:35477
 #, c-format
 msgid "secret attributes cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35571 src/store.c:35691
+#: src/store.c:35606 src/store.c:35726
 #, c-format
 msgid "cannot update inherited key metadata: %s\n"
 msgstr ""
 
-#: src/store.c:35578 src/store.c:35698
+#: src/store.c:35613 src/store.c:35733
 #, c-format
 msgid "key metadata cannot be changed for an ephemeral secret\n"
 msgstr ""
 
-#: src/store.c:35579 src/store.c:35699
+#: src/store.c:35614 src/store.c:35734
 #, c-format
 msgid "key metadata cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:35584
+#: src/store.c:35619
 #, c-format
 msgid "key metadata cannot be set for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:35616
+#: src/store.c:35651
 #, c-format
 msgid "missing key for meta get\n"
 msgstr ""
 
-#: src/store.c:35616
+#: src/store.c:35651
 #, c-format
 msgid "invalid arguments for meta get\n"
 msgstr ""
 
-#: src/store.c:35644
+#: src/store.c:35679
 #, c-format
 msgid "missing key for meta set\n"
 msgstr ""
 
-#: src/store.c:35644
+#: src/store.c:35679
 #, c-format
 msgid "invalid arguments for meta set\n"
 msgstr ""
 
-#: src/store.c:35656
+#: src/store.c:35691
 #, c-format
 msgid "missing key for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35656
+#: src/store.c:35691
 #, c-format
 msgid "invalid arguments for meta mark-leaked\n"
 msgstr ""
 
-#: src/store.c:35679
+#: src/store.c:35714
 #, c-format
 msgid "missing key for meta unset\n"
 msgstr ""
 
-#: src/store.c:35679
+#: src/store.c:35714
 #, c-format
 msgid "invalid arguments for meta unset\n"
 msgstr ""
 
-#: src/store.c:35978
+#: src/store.c:36013
 #, c-format
 msgid "invalid relation kind: %s\n"
 msgstr ""
 
-#: src/store.c:36022
+#: src/store.c:36057
 #, c-format
 msgid "relation member cannot reference an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:36028
+#: src/store.c:36063
 #, c-format
 msgid "relation member cannot reference hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:36065 src/store.c:36072
+#: src/store.c:36100 src/store.c:36107
 #, c-format
 msgid "invalid arguments for relation set\n"
 msgstr ""
 
-#: src/store.c:36072
+#: src/store.c:36107
 #, c-format
 msgid "missing relation id for relation set\n"
 msgstr ""
 
-#: src/store.c:36078 src/store.c:37272 src/store.c:37321
+#: src/store.c:36113 src/store.c:37307 src/store.c:37356
 #, c-format
 msgid "invalid relation id: %s\n"
 msgstr ""
 
-#: src/store.c:36083
+#: src/store.c:36118
 #, c-format
 msgid "relation set requires at least two --member ROLE=KEYREF options\n"
 msgstr ""
 
-#: src/store.c:36095 src/store.c:37331
+#: src/store.c:36130 src/store.c:37366
 #, c-format
 msgid "relations cannot be changed for a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:36948 src/store.c:36954
+#: src/store.c:36983 src/store.c:36989
 #, c-format
 msgid "invalid arguments for relation suggest-link\n"
 msgstr ""
 
-#: src/store.c:37147
+#: src/store.c:37182
 #, c-format
 msgid "invalid arguments for relation ls\n"
 msgstr ""
 
-#: src/store.c:37166
+#: src/store.c:37201
 #, c-format
 msgid "relation ls requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37219
+#: src/store.c:37254
 #, c-format
 msgid "relation search requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37252
+#: src/store.c:37287
 #, c-format
 msgid "missing key for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37252
+#: src/store.c:37287
 #, c-format
 msgid "invalid arguments for relation suggest-refresh\n"
 msgstr ""
 
-#: src/store.c:37267
+#: src/store.c:37302
 #, c-format
 msgid "missing relation id for relation show\n"
 msgstr ""
 
-#: src/store.c:37267
+#: src/store.c:37302
 #, c-format
 msgid "invalid arguments for relation show\n"
 msgstr ""
 
-#: src/store.c:37279
+#: src/store.c:37314
 #, c-format
 msgid "relation show requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37316
+#: src/store.c:37351
 #, c-format
 msgid "missing relation id for relation rm\n"
 msgstr ""
 
-#: src/store.c:37316
+#: src/store.c:37351
 #, c-format
 msgid "invalid arguments for relation rm\n"
 msgstr ""
 
-#: src/store.c:37361
+#: src/store.c:37396
 #, c-format
 msgid "missing key for exists\n"
 msgstr ""
 
-#: src/store.c:37366
+#: src/store.c:37401
 #, c-format
 msgid "invalid arguments for exists\n"
 msgstr ""
 
-#: src/store.c:37395
+#: src/store.c:37430
 #, c-format
 msgid "missing key for id\n"
 msgstr ""
 
-#: src/store.c:37400
+#: src/store.c:37435
 #, c-format
 msgid "invalid arguments for id\n"
 msgstr ""
 
-#: src/store.c:37420
+#: src/store.c:37455
 #, c-format
 msgid "secret id is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37448
+#: src/store.c:37483
 #, c-format
 msgid "missing UUID for secret status\n"
 msgstr ""
 
-#: src/store.c:37458
+#: src/store.c:37493
 #, c-format
 msgid "invalid arguments for secret status\n"
 msgstr ""
 
-#: src/store.c:37463
+#: src/store.c:37498
 #, c-format
 msgid "invalid UUID for secret status: %s\n"
 msgstr ""
 
-#: src/store.c:37471
+#: src/store.c:37506
 #, c-format
 msgid "secret status requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:37483
+#: src/store.c:37518
 #, c-format
 msgid "secret status is available only for store format v2\n"
 msgstr ""
 
-#: src/store.c:37493
+#: src/store.c:37528
 #, c-format
 msgid "secret object not found: %s\n"
 msgstr ""
 
-#: src/store.c:37497
+#: src/store.c:37532
 #, c-format
 msgid "invalid secret object: %s\n"
 msgstr ""
 
-#: src/store.c:37627
+#: src/store.c:37662
 #, c-format
 msgid "key value contains NUL byte and cannot be shell-escaped: %s\n"
 msgstr ""
 
-#: src/store.c:37641 src/store.c:37709
+#: src/store.c:37676 src/store.c:37744
 #, c-format
 msgid "failed to write standard output\n"
 msgstr ""
 
-#: src/store.c:37690
+#: src/store.c:37725
 #, c-format
 msgid "refusing to write secret to a terminal\n"
 msgstr ""
 
-#: src/store.c:37837 src/store.c:38378
+#: src/store.c:37872 src/store.c:38413
 #, c-format
 msgid ""
 "ephemeral secrets require key_visibility=unlocked and value_access=unlocked\n"
 msgstr ""
 
-#: src/store.c:37892 src/store.c:38853 src/store.c:47912
+#: src/store.c:37927 src/store.c:38888 src/store.c:48006
 #, c-format
 msgid "mutation planning is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:37907
+#: src/store.c:37942
 #, c-format
 msgid "secret attributes are not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:38012 src/store.c:38260 src/store.c:38270 src/store.c:38292
-#: src/store.c:38317 src/store.c:38326 src/store.c:38336 src/store.c:38365
-#: src/store.c:38441 src/store.c:38474 src/store.c:38483
+#: src/store.c:38047 src/store.c:38295 src/store.c:38305 src/store.c:38327
+#: src/store.c:38352 src/store.c:38361 src/store.c:38371 src/store.c:38400
+#: src/store.c:38476 src/store.c:38509 src/store.c:38518
 #, c-format
 msgid "invalid arguments for set\n"
 msgstr ""
 
-#: src/store.c:38044
+#: src/store.c:38079
 #, c-format
 msgid "invalid generated secret charset\n"
 msgstr ""
 
-#: src/store.c:38065
+#: src/store.c:38100
 #, c-format
 msgid "generated secret charset is too large\n"
 msgstr ""
 
-#: src/store.c:38113
+#: src/store.c:38148
 #, c-format
 msgid "invalid generated secret length or charset\n"
 msgstr ""
 
-#: src/store.c:38127 src/store.c:38136
+#: src/store.c:38162 src/store.c:38171
 #, c-format
 msgid "invalid generated secret charset: %s\n"
 msgstr ""
 
-#: src/store.c:38141
+#: src/store.c:38176
 #, c-format
 msgid "duplicate generated secret charset class: %s\n"
 msgstr ""
 
-#: src/store.c:38152
+#: src/store.c:38187
 #, c-format
 msgid "generated secret length is too short for the selected charset classes\n"
 msgstr ""
 
-#: src/store.c:38343
+#: src/store.c:38378
 #, c-format
 msgid "environment variable is not set: %s\n"
 msgstr ""
 
-#: src/store.c:38387
+#: src/store.c:38422
 #, c-format
 msgid "missing key for set\n"
 msgstr ""
 
-#: src/store.c:38397
+#: src/store.c:38432
 #, c-format
 msgid "invalid arguments for generated set\n"
 msgstr ""
 
-#: src/store.c:38423
+#: src/store.c:38458
 #, c-format
 msgid "--length, --charset, and --require-each-class require --generate\n"
 msgstr ""
 
-#: src/store.c:38447
+#: src/store.c:38482
 #, c-format
 msgid "set --ephemeral accepts exactly one key\n"
 msgstr ""
 
-#: src/store.c:38496
+#: src/store.c:38531
 #, c-format
 msgid "refusing to read secret from a terminal\n"
 msgstr ""
 
-#: src/store.c:39036
+#: src/store.c:39071
 #, c-format
 msgid "key has no inherited mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39145
+#: src/store.c:39180
 #, c-format
 msgid "invalid orphan mask chain; inspect fsck --format v2 --dangling: %s\n"
 msgstr ""
 
-#: src/store.c:39154
+#: src/store.c:39189
 #, c-format
 msgid ""
 "multiple orphan mask chains match key; inspect list --all-masks --long: %s\n"
 msgstr ""
 
-#: src/store.c:39183
+#: src/store.c:39218
 #, c-format
 msgid "key has no mask barrier to rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39210
+#: src/store.c:39245
 #, c-format
 msgid ""
 "mask rebind found no unique inherited v2 target; inspect domain ls --"
@@ -4526,534 +4526,539 @@ msgid ""
 "inaccessible candidates without unmasking: %s\n"
 msgstr ""
 
-#: src/store.c:39231
+#: src/store.c:39266
 #, c-format
 msgid "canonical mask requires an inherited v2 entry: %s\n"
 msgstr ""
 
-#: src/store.c:39289
+#: src/store.c:39324
 #, c-format
 msgid "orphan mask barrier requires mask --rebind: %s\n"
 msgstr ""
 
-#: src/store.c:39313
+#: src/store.c:39348
 #, c-format
 msgid "conflicting canonical mask target: %s\n"
 msgstr ""
 
-#: src/store.c:39319 src/store.c:39329
+#: src/store.c:39354 src/store.c:39364
 #, c-format
 msgid "conflicting canonical mask name: %s\n"
 msgstr ""
 
-#: src/store.c:39340
+#: src/store.c:39375
 #, c-format
 msgid ""
 "target is already masked by another chain; inspect list --all-masks --long "
 "and choose a chain with unmask --dry-run --mask-chain: %s\n"
 msgstr ""
 
-#: src/store.c:39427
+#: src/store.c:39462
 #, c-format
 msgid ""
 "hidden-name mask cannot be projected to v1 rollback state without exposing "
 "its name: %s\n"
 msgstr ""
 
-#: src/store.c:39455
+#: src/store.c:39490
 #, c-format
 msgid ""
 "ambiguous legacy mask blocks this write; inspect list --all-masks --long and "
 "use mask --rebind after exactly one inherited v2 target remains: %s\n"
 msgstr ""
 
-#: src/store.c:39562 src/store.c:40370 src/store.c:40405 src/store.c:40412
-#: src/store.c:40509 src/store.c:40515
+#: src/store.c:39597 src/store.c:40405 src/store.c:40440 src/store.c:40447
+#: src/store.c:40544 src/store.c:40550
 #, c-format
 msgid "failed to encode mask operation plan\n"
 msgstr ""
 
-#: src/store.c:39718
+#: src/store.c:39753
 #, c-format
 msgid "%s is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:39768 src/store.c:39800
+#: src/store.c:39803 src/store.c:39835
 #, c-format
 msgid "key exists locally and cannot be masked: %s\n"
 msgstr ""
 
-#: src/store.c:39920
+#: src/store.c:39955
 #, c-format
 msgid "cannot unmask while matching mask state is locked\n"
 msgstr ""
 
-#: src/store.c:39936
+#: src/store.c:39971
 #, c-format
 msgid "ambiguous legacy mask requires mask --rebind before unmask: %s\n"
 msgstr ""
 
-#: src/store.c:39969
+#: src/store.c:40004
 #, c-format
 msgid "mask chain does not protect requested key: %s\n"
 msgstr ""
 
-#: src/store.c:39977
+#: src/store.c:40012
 #, c-format
 msgid ""
 "multiple mask chains match key; use list --all-masks --long and --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:40043
+#: src/store.c:40078
 #, c-format
 msgid "mask state changed since plan\n"
 msgstr ""
 
-#: src/store.c:40050 src/store.c:40688 src/store.c:40700
+#: src/store.c:40085 src/store.c:40723 src/store.c:40735
 #, c-format
 msgid "key is not masked in current domain: %s\n"
 msgstr ""
 
-#: src/store.c:40083
+#: src/store.c:40118
 #, c-format
 msgid ""
 "mask chain protects multiple key names; inspect with unmask --dry-run --mask-"
 "chain: %s\n"
 msgstr ""
 
-#: src/store.c:40685
+#: src/store.c:40720
 #, c-format
 msgid ""
 "cannot unmask a persisted tombstone while volatile session overlay is "
 "active: %s\n"
 msgstr ""
 
-#: src/store.c:40734
+#: src/store.c:40769
 #, c-format
 msgid "invalid UUID source for ln: %s\n"
 msgstr ""
 
-#: src/store.c:40768
+#: src/store.c:40803
 #, c-format
 msgid "secret UUID is not authorized in current context: %s\n"
 msgstr ""
 
-#: src/store.c:40910 src/store.c:40916
+#: src/store.c:40945 src/store.c:40951
 #, c-format
 msgid "invalid arguments for ln\n"
 msgstr ""
 
-#: src/store.c:40921
+#: src/store.c:40956
 #, c-format
 msgid "--skip-same-value-check requires --replace\n"
 msgstr ""
 
-#: src/store.c:40975 src/store.c:41283 src/store.c:42793 src/store.c:43303
-#: src/store.c:45858
+#: src/store.c:41010 src/store.c:41318 src/store.c:42871 src/store.c:43390
+#: src/store.c:45945
 #, c-format
 msgid "destination key already exists: %s\n"
 msgstr ""
 
-#: src/store.c:41027
+#: src/store.c:41062
 #, c-format
 msgid "UUID references are only valid as ln source: %s\n"
 msgstr ""
 
-#: src/store.c:41032 src/store.c:41067 src/store.c:41146 src/store.c:41230
-#: src/store.c:41254 src/store.c:43249 src/store.c:43273
+#: src/store.c:41067 src/store.c:41102 src/store.c:41181 src/store.c:41265
+#: src/store.c:41289 src/store.c:43336 src/store.c:43360
 #, c-format
 msgid "source and destination keys must differ\n"
 msgstr ""
 
-#: src/store.c:41083
+#: src/store.c:41118
 #, c-format
 msgid "ln is not supported in a volatile session overlay\n"
 msgstr ""
 
-#: src/store.c:41094 src/store.c:41119
+#: src/store.c:41129 src/store.c:41154
 #, c-format
 msgid "ln requires source and destination in v2 stores\n"
 msgstr ""
 
-#: src/store.c:41115 src/store.c:41127
+#: src/store.c:41150 src/store.c:41162
 #, c-format
 msgid "ln is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41133
+#: src/store.c:41168
 #, c-format
 msgid ""
 "destination key already exists: %s (use --replace to replace a same-name key "
 "after value confirmation)\n"
 msgstr ""
 
-#: src/store.c:41139
+#: src/store.c:41174
 #, c-format
 msgid "ln --replace only supports existing same-name key references\n"
 msgstr ""
 
-#: src/store.c:41166
+#: src/store.c:41201
 #, c-format
 msgid ""
 "same-name destination value differs: %s (use --skip-same-value-check with --"
 "replace to replace anyway)\n"
 msgstr ""
 
-#: src/store.c:41225
+#: src/store.c:41260
 #, c-format
 msgid "invalid arguments for cp\n"
 msgstr ""
 
-#: src/store.c:41296
+#: src/store.c:41331
 #, c-format
 msgid "cp is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:41320 src/store.c:42956 src/store.c:43387
+#: src/store.c:41355 src/store.c:43034 src/store.c:43474
 #, c-format
 msgid "key metadata cannot be preserved for hidden v2 key: %s\n"
 msgstr ""
 
-#: src/store.c:41395
+#: src/store.c:41430
 #, c-format
 msgid "too many move relation dependencies\n"
 msgstr ""
 
-#: src/store.c:41896
+#: src/store.c:41931
 #, c-format
 msgid "affected descendant mask is inaccessible: %s\n"
 msgstr ""
 
-#: src/store.c:42799 src/store.c:43329
+#: src/store.c:42877 src/store.c:43416
 #, c-format
 msgid "mv requires v2 source and destination stores\n"
 msgstr ""
 
-#: src/store.c:42819
+#: src/store.c:42897
 #, c-format
 msgid ""
 "mv mutation planning requires a local source in the same v2 domain and "
 "store\n"
 msgstr ""
 
-#: src/store.c:42915
+#: src/store.c:42993
 #, c-format
 msgid "mv requires normalized v2 object value storage across namespaces\n"
 msgstr ""
 
-#: src/store.c:43244
+#: src/store.c:43331
 #, c-format
 msgid "invalid arguments for mv\n"
 msgstr ""
 
-#: src/store.c:43317
+#: src/store.c:43404
 #, c-format
 msgid "mv is not supported for an ephemeral secret: %s\n"
 msgstr ""
 
-#: src/store.c:43346 src/store.c:47942
+#: src/store.c:43433 src/store.c:48036
 #, c-format
 msgid "mask mutation planning requires store format v2\n"
 msgstr ""
 
-#: src/store.c:43353
+#: src/store.c:43440
 #, c-format
 msgid "mv requires matching source and destination store formats\n"
 msgstr ""
 
-#: src/store.c:43517
+#: src/store.c:43604
 #, c-format
 msgid "invalid arguments for %s\n"
 msgstr ""
 
-#: src/store.c:43584
+#: src/store.c:43671
 #, c-format
 msgid "mask planning and rebind require a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43613
+#: src/store.c:43700
 #, c-format
 msgid "canonical mask planning requires an inherited v2 entry\n"
 msgstr ""
 
-#: src/store.c:43733
+#: src/store.c:43820
 #, c-format
 msgid "unmask planning requires a persisted v2 store\n"
 msgstr ""
 
-#: src/store.c:43784
+#: src/store.c:43871
 #, c-format
 msgid ""
 "warning: unmask: removed mask chain; %s remains masked by %zu other chain or "
 "barrier\n"
 msgstr ""
 
-#: src/store.c:43791
+#: src/store.c:43878
 #, c-format
 msgid ""
 "warning: unmask: %s remains local; removing it later may expose the "
 "inherited value\n"
 msgstr ""
 
-#: src/store.c:43825
+#: src/store.c:43912
 #, c-format
 msgid "ephemeral key not found: %s\n"
 msgstr ""
 
-#: src/store.c:43831
+#: src/store.c:43918
 #, c-format
 msgid "cannot remove inherited ephemeral key; use its source domain: %s\n"
 msgstr ""
 
-#: src/store.c:43873 src/store.c:43880
+#: src/store.c:43960 src/store.c:43967
 #, c-format
 msgid "invalid arguments for rm\n"
 msgstr ""
 
-#: src/store.c:44008 src/store.c:44519 src/store.c:44877 src/store.c:45340
-#: src/store.c:45426
+#: src/store.c:44095 src/store.c:44606 src/store.c:44964 src/store.c:45427
+#: src/store.c:45513
 #, c-format
 msgid "--store is not valid with store commands\n"
 msgstr ""
 
-#: src/store.c:44108
+#: src/store.c:44195
 #, c-format
 msgid "store migrate requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:44119 src/store.c:44739 src/store.c:45461
+#: src/store.c:44206 src/store.c:44826 src/store.c:45548
 #, c-format
 msgid "store not found: %s\n"
 msgstr ""
 
-#: src/store.c:44130
+#: src/store.c:44217
 #, c-format
 msgid "store format is v2; migration is not needed\n"
 msgstr ""
 
-#: src/store.c:44408
+#: src/store.c:44495
 #, c-format
 msgid "v2 migration artifacts already exist\n"
 msgstr ""
 
-#: src/store.c:44477
+#: src/store.c:44564
 #, c-format
 msgid "v2 migration verification failed\n"
 msgstr ""
 
-#: src/store.c:44729
+#: src/store.c:44816
 #, c-format
 msgid "store finalize-migration requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:44750
+#: src/store.c:44837
 #, c-format
 msgid "store format is v1; finalize-migration requires a migrated v2 store\n"
 msgstr ""
 
-#: src/store.c:45288
+#: src/store.c:45375
 #, c-format
 msgid "domain is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:45345
+#: src/store.c:45432
 #, c-format
 msgid "missing store name for store create\n"
 msgstr ""
 
-#: src/store.c:45350
+#: src/store.c:45437
 #, c-format
 msgid "invalid arguments for store create\n"
 msgstr ""
 
-#: src/store.c:45375
+#: src/store.c:45462
 #, c-format
 msgid "store already exists: %s\n"
 msgstr ""
 
-#: src/store.c:45431
+#: src/store.c:45518
 #, c-format
 msgid "missing store name for store delete\n"
 msgstr ""
 
-#: src/store.c:45436
+#: src/store.c:45523
 #, c-format
 msgid "invalid arguments for store delete\n"
 msgstr ""
 
-#: src/store.c:45477
+#: src/store.c:45564
 #, c-format
 msgid "store is not empty: %s\n"
 msgstr ""
 
-#: src/store.c:45486
+#: src/store.c:45573
 #, c-format
 msgid "store has pending or quarantined GC work: %s\n"
 msgstr ""
 
-#: src/store.c:45530
+#: src/store.c:45617
 #, c-format
 msgid "key value contains NUL byte and cannot be exported: %s\n"
 msgstr ""
 
-#: src/store.c:45730 src/store.c:45738
+#: src/store.c:45817 src/store.c:45825
 #, c-format
 msgid "invalid arguments for save\n"
 msgstr ""
 
-#: src/store.c:45750
+#: src/store.c:45837
 msgid "Create secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45751
+#: src/store.c:45838
 msgid "Confirm secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:45807
+#: src/store.c:45894
 #, c-format
 msgid "invalid load conflict policy: %s\n"
 msgstr ""
 
-#: src/store.c:45812
+#: src/store.c:45899
 #, c-format
 msgid "conflicting load conflict policies\n"
 msgstr ""
 
-#: src/store.c:45825 src/store.c:45831
+#: src/store.c:45912 src/store.c:45918
 #, c-format
 msgid "invalid arguments for load\n"
 msgstr ""
 
-#: src/store.c:45890
+#: src/store.c:45977
 #, c-format
 msgid "cannot load linked v2 object into a v1 store without splitting links\n"
 msgstr ""
 
-#: src/store.c:45891
+#: src/store.c:45978
 #, c-format
 msgid ""
 "  use --allow-link-split to write independent v1 values, or load into a v2 "
 "store to preserve links\n"
 msgstr ""
 
-#: src/store.c:45925
+#: src/store.c:46012
 msgid "Enter secdat bundle passphrase: "
 msgstr ""
 
-#: src/store.c:46404
+#: src/store.c:46491
 #, c-format
 msgid "  dir=%s\n"
 msgstr ""
 
-#: src/store.c:46407
+#: src/store.c:46494
 #, c-format
 msgid "  domain=%s\n"
 msgstr ""
 
-#: src/store.c:46410
+#: src/store.c:46497
 #, c-format
 msgid "  store=%s\n"
 msgstr ""
 
-#: src/store.c:46449
+#: src/store.c:46536
 #, c-format
 msgid "invalid mask action: %s\n"
 msgstr ""
 
-#: src/store.c:46453
+#: src/store.c:46540
 #, c-format
 msgid "conflicting mask action options\n"
 msgstr ""
 
-#: src/store.c:46467
+#: src/store.c:46554
 #, c-format
 msgid "conflicting mask warning options\n"
 msgstr ""
 
-#: src/store.c:46548
+#: src/store.c:46635
 #, c-format
 msgid "missing value for --mask-action\n"
 msgstr ""
 
-#: src/store.c:46578 src/store.c:46610
+#: src/store.c:46665 src/store.c:46697
 #, c-format
 msgid "invalid mask warning policy: %s\n"
 msgstr ""
 
-#: src/store.c:46589
+#: src/store.c:46676
 #, c-format
 msgid "missing value for --mask-warnings\n"
 msgstr ""
 
-#: src/store.c:47126
+#: src/store.c:47215
 #, c-format
 msgid "mutation failed to preserve a mask\n"
 msgstr ""
 
-#: src/store.c:47225 src/store.c:47487
+#: src/store.c:47314 src/store.c:47576
 #, c-format
 msgid "failed to encode mutation plan\n"
 msgstr ""
 
-#: src/store.c:47584
+#: src/store.c:47674
 #, c-format
 msgid "warning: %s: "
 msgstr ""
 
-#: src/store.c:47598
+#: src/store.c:47688
 #, c-format
 msgid "%zu directly affected masked key slot(s)"
 msgstr ""
 
-#: src/store.c:47602
+#: src/store.c:47692
+#, c-format
+msgid "%zu mask(s) followed preserved entry identity"
+msgstr ""
+
+#: src/store.c:47696
 #, c-format
 msgid "%zu mask(s) became dormant"
 msgstr ""
 
-#: src/store.c:47606
+#: src/store.c:47700
 #, c-format
 msgid "%zu dormant mask(s) reactivated"
 msgstr ""
 
-#: src/store.c:47610
+#: src/store.c:47704
 #, c-format
 msgid "%zu mask(s) became orphaned"
 msgstr ""
 
-#: src/store.c:47614
+#: src/store.c:47708
 #, c-format
 msgid "%zu source mask(s) created"
 msgstr ""
 
-#: src/store.c:47618
+#: src/store.c:47712
 msgid "; inspect with 'secdat --dir DIR list --all-masks --long'\n"
 msgstr ""
 
-#: src/store.c:47740
+#: src/store.c:47834
 msgid "ambiguous legacy mask blocks this mutation\n"
 msgstr ""
 
-#: src/store.c:47741
+#: src/store.c:47835
 msgid "mask interaction rejected before mutation\n"
 msgstr ""
 
-#: src/store.c:47924
+#: src/store.c:48018
 #, c-format
 msgid "mutation planning requires a registered current domain\n"
 msgstr ""
 
-#: src/store.c:48042
+#: src/store.c:48136
 #, c-format
 msgid "mutation planning options are not supported with --ephemeral\n"
 msgstr ""
 
-#: src/store.c:48060
+#: src/store.c:48154
 #, c-format
 msgid "cannot combine --dir and --domain\n"
 msgstr ""
 
-#: src/store.c:48074 src/store.c:48083
+#: src/store.c:48168 src/store.c:48177
 #, c-format
 msgid "failed to recover pending transactions\n"
 msgstr ""

--- a/src/cli.c
+++ b/src/cli.c
@@ -1028,6 +1028,7 @@ static const char *secdat_cli_completion_command_prev_option_mode(const char *co
             return "none";
         }
     } else if (strcmp(command, "cp") == 0
+        || strcmp(command, "mv") == 0
         || strcmp(command, "ln") == 0
         || strcmp(command, "rm") == 0
         || strcmp(command, "load") == 0) {
@@ -1294,6 +1295,10 @@ int secdat_cli_complete(int argc, char **argv)
         "--mask-action", "--mask-warnings", "--warn-mask", "--no-warn-mask",
         "--dry-run", "--json", "--help", "-h", NULL,
     };
+    static const char *const mv_options[] = {
+        "--mask-action", "--mask-warnings", "--warn-mask", "--no-warn-mask",
+        "--dry-run", "--json", "--help", "-h", NULL,
+    };
     static const char *const ln_options[] = {
         "--replace", "--skip-same-value-check", "--mask-action",
         "--mask-warnings", "--warn-mask", "--no-warn-mask",
@@ -1459,6 +1464,8 @@ int secdat_cli_complete(int argc, char **argv)
         secdat_cli_completion_print_candidates(current, rm_options);
     } else if (strcmp(command, "cp") == 0) {
         secdat_cli_completion_print_candidates(current, cp_options);
+    } else if (strcmp(command, "mv") == 0) {
+        secdat_cli_completion_print_candidates(current, mv_options);
     } else if (strcmp(command, "ln") == 0) {
         secdat_cli_completion_print_candidates(current, ln_options);
     } else if (strcmp(command, "load") == 0) {
@@ -1678,7 +1685,7 @@ static void secdat_cli_print_usage_line(const char *program_name, enum secdat_co
         secdat_cli_print_usage_columns(program_name, "[-d DIR|--dir DIR] [-s STORE|--store STORE]", "rm", "--ephemeral [-f|--ignore-missing] KEYREF");
         break;
     case SECDAT_COMMAND_MV:
-        secdat_cli_print_usage_columns(program_name, "[-d DIR|--dir DIR] [-s STORE|--store STORE]", "mv", "SRC_KEYREF DST_KEYREF");
+        secdat_cli_print_usage_columns(program_name, "[-d DIR|--dir DIR] [-s STORE|--store STORE]", "mv", "[--mask-action=preserve|reject] [--mask-warnings=default|on|off] [--warn-mask|--no-warn-mask] [--dry-run] [--json] SRC_KEYREF DST_KEYREF");
         break;
     case SECDAT_COMMAND_CP:
         secdat_cli_print_usage_columns(program_name, "[-d DIR|--dir DIR] [-s STORE|--store STORE]", "cp", "[--mask-action=preserve|reject] [--mask-warnings=default|on|off] [--warn-mask|--no-warn-mask] [--dry-run] [--json] SRC_KEYREF DST_KEYREF");
@@ -2049,6 +2056,9 @@ static void secdat_cli_print_target_meaning(const char *target)
     }
     if (target != NULL && strcmp(target, "mv") == 0) {
         secdat_cli_print_detail_line(_("  mv: rename or relocate one key between resolved locations\n"));
+        secdat_cli_print_detail_line(_("  a same-domain/store local v2 rename preserves both entry and secret IDs, existing links, and object refcount\n"));
+        secdat_cli_print_detail_line(_("  descendant identity masks follow the preserved entry; relation KEYREF rewrites are reported separately in the common mutation plan\n"));
+        secdat_cli_print_detail_line(_("  --mask-action=preserve is the default; reject, warning controls, dry-run, and JSON apply to local same-namespace v2 rename\n"));
         return;
     }
     if (target != NULL && strcmp(target, "cp") == 0) {

--- a/src/store.c
+++ b/src/store.c
@@ -783,6 +783,7 @@ struct secdat_mutation_impact_row {
     char domain_id[PATH_MAX];
     char store_name[PATH_MAX];
     char key[PATH_MAX];
+    char key_after[PATH_MAX];
     char target_entry_id[64];
     char mask_chain_id[64];
     enum secdat_mutation_impact_event event;
@@ -792,15 +793,34 @@ struct secdat_mutation_impact_row {
     int has_state_after;
 };
 
+struct secdat_mutation_relation_consequence {
+    char domain_id[PATH_MAX];
+    char store_name[PATH_MAX];
+    char relation_id[PATH_MAX];
+    char source_keyref[PATH_MAX * 2];
+    char destination_keyref[PATH_MAX * 2];
+    size_t rewritten_member_count;
+};
+
 struct secdat_mutation_plan {
     struct secdat_mutation_policy_options policy;
     struct secdat_mutation_slot_list slots;
     struct secdat_mutation_impact_row *rows;
+    struct secdat_mutation_relation_consequence *relation_consequences;
     size_t row_count;
     size_t row_capacity;
+    size_t relation_consequence_count;
+    size_t relation_consequence_capacity;
     size_t impact_counts[SECDAT_MUTATION_IMPACT_EVENT_COUNT];
     size_t changed_file_count;
     char operation[32];
+    char source_secret_id[64];
+    char destination_secret_id[64];
+    char source_entry_id[64];
+    char destination_entry_id[64];
+    int has_identity_result;
+    int entry_id_preserved;
+    int secret_id_preserved;
     int rejected;
 };
 
@@ -811,6 +831,7 @@ struct secdat_mutation_stage_context {
 };
 
 static struct secdat_mutation_stage_context secdat_mutation_stage;
+static struct secdat_mutation_plan *secdat_active_mutation_plan;
 
 struct secdat_prepared_state_file {
     char path[PATH_MAX];
@@ -1386,6 +1407,28 @@ static int secdat_prepared_write_set_record(
 static int secdat_prepared_directory_guard_record(
     struct secdat_prepared_write_set *write_set,
     const char *path
+);
+static int secdat_mutation_policy_was_requested(
+    const struct secdat_mutation_policy_options *policy
+);
+static int secdat_mutation_plan_append_row(
+    struct secdat_mutation_plan *plan,
+    const struct secdat_mutation_slot *slot,
+    const struct secdat_mask_view *view,
+    enum secdat_mutation_impact_event event,
+    const struct secdat_mask_view *after
+);
+static int secdat_print_mutation_plan(
+    const struct secdat_mutation_plan *plan,
+    int committed
+);
+static void secdat_mutation_emit_warning(
+    const struct secdat_mutation_plan *plan
+);
+static int secdat_render_scoped_precommit(
+    struct secdat_mutation_plan *plan,
+    int hard_error,
+    int *status
 );
 static int secdat_recover_transactions(void);
 static int secdat_transaction_ensure_root(char *root, size_t root_size);
@@ -41639,6 +41682,405 @@ static int secdat_move_apply_relation_updates(
     return 0;
 }
 
+static int secdat_mutation_plan_set_mv_identity(
+    struct secdat_mutation_plan *plan,
+    const char *source_secret_id,
+    const char *destination_secret_id,
+    const char *source_entry_id,
+    const char *destination_entry_id
+)
+{
+    if (plan == NULL) {
+        return 0;
+    }
+    if (secdat_copy_string(
+            plan->source_secret_id,
+            sizeof(plan->source_secret_id),
+            source_secret_id
+        ) != 0
+        || secdat_copy_string(
+            plan->destination_secret_id,
+            sizeof(plan->destination_secret_id),
+            destination_secret_id
+        ) != 0
+        || secdat_copy_string(
+            plan->source_entry_id,
+            sizeof(plan->source_entry_id),
+            source_entry_id
+        ) != 0
+        || secdat_copy_string(
+            plan->destination_entry_id,
+            sizeof(plan->destination_entry_id),
+            destination_entry_id
+        ) != 0) {
+        return 1;
+    }
+    plan->has_identity_result = 1;
+    plan->entry_id_preserved = strcmp(source_entry_id, destination_entry_id) == 0;
+    plan->secret_id_preserved = strcmp(source_secret_id, destination_secret_id) == 0;
+    return 0;
+}
+
+static int secdat_mutation_plan_append_relation_consequence(
+    struct secdat_mutation_plan *plan,
+    const struct secdat_move_relation_update *update,
+    const char *source_keyref,
+    const char *destination_keyref,
+    size_t rewritten_member_count
+)
+{
+    struct secdat_mutation_relation_consequence *resized;
+    struct secdat_mutation_relation_consequence *row;
+    size_t next_capacity;
+
+    if (plan == NULL || rewritten_member_count == 0) {
+        return 0;
+    }
+    if (plan->relation_consequence_count
+        == plan->relation_consequence_capacity) {
+        next_capacity = plan->relation_consequence_capacity == 0
+            ? 4
+            : plan->relation_consequence_capacity * 2;
+        resized = realloc(
+            plan->relation_consequences,
+            next_capacity * sizeof(*resized)
+        );
+        if (resized == NULL) {
+            fprintf(stderr, _("out of memory\n"));
+            return 1;
+        }
+        plan->relation_consequences = resized;
+        plan->relation_consequence_capacity = next_capacity;
+    }
+    row = &plan->relation_consequences[plan->relation_consequence_count];
+    memset(row, 0, sizeof(*row));
+    if (secdat_copy_string(
+            row->domain_id,
+            sizeof(row->domain_id),
+            update->domain_id
+        ) != 0
+        || secdat_copy_string(
+            row->store_name,
+            sizeof(row->store_name),
+            update->store_name
+        ) != 0
+        || secdat_copy_string(
+            row->relation_id,
+            sizeof(row->relation_id),
+            update->relation_id
+        ) != 0
+        || secdat_copy_string(
+            row->source_keyref,
+            sizeof(row->source_keyref),
+            source_keyref
+        ) != 0
+        || secdat_copy_string(
+            row->destination_keyref,
+            sizeof(row->destination_keyref),
+            destination_keyref
+        ) != 0) {
+        return 1;
+    }
+    row->rewritten_member_count = rewritten_member_count;
+    plan->relation_consequence_count += 1;
+    return 0;
+}
+
+static int secdat_mutation_plan_collect_mv_relations(
+    struct secdat_mutation_plan *plan,
+    const struct secdat_move_relation_update_list *updates,
+    const char *source_keyref,
+    const char *destination_keyref
+)
+{
+    size_t update_index;
+
+    if (plan == NULL) {
+        return 0;
+    }
+    for (update_index = 0; update_index < updates->count; update_index += 1) {
+        const struct secdat_move_relation_update *update =
+            &updates->items[update_index];
+        size_t member_index;
+        size_t rewritten_member_count = 0;
+
+        for (member_index = 0;
+             member_index < update->before_keyrefs.count;
+             member_index += 1) {
+            if (strcmp(
+                    update->before_keyrefs.items[member_index],
+                    source_keyref
+                ) == 0) {
+                rewritten_member_count += 1;
+            }
+        }
+        if (secdat_mutation_plan_append_relation_consequence(
+                plan,
+                update,
+                source_keyref,
+                destination_keyref,
+                rewritten_member_count
+            ) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int secdat_mutation_plan_find_mv_mask_view(
+    const char *mask_domain_id,
+    const char *mask_store,
+    const char *target_entry_id,
+    const char *mask_chain_id,
+    struct secdat_mask_view *view_out
+)
+{
+    struct secdat_domain_chain chain = {0};
+    struct secdat_mask_view_list views = {0};
+    size_t index;
+    int found = 0;
+    int status = 1;
+
+    memset(view_out, 0, sizeof(*view_out));
+    if (secdat_domain_chain_from_id(mask_domain_id, &chain) != 0
+        || secdat_collect_canonical_mask_views(
+            &chain,
+            mask_store,
+            &views
+        ) != 0) {
+        goto cleanup;
+    }
+    for (index = 0; index < views.count; index += 1) {
+        const struct secdat_mask_view *candidate = &views.items[index];
+
+        if (strcmp(candidate->target_entry_id, target_entry_id) != 0
+            || (mask_chain_id != NULL && mask_chain_id[0] != '\0'
+                && strcmp(candidate->mask_chain_id, mask_chain_id) != 0)) {
+            continue;
+        }
+        if (found) {
+            fprintf(
+                stderr,
+                _("duplicate v2 mask target entry: %s\n"),
+                target_entry_id
+            );
+            goto cleanup;
+        }
+        *view_out = *candidate;
+        found = 1;
+    }
+    if (!found) {
+        fprintf(
+            stderr,
+            _("affected descendant mask is inaccessible: %s\n"),
+            target_entry_id
+        );
+        goto cleanup;
+    }
+    status = 0;
+
+cleanup:
+    secdat_mask_view_list_free(&views);
+    secdat_domain_chain_free(&chain);
+    return status;
+}
+
+static int secdat_mutation_plan_capture_mv_masks(
+    struct secdat_mutation_plan *plan,
+    struct secdat_dependency_update_plan *dependency_plan,
+    const char *target_entry_id
+)
+{
+    json_t *edges = NULL;
+    int found = 0;
+    size_t index;
+    int status = 1;
+
+    if (plan == NULL) {
+        return 0;
+    }
+    if (secdat_dependency_update_plan_collect_group(
+            dependency_plan,
+            'M',
+            target_entry_id,
+            &edges,
+            &found
+        ) != 0) {
+        goto cleanup;
+    }
+    if (!found) {
+        status = 0;
+        goto cleanup;
+    }
+    for (index = 0; index < json_array_size(edges); index += 1) {
+        json_t *edge = json_array_get(edges, index);
+        const char *mask_domain_id = json_string_value(
+            json_object_get(edge, "mask_domain_id")
+        );
+        const char *mask_store = json_string_value(
+            json_object_get(edge, "mask_store")
+        );
+        struct secdat_mask_view view;
+        struct secdat_mutation_slot slot;
+        size_t edge_count = 0;
+
+        memset(&slot, 0, sizeof(slot));
+        if (mask_domain_id == NULL || mask_store == NULL
+            || secdat_dependency_mask_edge_validate(
+                edge,
+                target_entry_id,
+                &edge_count
+            ) != 0
+            || edge_count != 1
+            || secdat_mutation_plan_find_mv_mask_view(
+                mask_domain_id,
+                mask_store,
+                target_entry_id,
+                NULL,
+                &view
+            ) != 0
+            || secdat_copy_string(
+                slot.domain_id,
+                sizeof(slot.domain_id),
+                mask_domain_id
+            ) != 0
+            || secdat_copy_string(
+                slot.store_name,
+                sizeof(slot.store_name),
+                secdat_effective_store_name(mask_store)
+            ) != 0
+            || secdat_copy_string(
+                slot.key,
+                sizeof(slot.key),
+                view.key
+            ) != 0
+            || secdat_mutation_plan_append_row(
+                plan,
+                &slot,
+                &view,
+                SECDAT_MUTATION_IMPACT_DIRECT_HIT,
+                NULL
+            ) != 0) {
+            goto cleanup;
+        }
+    }
+    status = 0;
+
+cleanup:
+    json_decref(edges);
+    return status;
+}
+
+static int secdat_mutation_plan_append_mv_mask_transition(
+    struct secdat_mutation_plan *plan,
+    const struct secdat_mutation_impact_row *row,
+    const struct secdat_mask_view *after
+)
+{
+    struct secdat_mask_view before;
+    struct secdat_mutation_slot slot;
+    enum secdat_mutation_impact_event transition;
+
+    if (!row->has_state_before || !row->has_state_after
+        || row->state_before == row->state_after) {
+        return 0;
+    }
+    if (row->state_after == SECDAT_MASK_STATE_ORPHANED) {
+        transition = SECDAT_MUTATION_IMPACT_ORPHANED;
+    } else if (row->state_before == SECDAT_MASK_STATE_ACTIVE
+        && row->state_after == SECDAT_MASK_STATE_DORMANT) {
+        transition = SECDAT_MUTATION_IMPACT_BECAME_DORMANT;
+    } else if (row->state_before == SECDAT_MASK_STATE_DORMANT
+        && row->state_after == SECDAT_MASK_STATE_ACTIVE) {
+        transition = SECDAT_MUTATION_IMPACT_REACTIVATED;
+    } else {
+        return 0;
+    }
+    memset(&before, 0, sizeof(before));
+    memset(&slot, 0, sizeof(slot));
+    before.record_kind = SECDAT_MASK_RECORD_CANONICAL;
+    before.resolution = SECDAT_MASK_RESOLUTION_BOUND;
+    before.state = row->state_before;
+    if (secdat_copy_string(before.key, sizeof(before.key), row->key) != 0
+        || secdat_copy_string(
+            before.target_entry_id,
+            sizeof(before.target_entry_id),
+            row->target_entry_id
+        ) != 0
+        || secdat_copy_string(
+            before.mask_chain_id,
+            sizeof(before.mask_chain_id),
+            row->mask_chain_id
+        ) != 0
+        || secdat_copy_string(
+            slot.domain_id,
+            sizeof(slot.domain_id),
+            row->domain_id
+        ) != 0
+        || secdat_copy_string(
+            slot.store_name,
+            sizeof(slot.store_name),
+            row->store_name
+        ) != 0
+        || secdat_copy_string(slot.key, sizeof(slot.key), row->key) != 0) {
+        return 1;
+    }
+    return secdat_mutation_plan_append_row(
+        plan,
+        &slot,
+        &before,
+        transition,
+        after
+    );
+}
+
+static int secdat_mutation_plan_finish_mv_masks(
+    struct secdat_mutation_plan *plan,
+    const char *target_entry_id
+)
+{
+    size_t original_row_count;
+    size_t index;
+
+    if (plan == NULL) {
+        return 0;
+    }
+    original_row_count = plan->row_count;
+    for (index = 0; index < original_row_count; index += 1) {
+        struct secdat_mutation_impact_row *row = &plan->rows[index];
+        struct secdat_mask_view after;
+
+        if (row->event != SECDAT_MUTATION_IMPACT_DIRECT_HIT
+            || strcmp(row->target_entry_id, target_entry_id) != 0) {
+            continue;
+        }
+        if (secdat_mutation_plan_find_mv_mask_view(
+                row->domain_id,
+                row->store_name,
+                row->target_entry_id,
+                row->mask_chain_id,
+                &after
+            ) != 0
+            || secdat_copy_string(
+                row->key_after,
+                sizeof(row->key_after),
+                after.key
+            ) != 0) {
+            return 1;
+        }
+        row->state_after = after.state;
+        row->has_state_after = !after.state_unknown;
+        if (secdat_mutation_plan_append_mv_mask_transition(
+                plan,
+                row,
+                &after
+            ) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int secdat_domain_move_relation_update_exists(
     const struct secdat_move_relation_update_list *updates,
     const char *domain_id,
@@ -42278,9 +42720,11 @@ static int secdat_move_v2_entry(
     char destination_entry_id[64];
     enum secdat_store_format source_format;
     enum secdat_store_format destination_format;
+    struct secdat_mutation_plan *mutation_plan = NULL;
     int source_is_local;
     int same_namespace;
     int need_source_mask = 0;
+    int precommit_status;
     int unsafe_store = 0;
     int status = 1;
     size_t changed_file_count = 0;
@@ -42343,6 +42787,19 @@ static int secdat_move_v2_entry(
             secdat_effective_store_name(source_reference->store_value),
             secdat_effective_store_name(destination_reference->store_value)
         ) == 0;
+    if (secdat_active_mutation_plan != NULL) {
+        if (source_is_local && same_namespace) {
+            mutation_plan = secdat_active_mutation_plan;
+        } else if (secdat_mutation_policy_was_requested(
+                &secdat_active_mutation_plan->policy
+            )) {
+            fprintf(
+                stderr,
+                _("mv mutation planning requires a local source in the same v2 domain and store\n")
+            );
+            goto cleanup;
+        }
+    }
     if (secdat_read_store_format(
             source_domain_id,
             source_reference->store_value,
@@ -42366,6 +42823,13 @@ static int secdat_move_v2_entry(
             stderr,
             _("dependency index is incomplete; run fsck --format v2 --dependency-index --repair\n")
         );
+        goto cleanup;
+    }
+    if (secdat_mutation_plan_capture_mv_masks(
+            mutation_plan,
+            &dependency_plan,
+            source_entry.entry_id
+        ) != 0) {
         goto cleanup;
     }
     object_domain_id = source_entry.object_domain[0] == '\0'
@@ -42494,6 +42958,12 @@ static int secdat_move_v2_entry(
                 old_keyref,
                 new_keyref,
                 &relation_updates
+            ) != 0
+            || secdat_mutation_plan_collect_mv_relations(
+                mutation_plan,
+                &relation_updates,
+                old_keyref,
+                new_keyref
             ) != 0)) {
         goto cleanup;
     }
@@ -42543,6 +43013,15 @@ static int secdat_move_v2_entry(
     } else if (secdat_generate_uuid_v4(
             destination_entry_id,
             sizeof(destination_entry_id)
+        ) != 0) {
+        goto cleanup;
+    }
+    if (secdat_mutation_plan_set_mv_identity(
+            mutation_plan,
+            source_entry.secret_id,
+            source_entry.secret_id,
+            source_entry.entry_id,
+            destination_entry_id
         ) != 0) {
         goto cleanup;
     }
@@ -42636,6 +43115,12 @@ static int secdat_move_v2_entry(
             ) != 0)) {
         goto cleanup;
     }
+    if (secdat_mutation_plan_finish_mv_masks(
+            mutation_plan,
+            source_entry.entry_id
+        ) != 0) {
+        goto cleanup;
+    }
     if (secdat_gc_topology_plan_apply(&secdat_gc_topology_plan) != 0) {
         goto cleanup;
     }
@@ -42663,11 +43148,35 @@ static int secdat_move_v2_entry(
         || secdat_dependency_update_plan_append(
             &transaction,
             &dependency_plan
-        ) != 0
-        || secdat_transaction_commit(&transaction) != 0) {
+        ) != 0) {
+        goto cleanup;
+    }
+    if (mutation_plan != NULL) {
+        mutation_plan->changed_file_count = changed_file_count;
+        mutation_plan->rejected =
+            mutation_plan->policy.action == SECDAT_MUTATION_MASK_REJECT
+            && mutation_plan->row_count > 0;
+        precommit_status = secdat_render_scoped_precommit(
+            mutation_plan,
+            0,
+            &status
+        );
+        if (precommit_status < 0) {
+            goto cleanup;
+        }
+        if (precommit_status > 0) {
+            goto cleanup;
+        }
+    }
+    if (secdat_transaction_commit(&transaction) != 0
+        || (mutation_plan != NULL
+            && secdat_print_mutation_plan(mutation_plan, 1) != 0)) {
         goto cleanup;
     }
     secdat_gc_topology_notify_agents(&secdat_gc_topology_plan);
+    if (mutation_plan != NULL) {
+        secdat_mutation_emit_warning(mutation_plan);
+    }
     (void)unsafe_store;
     (void)changed_file_count;
     status = 0;
@@ -42804,6 +43313,16 @@ static int secdat_command_mv(const struct secdat_cli *cli)
             &source_chain,
             &destination_reference,
             &destination_chain
+        );
+        goto cleanup;
+    }
+    if (secdat_active_mutation_plan != NULL
+        && secdat_mutation_policy_was_requested(
+            &secdat_active_mutation_plan->policy
+        )) {
+        fprintf(
+            stderr,
+            _("mask mutation planning requires store format v2\n")
         );
         goto cleanup;
     }
@@ -46172,7 +46691,90 @@ static void secdat_mutation_plan_reset(struct secdat_mutation_plan *plan)
         plan->row_capacity * sizeof(*plan->rows)
     );
     free(plan->rows);
+    secdat_secure_clear(
+        plan->relation_consequences,
+        plan->relation_consequence_capacity
+            * sizeof(*plan->relation_consequences)
+    );
+    free(plan->relation_consequences);
     memset(plan, 0, sizeof(*plan));
+}
+
+static int secdat_run_planned_mv(const struct secdat_cli *cli)
+{
+    struct secdat_cli filtered;
+    struct secdat_mutation_plan plan;
+    char **filtered_argv = NULL;
+    int status;
+
+    memset(&plan, 0, sizeof(plan));
+    status = secdat_parse_mutation_policy_options(
+        cli,
+        &filtered,
+        &plan.policy,
+        &filtered_argv
+    );
+    if (status != 0) {
+        return status;
+    }
+    if (secdat_copy_string(
+            plan.operation,
+            sizeof(plan.operation),
+            "mv"
+        ) != 0) {
+        free(filtered_argv);
+        return 1;
+    }
+    secdat_active_mutation_plan = &plan;
+    status = secdat_dispatch_command(&filtered);
+    secdat_active_mutation_plan = NULL;
+    free(filtered_argv);
+    secdat_mutation_plan_reset(&plan);
+    return status;
+}
+
+static int secdat_mutation_plan_fill_row_identity(
+    struct secdat_mutation_impact_row *row,
+    const struct secdat_mutation_slot *slot,
+    const struct secdat_mask_view *identity_view,
+    const struct secdat_mask_view *after
+)
+{
+    if (secdat_copy_string(
+            row->domain_id,
+            sizeof(row->domain_id),
+            slot->domain_id
+        ) != 0
+        || secdat_copy_string(
+            row->store_name,
+            sizeof(row->store_name),
+            slot->store_name
+        ) != 0
+        || secdat_copy_string(
+            row->key,
+            sizeof(row->key),
+            slot->key
+        ) != 0
+        || secdat_copy_string(
+            row->key_after,
+            sizeof(row->key_after),
+            after != NULL ? after->key : slot->key
+        ) != 0) {
+        return 1;
+    }
+    if (identity_view == NULL) {
+        return 0;
+    }
+    return secdat_copy_string(
+            row->target_entry_id,
+            sizeof(row->target_entry_id),
+            identity_view->target_entry_id
+        ) != 0
+        || secdat_copy_string(
+            row->mask_chain_id,
+            sizeof(row->mask_chain_id),
+            identity_view->mask_chain_id
+        ) != 0;
 }
 
 static int secdat_mutation_plan_append_row(
@@ -46207,32 +46809,12 @@ static int secdat_mutation_plan_append_row(
     row = &plan->rows[plan->row_count];
     memset(row, 0, sizeof(*row));
     row->event = event;
-    if (secdat_copy_string(
-            row->domain_id,
-            sizeof(row->domain_id),
-            slot->domain_id
-        ) != 0
-        || secdat_copy_string(
-            row->store_name,
-            sizeof(row->store_name),
-            slot->store_name
-        ) != 0
-        || secdat_copy_string(
-            row->key,
-            sizeof(row->key),
-            slot->key
-        ) != 0
-        || (identity_view != NULL
-            && (secdat_copy_string(
-                    row->target_entry_id,
-                    sizeof(row->target_entry_id),
-                    identity_view->target_entry_id
-                ) != 0
-                || secdat_copy_string(
-                    row->mask_chain_id,
-                    sizeof(row->mask_chain_id),
-                    identity_view->mask_chain_id
-                ) != 0))) {
+    if (secdat_mutation_plan_fill_row_identity(
+            row,
+            slot,
+            identity_view,
+            after
+        ) != 0) {
         return 1;
     }
     if (view != NULL && !view->state_unknown) {
@@ -46611,11 +47193,14 @@ static int secdat_print_mutation_plan(
         json_t *root = json_object();
         json_t *counts = json_object();
         json_t *rows = json_array();
+        json_t *relation_rows = json_array();
 
-        if (root == NULL || counts == NULL || rows == NULL) {
+        if (root == NULL || counts == NULL || rows == NULL
+            || relation_rows == NULL) {
             json_decref(root);
             json_decref(counts);
             json_decref(rows);
+            json_decref(relation_rows);
             fprintf(stderr, _("failed to encode mutation plan\n"));
             return 1;
         }
@@ -46653,6 +47238,11 @@ static int secdat_print_mutation_plan(
                     item,
                     "key",
                     json_string(row->key)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "key_after",
+                    json_string(row->key_after)
                 ) != 0
                 || json_object_set_new(
                     item,
@@ -46699,6 +47289,57 @@ static int secdat_print_mutation_plan(
             }
             json_decref(item);
         }
+        for (index = 0;
+             index < plan->relation_consequence_count;
+             index += 1) {
+            const struct secdat_mutation_relation_consequence *row =
+                &plan->relation_consequences[index];
+            json_t *item = json_object();
+
+            if (item == NULL
+                || json_object_set_new(
+                    item,
+                    "domain_id",
+                    json_string(row->domain_id)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "store",
+                    json_string(row->store_name)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "relation_id",
+                    json_string(row->relation_id)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "action",
+                    json_string("rewrite-keyref")
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "source_keyref",
+                    json_string(row->source_keyref)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "destination_keyref",
+                    json_string(row->destination_keyref)
+                ) != 0
+                || json_object_set_new(
+                    item,
+                    "rewritten_member_count",
+                    json_integer(
+                        (json_int_t)row->rewritten_member_count
+                    )
+                ) != 0
+                || json_array_append(relation_rows, item) != 0) {
+                json_decref(item);
+                goto json_error;
+            }
+            json_decref(item);
+        }
         if (json_object_set_new(
                 root,
                 "plan_schema_version",
@@ -46723,6 +47364,48 @@ static int secdat_print_mutation_plan(
                 root,
                 "committed",
                 json_boolean(committed)
+            ) != 0
+            || json_object_set_new(
+                root,
+                "source_secret_id",
+                plan->has_identity_result
+                    ? json_string(plan->source_secret_id)
+                    : json_null()
+            ) != 0
+            || json_object_set_new(
+                root,
+                "destination_secret_id",
+                plan->has_identity_result
+                    ? json_string(plan->destination_secret_id)
+                    : json_null()
+            ) != 0
+            || json_object_set_new(
+                root,
+                "source_entry_id",
+                plan->has_identity_result
+                    ? json_string(plan->source_entry_id)
+                    : json_null()
+            ) != 0
+            || json_object_set_new(
+                root,
+                "destination_entry_id",
+                plan->has_identity_result
+                    ? json_string(plan->destination_entry_id)
+                    : json_null()
+            ) != 0
+            || json_object_set_new(
+                root,
+                "entry_id_preserved",
+                plan->has_identity_result
+                    ? json_boolean(plan->entry_id_preserved)
+                    : json_null()
+            ) != 0
+            || json_object_set_new(
+                root,
+                "secret_id_preserved",
+                plan->has_identity_result
+                    ? json_boolean(plan->secret_id_preserved)
+                    : json_null()
             ) != 0
             || json_object_set_new(
                 root,
@@ -46752,6 +47435,18 @@ static int secdat_print_mutation_plan(
             ) != 0
             || json_object_set(root, "mask_impact_counts", counts) != 0
             || json_object_set(root, "mask_impact_rows", rows) != 0
+            || json_object_set_new(
+                root,
+                "relation_consequence_count",
+                json_integer(
+                    (json_int_t)plan->relation_consequence_count
+                )
+            ) != 0
+            || json_object_set(
+                root,
+                "relation_consequence_rows",
+                relation_rows
+            ) != 0
             || json_dumpf(root, stdout, JSON_COMPACT | JSON_SORT_KEYS)
                 != 0) {
             goto json_error;
@@ -46759,12 +47454,14 @@ static int secdat_print_mutation_plan(
         fputc('\n', stdout);
         json_decref(counts);
         json_decref(rows);
+        json_decref(relation_rows);
         json_decref(root);
         return 0;
 
 json_error:
         json_decref(counts);
         json_decref(rows);
+        json_decref(relation_rows);
         json_decref(root);
         fprintf(stderr, _("failed to encode mutation plan\n"));
         return 1;
@@ -46776,6 +47473,20 @@ json_error:
     printf("operation=%s\n", plan->operation);
     printf("ok=%s\n", plan->rejected ? "no" : "yes");
     printf("dry_run=%s\n", plan->policy.dry_run ? "yes" : "no");
+    if (plan->has_identity_result) {
+        printf("source_secret_id=%s\n", plan->source_secret_id);
+        printf("destination_secret_id=%s\n", plan->destination_secret_id);
+        printf("source_entry_id=%s\n", plan->source_entry_id);
+        printf("destination_entry_id=%s\n", plan->destination_entry_id);
+        printf(
+            "entry_id_preserved=%s\n",
+            plan->entry_id_preserved ? "yes" : "no"
+        );
+        printf(
+            "secret_id_preserved=%s\n",
+            plan->secret_id_preserved ? "yes" : "no"
+        );
+    }
     printf(
         "mask_action=%s\n",
         secdat_mutation_action_name(plan->policy.action)
@@ -46815,6 +47526,26 @@ json_error:
             row->has_state_after
                 ? secdat_mask_state_name(row->state_after)
                 : "-"
+        );
+    }
+    printf(
+        "relation_consequence_count=%zu\n",
+        plan->relation_consequence_count
+    );
+    for (index = 0;
+         index < plan->relation_consequence_count;
+         index += 1) {
+        const struct secdat_mutation_relation_consequence *row =
+            &plan->relation_consequences[index];
+
+        printf(
+            "relation_consequence_row=%s:%s:%s:%s:%s:%zu\n",
+            row->domain_id,
+            row->store_name,
+            row->relation_id,
+            row->source_keyref,
+            row->destination_keyref,
+            row->rewritten_member_count
         );
     }
     return 0;
@@ -47332,7 +48063,9 @@ int secdat_run_command(const struct secdat_cli *cli)
         secdat_mutation_lock_release(lock_owned);
         return 1;
     }
-    if (secdat_cli_requests_ephemeral_mutation(cli)) {
+    if (cli->command == SECDAT_COMMAND_MV) {
+        status = secdat_run_planned_mv(cli);
+    } else if (secdat_cli_requests_ephemeral_mutation(cli)) {
         status = secdat_run_ephemeral_mutation(cli);
     } else {
         status = secdat_command_uses_mutation_plan(cli->command)

--- a/src/store.c
+++ b/src/store.c
@@ -748,6 +748,7 @@ enum secdat_mutation_slot_operation {
 
 enum secdat_mutation_impact_event {
     SECDAT_MUTATION_IMPACT_DIRECT_HIT = 0,
+    SECDAT_MUTATION_IMPACT_FOLLOWED,
     SECDAT_MUTATION_IMPACT_BECAME_DORMANT,
     SECDAT_MUTATION_IMPACT_REACTIVATED,
     SECDAT_MUTATION_IMPACT_ORPHANED,
@@ -1417,6 +1418,11 @@ static int secdat_mutation_plan_append_row(
     const struct secdat_mask_view *view,
     enum secdat_mutation_impact_event event,
     const struct secdat_mask_view *after
+);
+static int secdat_mutation_collect_slot_impacts(
+    struct secdat_mutation_plan *plan,
+    const struct secdat_mutation_slot *slot,
+    int *hard_error
 );
 static int secdat_print_mutation_plan(
     const struct secdat_mutation_plan *plan,
@@ -23027,6 +23033,31 @@ static int secdat_transaction_append_prepared_write_set(
     return 0;
 }
 
+static size_t secdat_transaction_changed_write_count(
+    const struct secdat_transaction *transaction
+)
+{
+    size_t changed = 0;
+    size_t index;
+
+    for (index = 0; index < transaction->target_count; index += 1) {
+        const struct secdat_transaction_target *target =
+            &transaction->targets[index];
+
+        if (target->is_guard
+            || (target->before_exists == target->after_exists
+                && (!target->before_exists
+                    || strcmp(
+                        target->before_digest,
+                        target->after_digest
+                    ) == 0))) {
+            continue;
+        }
+        changed += 1;
+    }
+    return changed;
+}
+
 static int secdat_transaction_mark_source_removal(
     struct secdat_transaction *transaction,
     const char *source_path
@@ -25203,11 +25234,15 @@ static int secdat_read_v2_mask_record(
     int seen_key_visibility = 0;
     int seen_key_encryption = 0;
     int valid = 0;
+    int projected;
 
     memset(record, 0, sizeof(*record));
-    if (lstat(path, &file_status) != 0
-        || !S_ISREG(file_status.st_mode)
-        || (file_status.st_mode & 077) != 0
+    projected = secdat_projected_file_exists(path);
+    if (projected == 0
+        || (projected < 0
+            && (lstat(path, &file_status) != 0
+                || !S_ISREG(file_status.st_mode)
+                || (file_status.st_mode & 077) != 0))
         || !secdat_uuid_is_valid(file_target_entry_id)
         || secdat_read_v2_text_file(path, secdat_v2_mask_magic, &text, &length) != 0) {
         return 1;
@@ -41979,7 +42014,7 @@ static int secdat_mutation_plan_capture_mv_masks(
                 plan,
                 &slot,
                 &view,
-                SECDAT_MUTATION_IMPACT_DIRECT_HIT,
+                SECDAT_MUTATION_IMPACT_FOLLOWED,
                 NULL
             ) != 0) {
             goto cleanup;
@@ -42071,7 +42106,7 @@ static int secdat_mutation_plan_finish_mv_masks(
         struct secdat_mutation_impact_row *row = &plan->rows[index];
         struct secdat_mask_view after;
 
-        if (row->event != SECDAT_MUTATION_IMPACT_DIRECT_HIT
+        if (row->event != SECDAT_MUTATION_IMPACT_FOLLOWED
             || strcmp(row->target_entry_id, target_entry_id) != 0) {
             continue;
         }
@@ -42095,6 +42130,48 @@ static int secdat_mutation_plan_finish_mv_masks(
                 plan,
                 row,
                 &after
+            ) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int secdat_mutation_plan_collect_mv_slots(
+    struct secdat_mutation_plan *plan,
+    const char *domain_id,
+    const char *store_name,
+    const char *source_key,
+    const char *destination_key,
+    int *hard_error
+)
+{
+    size_t index;
+
+    if (plan == NULL) {
+        return 0;
+    }
+    if (secdat_mutation_slot_list_append(
+            &plan->slots,
+            domain_id,
+            store_name,
+            source_key,
+            SECDAT_MUTATION_SLOT_REMOVE
+        ) != 0
+        || secdat_mutation_slot_list_append(
+            &plan->slots,
+            domain_id,
+            store_name,
+            destination_key,
+            SECDAT_MUTATION_SLOT_WRITE
+        ) != 0) {
+        return 1;
+    }
+    for (index = 0; index < plan->slots.count; index += 1) {
+        if (secdat_mutation_collect_slot_impacts(
+                plan,
+                &plan->slots.items[index],
+                hard_error
             ) != 0) {
             return 1;
         }
@@ -42744,6 +42821,7 @@ static int secdat_move_v2_entry(
     struct secdat_mutation_plan *mutation_plan = NULL;
     int source_is_local;
     int same_namespace;
+    int hard_error = 0;
     int need_source_mask = 0;
     int precommit_status;
     int unsafe_store = 0;
@@ -43139,6 +43217,14 @@ static int secdat_move_v2_entry(
     if (secdat_mutation_plan_finish_mv_masks(
             mutation_plan,
             source_entry.entry_id
+        ) != 0
+        || secdat_mutation_plan_collect_mv_slots(
+            mutation_plan,
+            source_domain_id,
+            source_reference->store_value,
+            source_reference->key,
+            destination_reference->key,
+            &hard_error
         ) != 0) {
         goto cleanup;
     }
@@ -43173,13 +43259,14 @@ static int secdat_move_v2_entry(
         goto cleanup;
     }
     if (mutation_plan != NULL) {
-        mutation_plan->changed_file_count = changed_file_count;
-        mutation_plan->rejected =
-            mutation_plan->policy.action == SECDAT_MUTATION_MASK_REJECT
-            && mutation_plan->row_count > 0;
+        mutation_plan->changed_file_count =
+            secdat_transaction_changed_write_count(&transaction);
+        mutation_plan->rejected = hard_error
+            || (mutation_plan->policy.action == SECDAT_MUTATION_MASK_REJECT
+                && mutation_plan->row_count > 0);
         precommit_status = secdat_render_scoped_precommit(
             mutation_plan,
-            0,
+            hard_error,
             &status
         );
         if (precommit_status < 0) {
@@ -46689,6 +46776,8 @@ static const char *secdat_mutation_impact_event_name(
     switch (event) {
     case SECDAT_MUTATION_IMPACT_DIRECT_HIT:
         return "direct-hit";
+    case SECDAT_MUTATION_IMPACT_FOLLOWED:
+        return "followed";
     case SECDAT_MUTATION_IMPACT_BECAME_DORMANT:
         return "became-dormant";
     case SECDAT_MUTATION_IMPACT_REACTIVATED:
@@ -47536,10 +47625,11 @@ json_error:
             &plan->rows[index];
 
         printf(
-            "mask_impact_row=%s:%s:%s:%s:%s:%s\n",
+            "mask_impact_row=%s:%s:%s:%s:%s:%s:%s\n",
             row->domain_id,
             row->store_name,
             row->key,
+            row->key_after,
             secdat_mutation_impact_event_name(row->event),
             row->has_state_before
                 ? secdat_mask_state_name(row->state_before)
@@ -47596,6 +47686,10 @@ static void secdat_mutation_emit_warning(
     SECDAT_MUTATION_WARNING_FACT(
         SECDAT_MUTATION_IMPACT_DIRECT_HIT,
         _("%zu directly affected masked key slot(s)")
+    );
+    SECDAT_MUTATION_WARNING_FACT(
+        SECDAT_MUTATION_IMPACT_FOLLOWED,
+        _("%zu mask(s) followed preserved entry identity")
     );
     SECDAT_MUTATION_WARNING_FACT(
         SECDAT_MUTATION_IMPACT_BECAME_DORMANT,

--- a/src/store.c
+++ b/src/store.c
@@ -29127,16 +29127,37 @@ static int secdat_dependency_mask_edge_validate(
     size_t *edge_count
 )
 {
+    const char *kind = json_string_value(json_object_get(edge, "kind"));
+    const char *edge_target_entry_id = json_string_value(
+        json_object_get(edge, "target_entry_id")
+    );
     const char *mask_domain = json_string_value(json_object_get(edge, "mask_domain_id"));
     const char *mask_store = json_string_value(json_object_get(edge, "mask_store"));
     const char *record_id = json_string_value(json_object_get(edge, "mask_record_id"));
     const char *primary_digest = json_string_value(json_object_get(edge, "primary_digest"));
+    const char *required_fields[] = {
+        kind,
+        edge_target_entry_id,
+        mask_domain,
+        mask_store,
+        record_id,
+        primary_digest,
+    };
     char mask_path[PATH_MAX];
     char actual_digest[SECDAT_SHA256_HEX_LENGTH + 1];
     struct secdat_v2_mask_record record;
+    size_t field_index;
 
-    if (strcmp(json_string_value(json_object_get(edge, "kind")), "mask-edge") != 0
-        || strcmp(json_string_value(json_object_get(edge, "target_entry_id")), target_entry_id) != 0
+    for (field_index = 0;
+         field_index < sizeof(required_fields) / sizeof(required_fields[0]);
+         field_index += 1) {
+        if (required_fields[field_index] == NULL) {
+            return 1;
+        }
+    }
+
+    if (strcmp(kind, "mask-edge") != 0
+        || strcmp(edge_target_entry_id, target_entry_id) != 0
         || strcmp(record_id, target_entry_id) != 0
         || secdat_build_v2_mask_path(
             mask_domain,

--- a/tests/completion_regression.sh
+++ b/tests/completion_regression.sh
@@ -409,6 +409,11 @@ if mode != "plain":
 mode, values, _ = run_completion("mv", "")
 if mode != "plain":
     raise SystemExit(f"FAIL: mv completion mode mismatch: {mode!r}")
+for expected in [
+    "--mask-action", "--mask-warnings", "--warn-mask", "--no-warn-mask",
+    "--dry-run", "--json",
+]:
+    assert_contains(values, expected, "mv options")
 
 mode, values, _ = run_completion("ln", "")
 if mode != "plain":

--- a/tests/mv_transaction_regression.sh
+++ b/tests/mv_transaction_regression.sh
@@ -138,6 +138,7 @@ for key, value in (
     ("CRASH_MOVE", "crash-value"),
     ("CROSS_MOVE", "cross-value"),
     ("HIDDEN_MOVE", "hidden-value"),
+    ("INACCESSIBLE_MOVE", "inaccessible-value"),
 ):
     set_key(root, key, value)
 
@@ -176,9 +177,20 @@ require_ok(
     ),
     "crash relation setup",
 )
+require_ok(
+    run(
+        "--dir", str(root), "relation", "set", "inaccessible-pair",
+        "--member", "first=INACCESSIBLE_MOVE", "--member", "second=OTHER",
+    ),
+    "inaccessible relation setup",
+)
 require_ok(run("--dir", str(child), "mask", "MOVE_MASK"), "mask setup")
 require_ok(run("--dir", str(child), "mask", "CRASH_MOVE"), "crash mask setup")
 require_ok(run("--dir", str(child), "mask", "HIDDEN_MOVE"), "hidden mask setup")
+require_ok(
+    run("--dir", str(child), "mask", "INACCESSIBLE_MOVE"),
+    "inaccessible mask setup",
+)
 
 move_secret = secret_id(root, "MOVE_MASK")
 move_entry = entry_id(root_id, move_secret, "MOVE_MASK")
@@ -286,6 +298,57 @@ require_ok(
     "dependency validation after dependent mv",
     "ok\n",
 )
+
+inaccessible_secret = secret_id(root, "INACCESSIBLE_MOVE")
+inaccessible_entry = entry_id(
+    root_id,
+    inaccessible_secret,
+    "INACCESSIBLE_MOVE",
+)
+inaccessible_mask = (
+    state_root
+    / "domains/by-id"
+    / child_id
+    / "stores/default/masks"
+    / f"{inaccessible_entry}.mask"
+)
+inaccessible_mask_before = inaccessible_mask.read_bytes()
+inaccessible_mask_mode = inaccessible_mask.stat().st_mode & 0o777
+inaccessible_relation_before = run(
+    "--dir", str(root), "relation", "show", "inaccessible-pair",
+)
+require_ok(
+    inaccessible_relation_before,
+    "inaccessible relation before rejected mv",
+    stdout=None,
+)
+inaccessible_mask.chmod(0)
+try:
+    inaccessible_move = run(
+        "--dir", str(root), "mv",
+        "INACCESSIBLE_MOVE", "INACCESSIBLE_MOVED",
+    )
+finally:
+    inaccessible_mask.chmod(inaccessible_mask_mode)
+if inaccessible_move.returncode != 1:
+    fail(f"inaccessible descendant mv was not rejected safely: {inaccessible_move}")
+if secret_id(root, "INACCESSIBLE_MOVE") != inaccessible_secret:
+    fail("inaccessible descendant mv changed the source identity")
+if entry_id(root_id, inaccessible_secret, "INACCESSIBLE_MOVE") != inaccessible_entry:
+    fail("inaccessible descendant mv changed the source entry")
+require_missing(root, "INACCESSIBLE_MOVED", "inaccessible descendant mv")
+if inaccessible_mask.read_bytes() != inaccessible_mask_before:
+    fail("inaccessible descendant mv changed the affected mask")
+inaccessible_relation_after = run(
+    "--dir", str(root), "relation", "show", "inaccessible-pair",
+)
+require_ok(
+    inaccessible_relation_after,
+    "inaccessible relation after rejected mv",
+    stdout=inaccessible_relation_before.stdout,
+)
+if run("--dir", str(child), "get", "INACCESSIBLE_MOVE").returncode == 0:
+    fail("inaccessible descendant mv lost the original identity mask")
 
 hidden_secret = secret_id(root, "HIDDEN_MOVE")
 hidden_entry = entry_id(root_id, hidden_secret)

--- a/tests/mv_transaction_regression.sh
+++ b/tests/mv_transaction_regression.sh
@@ -27,7 +27,8 @@ env.update(LC_ALL="C", LANGUAGE="C", SECDAT_MASTER_KEY="mv-transaction-master-ke
 root = work_root / "root"
 child = root / "child"
 destination = work_root / "destination"
-for path in (root, child, destination):
+legacy = work_root / "legacy"
+for path in (root, child, destination, legacy):
     path.mkdir(parents=True, exist_ok=True)
 state_root = Path(env["XDG_DATA_HOME"]) / "secdat"
 
@@ -125,9 +126,26 @@ def require_missing(path, key, label):
         fail(f"{label}: key still exists: {key}")
 
 
+def state_snapshot():
+    snapshot = {}
+    for path in sorted(state_root.rglob("*")):
+        relative = path.relative_to(state_root)
+        if path.is_file() and "transactions" not in relative.parts:
+            snapshot[str(relative)] = path.read_bytes()
+    return snapshot
+
+
+def manifest_changed_write_count(manifest):
+    return sum(
+        item.get("before") != item.get("after")
+        for item in manifest.get("writes", [])
+    )
+
+
 root_id = domain_id(root)
 child_id = domain_id(child)
 destination_id = domain_id(destination)
+domain_id(legacy)
 for path in (root, child, destination):
     migrate(path)
 
@@ -139,8 +157,16 @@ for key, value in (
     ("CROSS_MOVE", "cross-value"),
     ("HIDDEN_MOVE", "hidden-value"),
     ("INACCESSIBLE_MOVE", "inaccessible-value"),
+    ("WARNING_MOVE", "warning-value"),
+    ("FALLBACK_MOVE", "parent-fallback-value"),
+    ("DESTINATION_MASK", "destination-fallback-value"),
+    ("INHERITED_BOUNDARY", "inherited-boundary-value"),
+    ("CROSS_BOUNDARY", "cross-boundary-value"),
 ):
     set_key(root, key, value)
+set_key(child, "FALLBACK_MOVE", "child-override-value")
+set_key(child, "DESTINATION_SOURCE", "destination-source-value")
+set_key(legacy, "V1_MOVE", "v1-move-value")
 
 require_ok(
     run("--dir", str(root), "fsck", "--format", "v2", "--dependency-index", "--repair"),
@@ -187,10 +213,109 @@ require_ok(
 require_ok(run("--dir", str(child), "mask", "MOVE_MASK"), "mask setup")
 require_ok(run("--dir", str(child), "mask", "CRASH_MOVE"), "crash mask setup")
 require_ok(run("--dir", str(child), "mask", "HIDDEN_MOVE"), "hidden mask setup")
+require_ok(run("--dir", str(child), "mask", "WARNING_MOVE"), "warning mask setup")
 require_ok(
     run("--dir", str(child), "mask", "INACCESSIBLE_MOVE"),
     "inaccessible mask setup",
 )
+require_ok(
+    run("--dir", str(child), "mask", "DESTINATION_MASK"),
+    "destination mask setup",
+)
+
+fallback_secret = secret_id(child, "FALLBACK_MOVE")
+fallback_before = state_snapshot()
+fallback_reject = run(
+    "--dir", str(child), "mv", "--mask-action=reject", "--json",
+    "FALLBACK_MOVE", "FALLBACK_MOVED",
+)
+if fallback_reject.returncode == 0 or fallback_reject.stderr:
+    fail(f"source fallback mv reject mismatch: {fallback_reject}")
+fallback_report = json.loads(fallback_reject.stdout)
+fallback_rows = [
+    row for row in fallback_report["mask_impact_rows"]
+    if row.get("event") == "source-mask-created"
+]
+if (
+    fallback_report.get("ok")
+    or fallback_report.get("committed")
+    or fallback_report["mask_impact_counts"].get("source-mask-created") != 1
+    or len(fallback_rows) != 1
+    or fallback_rows[0].get("key") != "FALLBACK_MOVE"
+    or secret_id(child, "FALLBACK_MOVE") != fallback_secret
+    or state_snapshot() != fallback_before
+):
+    fail(f"source fallback mv plan mismatch: {fallback_report!r}")
+require_missing(child, "FALLBACK_MOVED", "source fallback rejected mv")
+
+destination_source_secret = secret_id(child, "DESTINATION_SOURCE")
+destination_before = state_snapshot()
+destination_dry = run(
+    "--dir", str(child), "mv", "--dry-run", "--json",
+    "DESTINATION_SOURCE", "DESTINATION_MASK",
+)
+require_ok(destination_dry, "destination mask mv dry-run", stdout=None)
+destination_dry_report = json.loads(destination_dry.stdout)
+destination_direct_rows = [
+    row for row in destination_dry_report["mask_impact_rows"]
+    if row.get("event") == "direct-hit"
+]
+if (
+    destination_dry_report["mask_impact_counts"].get("direct-hit") != 1
+    or destination_dry_report["mask_impact_counts"].get("became-dormant") != 1
+    or len(destination_direct_rows) != 1
+    or destination_direct_rows[0].get("key") != "DESTINATION_MASK"
+    or destination_direct_rows[0].get("state_before") != "active"
+    or destination_direct_rows[0].get("state_after") != "dormant"
+    or secret_id(child, "DESTINATION_SOURCE") != destination_source_secret
+    or state_snapshot() != destination_before
+):
+    fail(f"destination mask mv dry-run mismatch: {destination_dry_report!r}")
+require_missing(child, "DESTINATION_MASK", "destination mask dry-run")
+
+destination_reject = run(
+    "--dir", str(child), "mv", "--mask-action=reject", "--json",
+    "DESTINATION_SOURCE", "DESTINATION_MASK",
+)
+if destination_reject.returncode == 0 or destination_reject.stderr:
+    fail(f"destination mask mv reject mismatch: {destination_reject}")
+destination_reject_report = json.loads(destination_reject.stdout)
+if (
+    destination_reject_report["mask_impact_rows"]
+    != destination_dry_report["mask_impact_rows"]
+    or secret_id(child, "DESTINATION_SOURCE") != destination_source_secret
+    or state_snapshot() != destination_before
+):
+    fail(f"destination mask mv reject plan mismatch: {destination_reject_report!r}")
+require_missing(child, "DESTINATION_MASK", "destination mask rejected mv")
+
+destination_commit = run(
+    "--dir", str(child), "mv", "--no-warn-mask", "--json",
+    "DESTINATION_SOURCE", "DESTINATION_MASK",
+)
+require_ok(destination_commit, "destination mask mv commit", stdout=None)
+destination_commit_report = json.loads(destination_commit.stdout)
+if (
+    destination_commit_report["mask_impact_rows"]
+    != destination_dry_report["mask_impact_rows"]
+    or secret_id(child, "DESTINATION_MASK") != destination_source_secret
+):
+    fail(f"destination mask mv commit plan mismatch: {destination_commit_report!r}")
+require_missing(child, "DESTINATION_SOURCE", "destination mask committed mv")
+
+warning_move = run(
+    "--dir", str(root), "mv", "--json",
+    "WARNING_MOVE", "WARNING_MOVED",
+)
+expected_warning = (
+    "warning: mv: 1 mask(s) followed preserved entry identity; "
+    "inspect with 'secdat --dir DIR list --all-masks --long'\n"
+)
+if warning_move.returncode != 0 or warning_move.stderr != expected_warning:
+    fail(f"followed mask warning mismatch: {warning_move}")
+warning_report = json.loads(warning_move.stdout)
+if warning_report["mask_impact_counts"].get("followed") != 1:
+    fail(f"followed mask warning plan mismatch: {warning_report!r}")
 
 move_secret = secret_id(root, "MOVE_MASK")
 move_entry = entry_id(root_id, move_secret, "MOVE_MASK")
@@ -203,15 +328,27 @@ refcount_before_move = (
 epoch_path = state_root / "gc/reference-epoch"
 epoch_before_same = epoch_path.read_bytes()
 
+human_dry_run = run(
+    "--dir", str(root), "mv", "--dry-run",
+    "MOVE_MASK", "MOVE_MASKED",
+)
+require_ok(human_dry_run, "dependent mv human dry-run", stdout=None)
+expected_human_row = (
+    f"mask_impact_row={child_id}:default:MOVE_MASK:MOVE_MASKED:"
+    "followed:active:active\n"
+)
+if expected_human_row not in human_dry_run.stdout:
+    fail(f"dependent mv human row mismatch: {human_dry_run.stdout!r}")
+
 dry_run = run(
     "--dir", str(root), "mv", "--dry-run", "--json",
     "MOVE_MASK", "MOVE_MASKED",
 )
 require_ok(dry_run, "dependent mv dry-run", stdout=None)
 dry_report = json.loads(dry_run.stdout)
-direct_rows = [
+followed_rows = [
     row for row in dry_report["mask_impact_rows"]
-    if row.get("event") == "direct-hit"
+    if row.get("event") == "followed"
 ]
 relation_rows = dry_report["relation_consequence_rows"]
 if (
@@ -225,10 +362,10 @@ if (
     or dry_report.get("destination_entry_id") != move_entry
     or dry_report.get("entry_id_preserved") is not True
     or dry_report.get("secret_id_preserved") is not True
-    or dry_report["mask_impact_counts"].get("direct-hit") != 1
-    or len(direct_rows) != 1
-    or direct_rows[0].get("key") != "MOVE_MASK"
-    or direct_rows[0].get("key_after") != "MOVE_MASKED"
+    or dry_report["mask_impact_counts"].get("followed") != 1
+    or len(followed_rows) != 1
+    or followed_rows[0].get("key") != "MOVE_MASK"
+    or followed_rows[0].get("key_after") != "MOVE_MASKED"
     or dry_report.get("relation_consequence_count") != 1
     or len(relation_rows) != 1
     or relation_rows[0].get("relation_id") != "move-pair"
@@ -241,6 +378,31 @@ if secret_id(root, "MOVE_MASK") != move_secret:
 require_missing(root, "MOVE_MASKED", "mv dry-run")
 if secret_id(root, "MOVE_ALIAS") != move_secret:
     fail("mv dry-run changed the linked alias")
+
+dependent_prepared = run(
+    "--dir", str(root), "mv", "MOVE_MASK", "MOVE_MASKED",
+    extra_env={"SECDAT_TEST_TRANSACTION_CRASH_AFTER": "prepared"},
+)
+if dependent_prepared.returncode != 86:
+    fail(f"dependent mv did not stop at PREPARED: {dependent_prepared}")
+operations = pending_transactions()
+if len(operations) != 1:
+    fail(f"expected one dependent PREPARED mv transaction: {operations!r}")
+dependent_manifest = json.loads(
+    (operations[0] / "journal").read_text(encoding="utf-8").splitlines()[1]
+)
+if (
+    dry_report.get("changed_file_count")
+    != manifest_changed_write_count(dependent_manifest)
+):
+    fail(
+        "dependent mv dry-run write count does not match final manifest: "
+        f"{dry_report!r} {dependent_manifest!r}"
+    )
+require_ok(run("--dir", str(root), "status", "--quiet"), "dependent PREPARED cleanup")
+if secret_id(root, "MOVE_MASK") != move_secret:
+    fail("dependent PREPARED cleanup changed the source identity")
+require_missing(root, "MOVE_MASKED", "dependent PREPARED cleanup")
 
 rejected = run(
     "--dir", str(root), "mv", "--mask-action=reject", "--json",
@@ -263,6 +425,8 @@ require_ok(committed, "dependent mv", stdout=None)
 commit_report = json.loads(committed.stdout)
 if not commit_report.get("committed") or not commit_report.get("ok"):
     fail(f"dependent mv commit report mismatch: {commit_report!r}")
+if commit_report.get("changed_file_count") != dry_report.get("changed_file_count"):
+    fail(f"dependent mv dry-run/commit write count mismatch: {commit_report!r}")
 if secret_id(root, "MOVE_MASKED") != move_secret or entry_id(root_id, move_secret, "MOVE_MASKED") != move_entry:
     fail("same-namespace mv did not preserve entry and secret UUIDs")
 if secret_id(root, "MOVE_ALIAS") != move_secret or entry_id(root_id, move_secret, "MOVE_ALIAS") != alias_entry:
@@ -364,6 +528,12 @@ require_missing(root, "HIDDEN_MOVED", "locked hidden mv")
 
 prepared_secret = secret_id(root, "PREPARED_MOVE")
 prepared_entry = entry_id(root_id, prepared_secret)
+prepared_dry = run(
+    "--dir", str(root), "mv", "--dry-run", "--json",
+    "PREPARED_MOVE", "PREPARED_MOVED",
+)
+require_ok(prepared_dry, "PREPARED mv dry-run", stdout=None)
+prepared_dry_report = json.loads(prepared_dry.stdout)
 prepared = run(
     "--dir", str(root), "mv", "PREPARED_MOVE", "PREPARED_MOVED",
     extra_env={"SECDAT_TEST_TRANSACTION_CRASH_AFTER": "prepared"},
@@ -376,6 +546,14 @@ if len(operations) != 1:
 manifest = json.loads((operations[0] / "journal").read_text(encoding="utf-8").splitlines()[1])
 if manifest.get("command") != "mv" or manifest.get("state") != "prepared":
     fail(f"invalid PREPARED mv manifest: {manifest!r}")
+if (
+    prepared_dry_report.get("changed_file_count")
+    != manifest_changed_write_count(manifest)
+):
+    fail(
+        "PREPARED mv dry-run write count does not match final manifest: "
+        f"{prepared_dry_report!r} {manifest!r}"
+    )
 require_ok(run("--dir", str(root), "status", "--quiet"), "PREPARED mv cleanup")
 if pending_transactions() or secret_id(root, "PREPARED_MOVE") != prepared_secret:
     fail("PREPARED mv cleanup changed the source")
@@ -463,6 +641,30 @@ require_ok(
     "dependency validation after cross mv",
     "ok\n",
 )
+
+unsupported_cases = (
+    ("inherited", lambda options: run(
+        "--dir", str(child), "mv", *options,
+        "INHERITED_BOUNDARY", "INHERITED_MOVED",
+    )),
+    ("cross-domain", lambda options: run(
+        "mv", *options,
+        f"{root}/CROSS_BOUNDARY", f"{destination}/CROSS_BOUNDARY_MOVED",
+    )),
+    ("v1", lambda options: run(
+        "--dir", str(legacy), "mv", *options,
+        "V1_MOVE", "V1_MOVED",
+    )),
+)
+for boundary, invoke in unsupported_cases:
+    for options in (("--dry-run",), ("--json",), ("--mask-action=reject",)):
+        before = state_snapshot()
+        unsupported = invoke(options)
+        if unsupported.returncode == 0 or state_snapshot() != before:
+            fail(
+                f"unsupported {boundary} mv planning was not all-before "
+                f"for {options}: {unsupported}"
+            )
 
 print("PASS mv transaction regression")
 PY

--- a/tests/mv_transaction_regression.sh
+++ b/tests/mv_transaction_regression.sh
@@ -92,15 +92,37 @@ def secret_id(path, key):
     return result.stdout.strip()
 
 
-def entry_id(owner_id, secret):
+def entry_id(owner_id, secret, key=None):
     entry_dir = state_root / "domains/by-id" / owner_id / "stores/default/domain-ent"
     matches = [
         path.stem for path in entry_dir.glob("*.dent")
-        if f"secret_id={secret}\n" in path.read_text(encoding="utf-8")
+        if (
+            f"secret_id={secret}\n" in path.read_text(encoding="utf-8")
+            and (
+                key is None
+                or f"key={key}\n" in path.read_text(encoding="utf-8")
+            )
+        )
     ]
     if len(matches) != 1:
-        fail(f"expected one entry for {secret}, found {matches!r}")
+        fail(f"expected one entry for {secret} key={key!r}, found {matches!r}")
     return matches[0]
+
+
+def secret_status(path, secret):
+    result = run("--dir", str(path), "secret", "status", secret)
+    require_ok(result, f"secret status {secret}", stdout=None)
+    return dict(
+        line.split("=", 1)
+        for line in result.stdout.splitlines()
+        if "=" in line
+    )
+
+
+def require_missing(path, key, label):
+    result = run("--dir", str(path), "exists", key)
+    if result.returncode == 0:
+        fail(f"{label}: key still exists: {key}")
 
 
 root_id = domain_id(root)
@@ -115,6 +137,7 @@ for key, value in (
     ("PREPARED_MOVE", "prepared-value"),
     ("CRASH_MOVE", "crash-value"),
     ("CROSS_MOVE", "cross-value"),
+    ("HIDDEN_MOVE", "hidden-value"),
 ):
     set_key(root, key, value)
 
@@ -125,20 +148,119 @@ require_ok(
 )
 require_ok(
     run(
+        "--dir", str(root), "attr", "HIDDEN_MOVE",
+        "--key-visibility", "unlocked",
+    ),
+    "hide move source",
+)
+require_ok(
+    run("--dir", str(root), "ln", "MOVE_MASK", "MOVE_ALIAS"),
+    "move alias setup",
+)
+require_ok(
+    run("--dir", str(root), "ln", "CRASH_MOVE", "CRASH_ALIAS"),
+    "crash move alias setup",
+)
+
+require_ok(
+    run(
         "--dir", str(root), "relation", "set", "move-pair",
         "--member", "first=MOVE_MASK", "--member", "second=OTHER",
     ),
     "relation setup",
 )
+require_ok(
+    run(
+        "--dir", str(root), "relation", "set", "crash-pair",
+        "--member", "first=CRASH_MOVE", "--member", "second=OTHER",
+    ),
+    "crash relation setup",
+)
 require_ok(run("--dir", str(child), "mask", "MOVE_MASK"), "mask setup")
+require_ok(run("--dir", str(child), "mask", "CRASH_MOVE"), "crash mask setup")
+require_ok(run("--dir", str(child), "mask", "HIDDEN_MOVE"), "hidden mask setup")
 
 move_secret = secret_id(root, "MOVE_MASK")
-move_entry = entry_id(root_id, move_secret)
+move_entry = entry_id(root_id, move_secret, "MOVE_MASK")
+alias_entry = entry_id(root_id, move_secret, "MOVE_ALIAS")
+move_status_before = secret_status(root, move_secret)
+refcount_before_move = (
+    move_status_before["refcount_cached"],
+    move_status_before["refcount_actual"],
+)
 epoch_path = state_root / "gc/reference-epoch"
 epoch_before_same = epoch_path.read_bytes()
-require_ok(run("--dir", str(root), "mv", "MOVE_MASK", "MOVE_MASKED"), "dependent mv")
-if secret_id(root, "MOVE_MASKED") != move_secret or entry_id(root_id, move_secret) != move_entry:
+
+dry_run = run(
+    "--dir", str(root), "mv", "--dry-run", "--json",
+    "MOVE_MASK", "MOVE_MASKED",
+)
+require_ok(dry_run, "dependent mv dry-run", stdout=None)
+dry_report = json.loads(dry_run.stdout)
+direct_rows = [
+    row for row in dry_report["mask_impact_rows"]
+    if row.get("event") == "direct-hit"
+]
+relation_rows = dry_report["relation_consequence_rows"]
+if (
+    dry_report.get("operation") != "mv"
+    or not dry_report.get("ok")
+    or not dry_report.get("dry_run")
+    or dry_report.get("committed")
+    or dry_report.get("source_secret_id") != move_secret
+    or dry_report.get("destination_secret_id") != move_secret
+    or dry_report.get("source_entry_id") != move_entry
+    or dry_report.get("destination_entry_id") != move_entry
+    or dry_report.get("entry_id_preserved") is not True
+    or dry_report.get("secret_id_preserved") is not True
+    or dry_report["mask_impact_counts"].get("direct-hit") != 1
+    or len(direct_rows) != 1
+    or direct_rows[0].get("key") != "MOVE_MASK"
+    or direct_rows[0].get("key_after") != "MOVE_MASKED"
+    or dry_report.get("relation_consequence_count") != 1
+    or len(relation_rows) != 1
+    or relation_rows[0].get("relation_id") != "move-pair"
+    or relation_rows[0].get("action") != "rewrite-keyref"
+    or relation_rows[0].get("rewritten_member_count") != 1
+):
+    fail(f"dependent mv dry-run report mismatch: {dry_report!r}")
+if secret_id(root, "MOVE_MASK") != move_secret:
+    fail("mv dry-run changed the source identity")
+require_missing(root, "MOVE_MASKED", "mv dry-run")
+if secret_id(root, "MOVE_ALIAS") != move_secret:
+    fail("mv dry-run changed the linked alias")
+
+rejected = run(
+    "--dir", str(root), "mv", "--mask-action=reject", "--json",
+    "MOVE_MASK", "MOVE_MASKED",
+)
+if rejected.returncode == 0 or rejected.stderr:
+    fail(f"dependent mv reject mismatch: {rejected}")
+reject_report = json.loads(rejected.stdout)
+if reject_report.get("ok") or reject_report.get("committed"):
+    fail(f"dependent mv reject report mismatch: {reject_report!r}")
+if secret_id(root, "MOVE_MASK") != move_secret:
+    fail("rejected mv changed the source identity")
+require_missing(root, "MOVE_MASKED", "rejected mv")
+
+committed = run(
+    "--dir", str(root), "mv", "--no-warn-mask", "--json",
+    "MOVE_MASK", "MOVE_MASKED",
+)
+require_ok(committed, "dependent mv", stdout=None)
+commit_report = json.loads(committed.stdout)
+if not commit_report.get("committed") or not commit_report.get("ok"):
+    fail(f"dependent mv commit report mismatch: {commit_report!r}")
+if secret_id(root, "MOVE_MASKED") != move_secret or entry_id(root_id, move_secret, "MOVE_MASKED") != move_entry:
     fail("same-namespace mv did not preserve entry and secret UUIDs")
+if secret_id(root, "MOVE_ALIAS") != move_secret or entry_id(root_id, move_secret, "MOVE_ALIAS") != alias_entry:
+    fail("same-namespace mv changed the linked alias identity")
+move_status_after = secret_status(root, move_secret)
+if (
+    move_status_after["refcount_cached"],
+    move_status_after["refcount_actual"],
+) != refcount_before_move:
+    fail("same-namespace mv changed the linked secret refcount")
 if epoch_path.read_bytes() != epoch_before_same:
     fail("same-namespace mv rotated the reference epoch")
 relation = run("--dir", str(root), "relation", "show", "move-pair")
@@ -148,13 +270,34 @@ if "/MOVE_MASK:default" in relation.stdout or "/MOVE_MASKED:default" not in rela
 masked = run("--dir", str(child), "get", "MOVE_MASKED")
 if masked.returncode == 0:
     fail("identity mask did not follow the moved entry")
+require_ok(
+    run("--dir", str(root), "set", "MOVE_ALIAS", "--value", "linked-update"),
+    "linked alias update after mv",
+)
+require_ok(
+    run("--dir", str(root), "get", "MOVE_MASKED"),
+    "moved entry after linked alias update",
+    "linked-update",
+)
 require_ok(run("--dir", str(child), "unmask", "MOVE_MASKED"), "unmask moved entry")
-require_ok(run("--dir", str(child), "get", "MOVE_MASKED"), "unmasked moved value", "masked-value")
+require_ok(run("--dir", str(child), "get", "MOVE_MASKED"), "unmasked moved value", "linked-update")
 require_ok(
     run("--dir", str(root), "fsck", "--format", "v2", "--dependency-index"),
     "dependency validation after dependent mv",
     "ok\n",
 )
+
+hidden_secret = secret_id(root, "HIDDEN_MOVE")
+hidden_entry = entry_id(root_id, hidden_secret)
+hidden_move = run(
+    "--dir", str(root), "mv", "HIDDEN_MOVE", "HIDDEN_MOVED",
+    extra_env={"SECDAT_MASTER_KEY": ""},
+)
+if hidden_move.returncode == 0:
+    fail(f"locked hidden mv unexpectedly succeeded: {hidden_move}")
+if entry_id(root_id, hidden_secret) != hidden_entry:
+    fail("locked hidden mv changed the source entry")
+require_missing(root, "HIDDEN_MOVED", "locked hidden mv")
 
 prepared_secret = secret_id(root, "PREPARED_MOVE")
 prepared_entry = entry_id(root_id, prepared_secret)
@@ -177,7 +320,13 @@ if entry_id(root_id, prepared_secret) != prepared_entry:
     fail("PREPARED mv cleanup changed the source entry UUID")
 
 crash_secret = secret_id(root, "CRASH_MOVE")
-crash_entry = entry_id(root_id, crash_secret)
+crash_entry = entry_id(root_id, crash_secret, "CRASH_MOVE")
+crash_alias_entry = entry_id(root_id, crash_secret, "CRASH_ALIAS")
+crash_status_before = secret_status(root, crash_secret)
+crash_refcount_before = (
+    crash_status_before["refcount_cached"],
+    crash_status_before["refcount_actual"],
+)
 committing = run(
     "--dir", str(root), "mv", "CRASH_MOVE", "CRASH_MOVED",
     extra_env={"SECDAT_TEST_TRANSACTION_CRASH_AFTER": "target-1"},
@@ -185,8 +334,28 @@ committing = run(
 if committing.returncode != 86:
     fail(f"mv did not stop at target-1: {committing}")
 require_ok(run("--dir", str(root), "status", "--quiet"), "target-1 mv recovery")
-if secret_id(root, "CRASH_MOVED") != crash_secret or entry_id(root_id, crash_secret) != crash_entry:
+if secret_id(root, "CRASH_MOVED") != crash_secret or entry_id(root_id, crash_secret, "CRASH_MOVED") != crash_entry:
     fail("same-namespace target recovery did not preserve UUIDs")
+if secret_id(root, "CRASH_ALIAS") != crash_secret or entry_id(root_id, crash_secret, "CRASH_ALIAS") != crash_alias_entry:
+    fail("same-namespace target recovery changed the linked alias identity")
+crash_status_after = secret_status(root, crash_secret)
+if (
+    crash_status_after["refcount_cached"],
+    crash_status_after["refcount_actual"],
+) != crash_refcount_before:
+    fail("same-namespace target recovery changed the linked secret refcount")
+crash_relation = run("--dir", str(root), "relation", "show", "crash-pair")
+require_ok(crash_relation, "recovered moved relation", stdout=None)
+if "/CRASH_MOVE:default" in crash_relation.stdout or "/CRASH_MOVED:default" not in crash_relation.stdout:
+    fail(f"same-namespace target recovery did not rewrite relation: {crash_relation.stdout!r}")
+if run("--dir", str(child), "get", "CRASH_MOVED").returncode == 0:
+    fail("same-namespace target recovery lost the descendant identity mask")
+require_missing(root, "CRASH_MOVE", "same-namespace target recovery")
+require_ok(
+    run("--dir", str(root), "fsck", "--format", "v2", "--dependency-index"),
+    "dependency validation after recovered dependent mv",
+    "ok\n",
+)
 
 cross_secret = secret_id(root, "CROSS_MOVE")
 cross_entry = entry_id(root_id, cross_secret)


### PR DESCRIPTION
## Summary

- preserve `entry_id` and `secret_id` for same-domain/store local v2 `mv`
- keep existing `ln` aliases, relations, and descendant identity masks consistent
- include source/destination mask-slot effects in the prepared plan before reject
- report identity following as `followed` and count final non-no-op transaction writes
- cover fallback masks, destination masks, recovery, and unsupported planning boundaries

## Root cause

The dedicated `mv` planner only collected reverse mask edges for the moved
identity. It did not feed the source and destination name slots through the
shared mask-impact analyzer, so name-based mask effects could be prepared
without appearing in the reject plan.

## Validation

- independent RCA/static review: PASS
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp make check`: PASS
- configured with `--enable-fuse`; FUSE regression: PASS
- known non-forced XFAIL remains limited to #221

Closes #165
